### PR TITLE
fix '|&' pipe on travis osx vm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@
   script:
     - go build -v
     - go vet $(go list ./... | grep -v vendor)
-    - test -z "$(gofmt -s -l . |& grep -v vendor | tee /dev/stderr)"
+    - test -z "$(gofmt -s -l . 2>&1 | grep -v vendor | tee /dev/stderr)"
     - go test $(go list ./... | grep -v vendor)
     - go build ./hack/licenseok
     - find . -path ./vendor -prune -o -type f -name "*.go" -printf '%P\n' | xargs ./licenseok

--- a/status_test.go
+++ b/status_test.go
@@ -14,8 +14,8 @@ func TestStatusFormatVersion(t *testing.T) {
 
 	tests := map[gps.Version]string{
 		nil: "",
-		gps.NewBranch("master"): "branch master",
-		gps.NewVersion("1.0.0"): "1.0.0",
+		gps.NewBranch("master"):        "branch master",
+		gps.NewVersion("1.0.0"):        "1.0.0",
 		gps.Revision("flooboofoobooo"): "flooboo",
 	}
 	for version, expected := range tests {


### PR DESCRIPTION
`master` branch was failing the travis test for a while because of `status_test.go` format error by `gofmt`. just formatted.

And mainly, this PR for `|&` pipe is despite syntax error on travis osx vm, but test passes. (maybe due to differences `bash` version?)
See https://ember-canary.travis-ci.org/golang/dep/jobs/195026617#L77-L79
This will be a problem in the future, so fixed it together.

This pull request will pass travis test, but conflicted #143.
So if merge #143 first, I will rebase and fix pull request to only fixed `.travis.yml`.