### PR TITLE
fix panic when running dep -v

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,7 +60,9 @@ func main() {
 			}
 			args = cmd.flag.Args()
 		} else {
-			args = args[1:]
+			if len(args) > 0 {
+				args = args[1:]
+			}
 		}
 
 		if err := cmd.fn(args); err != nil {


### PR DESCRIPTION
fixes #52 

now it shows the usuage like it should:
```console
$ ./dep -v
usage: dep <command> [arguments]

Available commands:

init 
	Write Manifest file in the root of the project directory.
	
status [flags] [packages]
	Report the status of the current project's dependencies.
	
ensure [flags] <path>[:alt location][@<version specifier>]
	To ensure a dependency is in your project at a specific version (if specified).
	
help [command]
	Show documentation for the dep tool or the specified command.
```