### PR TITLE
Prevent problems comparing golden files on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Prevent problems comparing golden files on Windows
+**/testdata/** text eol=lf


### PR DESCRIPTION
Fixes #243.

This overrides a user's EOL settings for the `testdata/` directories, forcing all files under them to use LF. I've tested this out with Git for Windows by doing the following:

1. Clone and cd into the repo
1. Turn on AutoCRLF for the repo (so I don't muck up my entire machine)

    ```
    git config core.autocrlf true
    ```
1. Reset the cached files to apply the new line ending scheme

    ```
    git rm --cached -r .
    git reset --hard
    ```
1. Open the project in a text editor which can tell you the line ending types in use (I picked Atom).
1. Open some go files and make sure that AutoCRLF has applied windows style line endings.
1. Open `/testdata/analyzer/manifest.json` and verify that it uses LF, not CRLF.
1. Open `/cmd/dep/testdata/ensure/bare_lcok.golden.json` and verify that it uses LF as well.