### PR TITLE
Use GOPATH/pkg/depcache instead of GOPATH/depcache

### DIFF
--- a/context.go
+++ b/context.go
@@ -36,7 +36,7 @@ func newContext() (*ctx, error) {
 }
 
 func (c *ctx) sourceManager() (*gps.SourceMgr, error) {
-	return gps.NewSourceManager(analyzer{}, filepath.Join(c.GOPATH, "depcache"))
+	return gps.NewSourceManager(analyzer{}, filepath.Join(c.GOPATH, "pkg", "depcache"))
 }
 
 // loadProject searches for a project root from the provided path, then loads


### PR DESCRIPTION
Per discussion in #77 

This is a potentially bikesheddy (golang/go#17262, golang/go#4719, etc.), so let's get some 👍 before going ahead