### PR TITLE
Golden file pattern for integration tests, reduced commits

### DIFF
--- a/cmd/dep/init_test.go
+++ b/cmd/dep/init_test.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/golang/dep/test"
@@ -61,86 +62,40 @@ func TestInit(t *testing.T) {
 	}
 
 	// Build a fake consumer of these packages.
-	const root = "github.com/golang/notexist"
-	m := `package main
+	root := "src/github.com/golang/notexist"
+	h.TempCopy(root+"/foo/thing.go", "init/thing.input.go")
+	h.TempCopy(root+"/foo/bar/bar.go", "init/bar.input.go")
 
-import (
-	"github.com/Sirupsen/logrus"
-	"github.com/pkg/errors"
-
-	"` + root + `/foo/bar"
-)
-
-func main() {
-	err := nil
-	if err != nil {
-		errors.Wrap(err, "thing")
-	}
-	logrus.Info(bar.Qux)
-}`
-
-	h.TempFile("src/"+root+"/foo/thing.go", m)
-
-	m = `package bar
-
-const Qux = "yo yo!"
-`
-	h.TempFile("src/"+root+"/foo/bar/bar.go", m)
-
-	h.Cd(h.Path("src/" + root))
+	h.Cd(h.Path(root))
 	h.Run("init")
 
-	expectedManifest := `{
-    "dependencies": {
-        "github.com/Sirupsen/logrus": {
-            "revision": "42b84f9ec624953ecbf81a94feccb3f5935c5edf"
-        },
-        "github.com/pkg/errors": {
-            "version": ">=0.8.0, <1.0.0"
-        }
-    }
-}
-`
-	manifest := h.ReadManifest()
-	if manifest != expectedManifest {
-		t.Fatalf("expected %s, got %s", expectedManifest, manifest)
+	goldenManifest := "init/manifest.golden.json"
+	wantManifest := h.GetTestFileString(goldenManifest)
+	gotManifest := h.ReadManifest()
+	if wantManifest != gotManifest {
+		if *test.UpdateGolden {
+			if err := h.WriteTestFile(goldenManifest, gotManifest); err != nil {
+				t.Fatal(err)
+			}
+		} else {
+			t.Errorf("expected %s, got %s", wantManifest, gotManifest)
+		}
 	}
 
 	sysCommit := h.GetCommit("go.googlesource.com/sys")
-	expectedLock := `{
-    "memo": "668fe45796bc4e85a5a6c0a0f1eb6fab9e23588d1eb33f3a12b2ad5599a3575e",
-    "projects": [
-        {
-            "name": "github.com/Sirupsen/logrus",
-            "revision": "42b84f9ec624953ecbf81a94feccb3f5935c5edf",
-            "packages": [
-                "."
-            ]
-        },
-        {
-            "name": "github.com/pkg/errors",
-            "version": "v0.8.0",
-            "revision": "645ef00459ed84a119197bfb8d8205042c6df63d",
-            "packages": [
-                "."
-            ]
-        },
-        {
-            "name": "golang.org/x/sys",
-            "branch": "master",
-            "revision": "` + sysCommit + `",
-            "packages": [
-                "unix"
-            ]
-        }
-    ]
-}
-`
-	lock := h.ReadLock()
-	if lock != expectedLock {
-		t.Fatalf("expected %s, got %s", expectedLock, lock)
+	goldenLock := "init/lock.golden.json"
+	wantLock := strings.Replace(h.GetTestFileString(goldenLock), "` + sysCommit + `", sysCommit, 1)
+	gotLock := h.ReadLock()
+	if wantLock != gotLock {
+		if *test.UpdateGolden {
+			if err := h.WriteTestFile(goldenLock, gotLock); err != nil {
+				t.Fatal(err)
+			}
+		} else {
+			t.Errorf("expected %s, got %s", wantLock, gotLock)
+		}
 	}
 
 	// vendor should have been created & populated
-	h.MustExist(h.Path("src/" + root + "/vendor/github.com/Sirupsen/logrus"))
+	h.MustExist(h.Path(root + "/vendor/github.com/Sirupsen/logrus"))
 }

--- a/cmd/dep/testdata/init/bar.input.go
+++ b/cmd/dep/testdata/init/bar.input.go
@@ -1,0 +1,7 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package bar
+
+const Qux = "yo yo!"

--- a/cmd/dep/testdata/init/lock.golden.json
+++ b/cmd/dep/testdata/init/lock.golden.json
@@ -1,0 +1,28 @@
+{
+    "memo": "668fe45796bc4e85a5a6c0a0f1eb6fab9e23588d1eb33f3a12b2ad5599a3575e",
+    "projects": [
+        {
+            "name": "github.com/Sirupsen/logrus",
+            "revision": "42b84f9ec624953ecbf81a94feccb3f5935c5edf",
+            "packages": [
+                "."
+            ]
+        },
+        {
+            "name": "github.com/pkg/errors",
+            "version": "v0.8.0",
+            "revision": "645ef00459ed84a119197bfb8d8205042c6df63d",
+            "packages": [
+                "."
+            ]
+        },
+        {
+            "name": "golang.org/x/sys",
+            "branch": "master",
+            "revision": "` + sysCommit + `",
+            "packages": [
+                "unix"
+            ]
+        }
+    ]
+}

--- a/cmd/dep/testdata/init/manifest.golden.json
+++ b/cmd/dep/testdata/init/manifest.golden.json
@@ -1,0 +1,10 @@
+{
+    "dependencies": {
+        "github.com/Sirupsen/logrus": {
+            "revision": "42b84f9ec624953ecbf81a94feccb3f5935c5edf"
+        },
+        "github.com/pkg/errors": {
+            "version": ">=0.8.0, <1.0.0"
+        }
+    }
+}

--- a/cmd/dep/testdata/init/thing.input.go
+++ b/cmd/dep/testdata/init/thing.input.go
@@ -1,0 +1,20 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"github.com/Sirupsen/logrus"
+	"github.com/pkg/errors"
+
+	"github.com/golang/notexist/foo/bar"
+)
+
+func main() {
+	err := nil
+	if err != nil {
+		errors.Wrap(err, "thing")
+	}
+	logrus.Info(bar.Qux)
+}

