### PR TITLE
dep ensure: fix nil* when lock not exists

### DIFF
--- a/ensure.go
+++ b/ensure.go
@@ -147,10 +147,12 @@ func (cmd *ensureCommand) Run(args []string) error {
 			Constraint: pc.Constraint,
 		}
 
-		for i, lp := range p.l.P {
-			if lp.Ident() == pc.Ident {
-				p.l.P = append(p.l.P[:i], p.l.P[i+1:]...)
-				break
+		if p.l != nil {
+			for i, lp := range p.l.P {
+				if lp.Ident() == pc.Ident {
+					p.l.P = append(p.l.P[:i], p.l.P[i+1:]...)
+					break
+				}
 			}
 		}
 	}
@@ -171,10 +173,12 @@ func (cmd *ensureCommand) Run(args []string) error {
 			Constraint: pc.Constraint,
 		}
 
-		for i, lp := range p.l.P {
-			if lp.Ident() == pc.Ident {
-				p.l.P = append(p.l.P[:i], p.l.P[i+1:]...)
-				break
+		if p.l != nil {
+			for i, lp := range p.l.P {
+				if lp.Ident() == pc.Ident {
+					p.l.P = append(p.l.P[:i], p.l.P[i+1:]...)
+					break
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fix for #162.

ctx.loadProject() allows for the lock file to not exist, but we don't take that into account in ensure.Run when specifying projects or overrides.