### PR TITLE
ensure should write vendor when the directory is empty

### DIFF
--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -223,17 +223,11 @@ func (cmd *ensureCommand) Run(ctx *dep.Ctx, args []string) error {
 
 	// check if vendor exists, because if the locks are the same but
 	// vendor does not exist we should write vendor
-	var writeV bool
-	path := filepath.Join(sw.Root, "vendor")
-	vendorIsDir, err := dep.IsDir(path)
+	vendorExists, err := dep.IsNonEmptyDir(filepath.Join(sw.Root, "vendor"))
 	if err != nil {
 		return errors.Wrap(err, "ensure vendor is a directory")
 	}
-	vendorEmpty, _ := dep.IsEmptyDir(path)
-	vendorExists := vendorIsDir && !vendorEmpty
-	if !vendorExists && solution != nil {
-		writeV = true
-	}
+	writeV := !vendorExists && solution != nil
 
 	return errors.Wrap(sw.WriteAllSafe(writeV), "grouped write of manifest, lock and vendor")
 }

--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -226,7 +226,7 @@ func (cmd *ensureCommand) Run(ctx *dep.Ctx, args []string) error {
 	var writeV bool
 	path := filepath.Join(sw.Root, "vendor")
 	vendorIsDir, _ := dep.IsDir(path)
-	vendorEmpty, _ := dep.IsEmpty(path)
+	vendorEmpty, _ := dep.IsEmptyDir(path)
 	vendorExists := vendorIsDir && !vendorEmpty
 	if !vendorExists && solution != nil {
 		writeV = true

--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -225,7 +225,10 @@ func (cmd *ensureCommand) Run(ctx *dep.Ctx, args []string) error {
 	// vendor does not exist we should write vendor
 	var writeV bool
 	path := filepath.Join(sw.Root, "vendor")
-	vendorIsDir, _ := dep.IsDir(path)
+	vendorIsDir, err := dep.IsDir(path)
+	if err != nil {
+		return errors.Wrap(err, "ensure vendor is a directory")
+	}
 	vendorEmpty, _ := dep.IsEmptyDir(path)
 	vendorExists := vendorIsDir && !vendorEmpty
 	if !vendorExists && solution != nil {

--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -224,7 +224,10 @@ func (cmd *ensureCommand) Run(ctx *dep.Ctx, args []string) error {
 	// check if vendor exists, because if the locks are the same but
 	// vendor does not exist we should write vendor
 	var writeV bool
-	vendorExists, _ := dep.IsDir(filepath.Join(sw.Root, "vendor"))
+	path := filepath.Join(sw.Root, "vendor")
+	vendorIsDir, _ := dep.IsDir(path)
+	vendorEmpty, _ := dep.IsEmpty(path)
+	vendorExists := vendorIsDir && !vendorEmpty
 	if !vendorExists && solution != nil {
 		writeV = true
 	}

--- a/fs.go
+++ b/fs.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -42,6 +43,14 @@ func IsDir(name string) (bool, error) {
 		return false, fmt.Errorf("%q is not a directory", name)
 	}
 	return true, nil
+}
+
+func IsEmpty(name string) (bool, error) {
+	files, err := ioutil.ReadDir(name)
+	if err != nil {
+		return false, err
+	}
+	return len(files) == 0, nil
 }
 
 func writeFile(path string, in json.Marshaler) error {

--- a/fs.go
+++ b/fs.go
@@ -45,12 +45,17 @@ func IsDir(name string) (bool, error) {
 	return true, nil
 }
 
-func IsEmptyDir(name string) (bool, error) {
+func IsNonEmptyDir(name string) (bool, error) {
+	isDir, err := IsDir(name)
+	if !isDir || err != nil {
+		return isDir, err
+	}
+
 	files, err := ioutil.ReadDir(name)
 	if err != nil {
 		return false, err
 	}
-	return len(files) == 0, nil
+	return len(files) != 0, nil
 }
 
 func writeFile(path string, in json.Marshaler) error {

--- a/fs.go
+++ b/fs.go
@@ -45,7 +45,7 @@ func IsDir(name string) (bool, error) {
 	return true, nil
 }
 
-func IsEmpty(name string) (bool, error) {
+func IsEmptyDir(name string) (bool, error) {
 	files, err := ioutil.ReadDir(name)
 	if err != nil {
 		return false, err

--- a/fs_test.go
+++ b/fs_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
 	"github.com/golang/dep/test"
 )
 
@@ -192,10 +193,10 @@ func TestIsEmpty(t *testing.T) {
 	h.TempDir("empty")
 	tests := map[string]string{
 		wd: "false",
-		filepath.Join(wd, "_testdata"): "false",
-		filepath.Join(wd, "main.go"): "err",
+		filepath.Join(wd, "_testdata"):                      "false",
+		filepath.Join(wd, "main.go"):                        "err",
 		filepath.Join(wd, "this_file_does_not_exist.thing"): "err",
-		h.Path("empty"): "true",
+		h.Path("empty"):                                     "true",
 	}
 
 	for f, expected := range tests {

--- a/fs_test.go
+++ b/fs_test.go
@@ -192,15 +192,15 @@ func TestIsEmpty(t *testing.T) {
 	h := test.NewHelper(t)
 	h.TempDir("empty")
 	tests := map[string]string{
-		wd:                                                  "false",
-		"_testdata":                                         "false",
-		filepath.Join(wd, "main.go"):                        "err",
-		filepath.Join(wd, "this_file_does_not_exist.thing"): "err",
-		h.Path("empty"):                                     "true",
+		wd:                                                  "true",
+		"_testdata":                                         "true",
+		filepath.Join(wd, "fs.go"):                          "err",
+		filepath.Join(wd, "this_file_does_not_exist.thing"): "false",
+		h.Path("empty"):                                     "false",
 	}
 
 	for f, want := range tests {
-		empty, err := IsEmptyDir(f)
+		empty, err := IsNonEmptyDir(f)
 		if want == "err" {
 			if err == nil {
 				t.Fatalf("Wanted an error for %v, but it was nil", f)

--- a/fs_test.go
+++ b/fs_test.go
@@ -180,3 +180,40 @@ func TestIsDir(t *testing.T) {
 	}
 
 }
+
+func TestIsEmpty(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := map[string]string{
+		wd: "false",
+		filepath.Join(wd, "_testdata"): "false",
+		filepath.Join(wd, "main.go"): "err",
+		filepath.Join(wd, "this_file_does_not_exist.thing"): "err",
+		filepath.Join(wd, "_testdata/empty"): "true",
+	}
+
+	for f, expected := range tests {
+		empty, err := IsEmpty(f)
+		if expected == "err" {
+			if err == nil {
+				t.Fatalf("Expected an error for %v, but it was nil", f)
+			}
+			if empty {
+				t.Fatalf("Expected false with error for %v, but got true", f)
+			}
+		} else if err != nil {
+			t.Fatalf("expected no error for %v, got %v", f, err)
+		}
+
+		if expected == "true" && !empty {
+			t.Fatalf("Expected true for %v, but got false", f)
+		}
+
+		if expected == "false" && empty {
+			t.Fatalf("Expected false for %v, but got true", f)
+		}
+	}
+}

--- a/fs_test.go
+++ b/fs_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"github.com/golang/dep/test"
 )
 
 func TestCopyDir(t *testing.T) {
@@ -187,12 +188,14 @@ func TestIsEmpty(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	h := test.NewHelper(t)
+	h.TempDir("empty")
 	tests := map[string]string{
 		wd: "false",
 		filepath.Join(wd, "_testdata"): "false",
 		filepath.Join(wd, "main.go"): "err",
 		filepath.Join(wd, "this_file_does_not_exist.thing"): "err",
-		filepath.Join(wd, "_testdata/empty"): "true",
+		h.Path("empty"): "true",
 	}
 
 	for f, expected := range tests {

--- a/fs_test.go
+++ b/fs_test.go
@@ -196,7 +196,7 @@ func TestIsEmpty(t *testing.T) {
 	}
 
 	for f, expected := range tests {
-		empty, err := IsEmpty(f)
+		empty, err := IsEmptyDir(f)
 		if expected == "err" {
 			if err == nil {
 				t.Fatalf("Expected an error for %v, but it was nil", f)

--- a/fs_test.go
+++ b/fs_test.go
@@ -192,32 +192,32 @@ func TestIsEmpty(t *testing.T) {
 	h := test.NewHelper(t)
 	h.TempDir("empty")
 	tests := map[string]string{
-		wd: "false",
-		filepath.Join(wd, "_testdata"):                      "false",
+		wd:                                                  "false",
+		"_testdata":                                         "false",
 		filepath.Join(wd, "main.go"):                        "err",
 		filepath.Join(wd, "this_file_does_not_exist.thing"): "err",
 		h.Path("empty"):                                     "true",
 	}
 
-	for f, expected := range tests {
+	for f, want := range tests {
 		empty, err := IsEmptyDir(f)
-		if expected == "err" {
+		if want == "err" {
 			if err == nil {
-				t.Fatalf("Expected an error for %v, but it was nil", f)
+				t.Fatalf("Wanted an error for %v, but it was nil", f)
 			}
 			if empty {
-				t.Fatalf("Expected false with error for %v, but got true", f)
+				t.Fatalf("Wanted false with error for %v, but got true", f)
 			}
 		} else if err != nil {
-			t.Fatalf("expected no error for %v, got %v", f, err)
+			t.Fatalf("Wanted no error for %v, got %v", f, err)
 		}
 
-		if expected == "true" && !empty {
-			t.Fatalf("Expected true for %v, but got false", f)
+		if want == "true" && !empty {
+			t.Fatalf("Wanted true for %v, but got false", f)
 		}
 
-		if expected == "false" && empty {
-			t.Fatalf("Expected false for %v, but got true", f)
+		if want == "false" && empty {
+			t.Fatalf("Wanted false for %v, but got true", f)
 		}
 	}
 }


### PR DESCRIPTION
#234 
If the vendor directory existed & was empty, but the current lockfile matched the solution, nothing would be written to vendor. This adds a check to see if the directory is empty and forces the write in that case.