--- a/cmd/dep/testdata/remove/lock1.golden.json
+++ b/cmd/dep/testdata/remove/lock1.golden.json
@@ -1,0 +1,28 @@
+{
+    "memo": "7769242a737ed497aa39831eecfdc4a1bf59517df898907accc6bdc0f789a69b",
+    "projects": [
+        {
+            "name": "github.com/Sirupsen/logrus",
+            "revision": "42b84f9ec624953ecbf81a94feccb3f5935c5edf",
+            "packages": [
+                "."
+            ]
+        },
+        {
+            "name": "github.com/pkg/errors",
+            "version": "v0.8.0",
+            "revision": "645ef00459ed84a119197bfb8d8205042c6df63d",
+            "packages": [
+                "."
+            ]
+        },
+        {
+            "name": "golang.org/x/sys",
+            "branch": "master",
+            "revision": "e24f485414aeafb646f6fca458b0bf869c0880a1",
+            "packages": [
+                "unix"
+            ]
+        }
+    ]
+}

--- a/cmd/dep/testdata/remove/main.input.go
+++ b/cmd/dep/testdata/remove/main.input.go
@@ -1,0 +1,18 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"github.com/Sirupsen/logrus"
+	"github.com/pkg/errors"
+)
+
+func main() {
+	err := nil
+	if err != nil {
+		errors.Wrap(err, "thing")
+	}
+	logrus.Info("whatev")
+}

--- a/cmd/dep/testdata/remove/manifest.input.json
+++ b/cmd/dep/testdata/remove/manifest.input.json
@@ -1,0 +1,13 @@
+{
+  "dependencies": {
+      "github.com/not/used": {
+          "version": "2.0.0"
+      },
+      "github.com/Sirupsen/logrus": {
+          "revision": "42b84f9ec624953ecbf81a94feccb3f5935c5edf"
+      },
+      "github.com/pkg/errors": {
+          "version": ">=0.8.0, <1.0.0"
+      }
+  }
+}

--- a/cmd/dep/testdata/remove/manifest0.golden.json
+++ b/cmd/dep/testdata/remove/manifest0.golden.json
@@ -1,0 +1,10 @@
+{
+    "dependencies": {
+        "github.com/Sirupsen/logrus": {
+            "revision": "42b84f9ec624953ecbf81a94feccb3f5935c5edf"
+        },
+        "github.com/pkg/errors": {
+            "version": ">=0.8.0, <1.0.0"
+        }
+    }
+}

--- a/cmd/dep/testdata/remove/manifest1.golden.json
+++ b/cmd/dep/testdata/remove/manifest1.golden.json
@@ -1,0 +1,7 @@
+{
+    "dependencies": {
+        "github.com/Sirupsen/logrus": {
+            "revision": "42b84f9ec624953ecbf81a94feccb3f5935c5edf"
+        }
+    }
+}


### PR DESCRIPTION
Moving remaining integration tests to golden file pattern. For some reason, the remove_test.go is now passing on my PC, despite nothing being commented out or skipped. We'll see if Appveyor believes the same.