### PR TITLE
Disable OSX on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,9 @@
         go: 1.7.x
       - os: linux
         go: tip
-      - os: osx
-        go: 1.7.x
+# OSX wait times are unbearable right now. Re-enable when we can.
+      #- os: osx
+        #go: 1.7.x
   install:
     - echo "This is an override of the default install deps step in travis."
   script:


### PR DESCRIPTION
These wait times are unbearable. 

<img width="848" alt="travis_ci_status" src="https://cloud.githubusercontent.com/assets/21599/22317379/5e31572a-e341-11e6-995d-f3febfc9d7a5.png">

Combine that with the unreliability of appveyor, and CI is just borked right now. Disabling OSX, for now.