### PR TITLE
Fix misuse of t.Skipf

### DIFF
--- a/test/test.go
+++ b/test/test.go
@@ -217,7 +217,7 @@ func (tg *TestgoData) RunGo(args ...string) {
 // be run when executing tests in short mode.
 func NeedsExternalNetwork(t *testing.T) {
 	if testing.Short() {
-		t.Skipf("skipping test: no external network in -short mode")
+		t.Skip("skipping test: no external network in -short mode")
 	}
 }
 


### PR DESCRIPTION
sorry for the nit pull-request. I just noticed that t.Skipf is misused while reading the code.