### PR TITLE
ensure: implement -update flag

### DIFF
--- a/ensure.go
+++ b/ensure.go
@@ -101,6 +101,10 @@ func (cmd *ensureCommand) Run(args []string) error {
 		return nil
 	}
 
+	if cmd.update && len(args) > 0 {
+		return errors.New("Cannot pass -update and itemized project list (for now)")
+	}
+
 	p, err := depContext.loadProject("")
 	if err != nil {
 		return err


### PR DESCRIPTION
the easy part of #83 

not sure we really need a test for this, as the real work here is all covered by other subsystems that are tested (safewriter, gps itself).