### PR TITLE
Deglobalize dep context

### DIFF
--- a/ensure.go
+++ b/ensure.go
@@ -96,7 +96,7 @@ type ensureCommand struct {
 	overrides stringSlice
 }
 
-func (cmd *ensureCommand) Run(args []string) error {
+func (cmd *ensureCommand) Run(ctx *ctx, args []string) error {
 	if cmd.examples {
 		fmt.Fprintln(os.Stderr, strings.TrimSpace(ensureExamples))
 		return nil
@@ -106,12 +106,12 @@ func (cmd *ensureCommand) Run(args []string) error {
 		return errors.New("Cannot pass -update and itemized project list (for now)")
 	}
 
-	p, err := depContext.loadProject("")
+	p, err := ctx.loadProject("")
 	if err != nil {
 		return err
 	}
 
-	sm, err := depContext.sourceManager()
+	sm, err := ctx.sourceManager()
 	if err != nil {
 		return err
 	}

--- a/hash_in.go
+++ b/hash_in.go
@@ -22,13 +22,13 @@ func (cmd *hashinCommand) Register(fs *flag.FlagSet) {}
 
 type hashinCommand struct{}
 
-func (hashinCommand) Run(args []string) error {
-	p, err := depContext.loadProject("")
+func (hashinCommand) Run(ctx *ctx, args []string) error {
+	p, err := ctx.loadProject("")
 	if err != nil {
 		return err
 	}
 
-	sm, err := depContext.sourceManager()
+	sm, err := ctx.sourceManager()
 	if err != nil {
 		return err
 	}
@@ -36,7 +36,7 @@ func (hashinCommand) Run(args []string) error {
 	defer sm.Release()
 
 	params := p.makeParams()
-	cpr, err := depContext.splitAbsoluteProjectRoot(p.absroot)
+	cpr, err := ctx.splitAbsoluteProjectRoot(p.absroot)
 	if err != nil {
 		return errors.Wrap(err, "determineProjectRoot")
 	}

--- a/remove.go
+++ b/remove.go
@@ -42,20 +42,20 @@ type removeCommand struct {
 	keepSource bool
 }
 
-func (cmd *removeCommand) Run(args []string) error {
-	p, err := depContext.loadProject("")
+func (cmd *removeCommand) Run(ctx *ctx, args []string) error {
+	p, err := ctx.loadProject("")
 	if err != nil {
 		return err
 	}
 
-	sm, err := depContext.sourceManager()
+	sm, err := ctx.sourceManager()
 	if err != nil {
 		return err
 	}
 	sm.UseDefaultSignalHandling()
 	defer sm.Release()
 
-	cpr, err := depContext.splitAbsoluteProjectRoot(p.absroot)
+	cpr, err := ctx.splitAbsoluteProjectRoot(p.absroot)
 	if err != nil {
 		return errors.Wrap(err, "determineProjectRoot")
 	}

--- a/status.go
+++ b/status.go
@@ -64,13 +64,13 @@ type statusCommand struct {
 	modified bool
 }
 
-func (cmd *statusCommand) Run(args []string) error {
-	p, err := depContext.loadProject("")
+func (cmd *statusCommand) Run(ctx *ctx, args []string) error {
+	p, err := ctx.loadProject("")
 	if err != nil {
 		return err
 	}
 
-	sm, err := depContext.sourceManager()
+	sm, err := ctx.sourceManager()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In this commit, I altered the `command` interface so `Run` also accepts a `*ctx` and we no longer have to keep it global.

Tests are all passing and since `depContext` has been removed, if any other function needed the context it would not compile, so I don't think we should be worried anything has been broken by this.

Also, it solves https://github.com/golang/dep/issues/169. It was already solved by @vanadium23 here (https://github.com/golang/dep/pull/172), but since it's not merged yet and I needed the context there I already made the change. Since he fixed the issue, I think we should wait for his PR to be merged and rebase against master when it is :)