### PR TITLE
turn off skip TestInit() windows

### DIFF
--- a/init_test.go
+++ b/init_test.go
@@ -7,7 +7,6 @@ package main
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 )
 
@@ -104,10 +103,6 @@ func TestIsDir(t *testing.T) {
 func TestInit(t *testing.T) {
 	needsExternalNetwork(t)
 	needsGit(t)
-	// TODO: fix and remove this skip on windows
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping on windows momentarily")
-	}
 
 	tg := testgo(t)
 	defer tg.cleanup()


### PR DESCRIPTION
This is a PR to track the panic that comes in `TestInit()` on windows for #103 