### PR TITLE
add version command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 #  if you want to ignore files created by your editor/tools,
 #  please consider a global .gitignore https://help.github.com/articles/ignoring-files
 #  please do not open a pull request to add something created by your editor or tools
-dep
+cmd/dep/dep
+cmd/dep/dep.exe
 testdep

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@
 #  if you want to ignore files created by your editor/tools,
 #  please consider a global .gitignore https://help.github.com/articles/ignoring-files
 #  please do not open a pull request to add something created by your editor or tools
-cmd/dep/dep
-cmd/dep/dep.exe
-testdep
+/dep
+/testdep
+*.exe

--- a/cmd/dep/main.go
+++ b/cmd/dep/main.go
@@ -38,6 +38,7 @@ func main() {
 		&ensureCommand{},
 		&removeCommand{},
 		&hashinCommand{},
+		&versionCommand{},
 	}
 
 	usage := func() {

--- a/cmd/dep/version.go
+++ b/cmd/dep/version.go
@@ -1,0 +1,36 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/golang/dep"
+)
+
+const versionShortHelp = `Display version`
+const versionLongHelp = `
+Display version of this application.
+`
+
+const Version = "0.0.1"
+
+func (cmd *versionCommand) Name() string      { return "version" }
+func (cmd *versionCommand) Args() string      { return "" }
+func (cmd *versionCommand) ShortHelp() string { return versionShortHelp }
+func (cmd *versionCommand) LongHelp() string  { return versionLongHelp }
+func (cmd *versionCommand) Hidden() bool      { return false }
+
+func (cmd *versionCommand) Register(fs *flag.FlagSet) {
+}
+
+type versionCommand struct {
+}
+
+func (cmd *versionCommand) Run(ctx *dep.Ctx, args []string) error {
+	fmt.Println(Version)
+	return nil
+}


### PR DESCRIPTION
Displaying only version string because it may be used from shell. If you want verbosy messages, I'll fix this. (https://github.com/golang/dep/issues/209)