### PR TITLE
Non-existing import path with less side effects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@
     - go build -v ./cmd/dep
     - go vet $(go list ./... | grep -v vendor)
     - test -z "$(gofmt -s -l . 2>&1 | grep -v vendor | tee /dev/stderr)"
-    - go test -race $(go list ./... | grep -v vendor)
+    - go test -v -race $(go list ./... | grep -v vendor)
     - go build ./hack/licenseok
     - find . -path ./vendor -prune -o -type f -name "*.go" -printf '%P\n' | xargs ./licenseok
     - ./hack/validate-vendor.bash

--- a/cmd/dep/init_test.go
+++ b/cmd/dep/init_test.go
@@ -61,7 +61,7 @@ func TestInit(t *testing.T) {
 	}
 
 	// Build a fake consumer of these packages.
-	const root = "github.com/golang/notexist"
+	const root = "notexist.com/something.git"
 	m := `package main
 
 import (

--- a/cmd/dep/remove_test.go
+++ b/cmd/dep/remove_test.go
@@ -33,7 +33,7 @@ func TestRemove(t *testing.T) {
 	}
 
 	// Build a fake consumer of these packages.
-	const root = "github.com/golang/notexist"
+	const root = "notexist.com/something.git"
 	m := `package main
 
 import (

--- a/cmd/dep/remove_test.go
+++ b/cmd/dep/remove_test.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"testing"
+	"time"
 
 	"github.com/golang/dep/test"
 )
@@ -159,4 +160,7 @@ func main() {
 	if lock != expectedLock {
 		t.Fatalf("expected %s, got %s", expectedLock, lock)
 	}
+
+	// Sledgehammer approach to letting the gps goroutines finish.
+	time.Sleep(2 * time.Second)
 }

--- a/cmd/dep/remove_test.go
+++ b/cmd/dep/remove_test.go
@@ -52,7 +52,7 @@ func main() {
 	h.TempFile("src/"+root+"/thing.go", m)
 	origm := `{
     "dependencies": {
-        "github.com/not/used": {
+        "notexist.com/other.git": {
             "version": "2.0.0"
         },
         "github.com/Sirupsen/logrus": {
@@ -87,22 +87,22 @@ func main() {
 	}
 
 	h.TempFile("src/"+root+"/manifest.json", origm)
-	h.Run("remove", "github.com/not/used")
+	h.Run("remove", "notexist.com/other.git")
 
 	manifest = h.ReadManifest()
 	if manifest != expectedManifest {
 		t.Fatalf("expected %s, got %s", expectedManifest, manifest)
 	}
 
-	if err := h.DoRun([]string{"remove", "-unused", "github.com/not/used"}); err == nil {
+	if err := h.DoRun([]string{"remove", "-unused", "notexist.com/other.git"}); err == nil {
 		t.Fatal("rm with both -unused and arg should have failed")
 	}
 
-	if err := h.DoRun([]string{"remove", "github.com/not/present"}); err == nil {
+	if err := h.DoRun([]string{"remove", "notexist.com/third.git"}); err == nil {
 		t.Fatal("rm with arg not in manifest should have failed")
 	}
 
-	if err := h.DoRun([]string{"remove", "github.com/not/used", "github.com/not/present"}); err == nil {
+	if err := h.DoRun([]string{"remove", "notexist.com/other.git", "notexist.com/third.git"}); err == nil {
 		t.Fatal("rm with one arg not in manifest should have failed")
 	}
 
@@ -111,7 +111,7 @@ func main() {
 	}
 
 	h.TempFile("src/"+root+"/manifest.json", origm)
-	h.Run("remove", "-force", "github.com/pkg/errors", "github.com/not/used")
+	h.Run("remove", "-force", "github.com/pkg/errors", "notexist.com/other.git")
 
 	manifest = h.ReadManifest()
 	if manifest != `{


### PR DESCRIPTION
Using a github.com repository for a fixture intended to not exist has the unfortunate side effect of, at least sometimes, cauisng the tool to hang when prompting the user for a password. Hopefully this'll be improved by using a valid, deducible import path pointing to a nonexistent domain instead.

Fixes #214 (I hope)