### PR TITLE
Modify the file writing process

### DIFF
--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -5,6 +5,7 @@
 package dep
 
 import (
+	"bytes"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -41,13 +42,15 @@ func TestDeriveManifestAndLock(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	b, err := m.(*Manifest).MarshalJSON()
+	b := new(bytes.Buffer)
+
+	_, err = m.(*Manifest).WriteTo(b)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if (string(b)) != contents {
-		t.Fatalf("expected %s\n got %s", contents, string(b))
+	if (b.String()) != contents {
+		t.Fatalf("expected %s\n got %s", contents, b.String())
 	}
 
 	if l != nil {

--- a/fs.go
+++ b/fs.go
@@ -5,7 +5,6 @@
 package dep
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -44,20 +43,18 @@ func IsDir(name string) (bool, error) {
 	return true, nil
 }
 
-func writeFile(path string, in json.Marshaler) error {
+func writeFile(path string, wt io.WriterTo) error {
 	f, err := os.Create(path)
 	if err != nil {
 		return err
 	}
 	defer f.Close()
 
-	b, err := in.MarshalJSON()
-	if err != nil {
+	if _, err := wt.WriteTo(f); err != nil {
 		return err
 	}
 
-	_, err = f.Write(b)
-	return err
+	return nil
 }
 
 // renameWithFallback attempts to rename a file or directory, but falls back to

--- a/lock.go
+++ b/lock.go
@@ -85,7 +85,7 @@ func (l *Lock) Projects() []gps.LockedProject {
 	return l.P
 }
 
-func (l *Lock) MarshalJSON() ([]byte, error) {
+func (l *Lock) WriteTo(w io.Writer) (int64, error) {
 	raw := rawLock{
 		Memo: hex.EncodeToString(l.Memo),
 		P:    make([]lockedDep, len(l.P)),
@@ -125,13 +125,13 @@ func (l *Lock) MarshalJSON() ([]byte, error) {
 
 	// TODO sort output - #15
 
-	var buf bytes.Buffer
-	enc := json.NewEncoder(&buf)
+	enc := json.NewEncoder(w)
 	enc.SetIndent("", "    ")
 	enc.SetEscapeHTML(false)
-	err := enc.Encode(raw)
 
-	return buf.Bytes(), err
+	// Always return 0 as the number of bytes written
+	// because json.Encoder.Encode() does not return it.
+	return 0, enc.Encode(raw)
 }
 
 // LockFromInterface converts an arbitrary gps.Lock to dep's representation of a

--- a/lock_test.go
+++ b/lock_test.go
@@ -5,6 +5,7 @@
 package dep
 
 import (
+	"bytes"
 	"encoding/hex"
 	"reflect"
 	"strings"
@@ -87,12 +88,13 @@ func TestWriteLock(t *testing.T) {
 		},
 	}
 
-	b, err := l.MarshalJSON()
-	if err != nil {
+	b := new(bytes.Buffer)
+
+	if _, err := l.WriteTo(b); err != nil {
 		t.Fatalf("Error while marshaling valid lock to JSON: %q", err)
 	}
 
-	if string(b) != lg {
-		t.Errorf("Valid lock did not marshal to JSON as expected:\n\t(GOT): %s\n\t(WNT): %s", string(b), lg)
+	if b.String() != lg {
+		t.Errorf("Valid lock did not marshal to JSON as expected:\n\t(GOT): %s\n\t(WNT): %s", b.String(), lg)
 	}
 }

--- a/manifest.go
+++ b/manifest.go
@@ -5,7 +5,6 @@
 package dep
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -108,7 +107,7 @@ func toProps(n string, p possibleProps) (pp gps.ProjectProperties, err error) {
 	return pp, nil
 }
 
-func (m *Manifest) MarshalJSON() ([]byte, error) {
+func (m *Manifest) WriteTo(w io.Writer) (int64, error) {
 	raw := rawManifest{
 		Dependencies: make(map[string]possibleProps, len(m.Dependencies)),
 		Overrides:    make(map[string]possibleProps, len(m.Ovr)),
@@ -124,13 +123,13 @@ func (m *Manifest) MarshalJSON() ([]byte, error) {
 		raw.Overrides[string(n)] = toPossible(pp)
 	}
 
-	var buf bytes.Buffer
-	enc := json.NewEncoder(&buf)
+	enc := json.NewEncoder(w)
 	enc.SetIndent("", "    ")
 	enc.SetEscapeHTML(false)
-	err := enc.Encode(raw)
 
-	return buf.Bytes(), err
+	// Always return 0 as the number of bytes written
+	// because json.Encoder.Encode() does not return it.
+	return 0, enc.Encode(raw)
 }
 
 func toPossible(pp gps.ProjectProperties) possibleProps {

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -5,6 +5,7 @@
 package dep
 
 import (
+	"bytes"
 	"reflect"
 	"strings"
 	"testing"
@@ -119,12 +120,13 @@ func TestWriteManifest(t *testing.T) {
 		Ignores: []string{"github.com/foo/bar"},
 	}
 
-	b, err := m.MarshalJSON()
-	if err != nil {
+	b := new(bytes.Buffer)
+
+	if _, err := m.WriteTo(b); err != nil {
 		t.Fatalf("Error while marshaling valid manifest to JSON: %q", err)
 	}
 
-	if string(b) != jg {
-		t.Errorf("Valid manifest did not marshal to JSON as expected:\n\t(GOT): %s\n\t(WNT): %s", string(b), jg)
+	if b.String() != jg {
+		t.Errorf("Valid manifest did not marshal to JSON as expected:\n\t(GOT): %s\n\t(WNT): %s", b.String(), jg)
 	}
 }


### PR DESCRIPTION
When writing the contents of `Manifest` and `Lock` to a file, it is inefficient (needs more memory allocation) to write the contents to `bytes.Buffer` before writing them to a file.

Using `bytes.Buffer` can be omitted, so `{Manifest,Lock}.Marshal()` is modified not to use `bytes.Buffer` and renamed to `WriteTo` to let `Manifest` and `Lock` implement `io.WriterTo` interface.