### PR TITLE
Change returning value of ctx.loadProject when error

### DIFF
--- a/context.go
+++ b/context.go
@@ -60,7 +60,7 @@ func (c *ctx) loadProject(path string) (*project, error) {
 	}
 
 	if err != nil {
-		return p, err
+		return nil, err
 	}
 
 	ip, err := c.splitAbsoluteProjectRoot(p.absroot)


### PR DESCRIPTION
Hi

I've changed the returning value of ctx.loadProject when error because the first returning value is useless.
