### PR TITLE
handle slashed GOPATH

### DIFF
--- a/context.go
+++ b/context.go
@@ -30,7 +30,9 @@ func newContext() (*ctx, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "getting work directory")
 	}
+	wd = filepath.FromSlash(wd)
 	for _, gp := range filepath.SplitList(buildContext.GOPATH) {
+		gp = filepath.FromSlash(gp)
 		if strings.HasPrefix(wd, gp) {
 			return &ctx{GOPATH: gp}, nil
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -77,3 +77,21 @@ func TestProjectMakeParams(t *testing.T) {
 		t.Error("makeParams() returned gps.SolveParameters with incorrect Lock")
 	}
 }
+
+func TestSlashedGOPATH(t *testing.T) {
+	tg := testgo(t)
+	defer tg.cleanup()
+	tg.tempDir("src")
+
+	tg.setenv("GOPATH", filepath.ToSlash(tg.path(".")))
+	_, err := newContext()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tg.setenv("GOPATH", filepath.FromSlash(tg.path(".")))
+	_, err = newContext()
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
On Windows, I use slash separated GOPATH like `C:/dev/go` because backslash often makes wrong.