### PR TITLE
Improve coverage for DeriveManifestAndLock

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -23,7 +23,7 @@ func (a Analyzer) DeriveManifestAndLock(path string, n gps.ProjectRoot) (gps.Man
 	}
 	f, err := os.Open(mf)
 	if err != nil {
-		return nil, nil, nil
+		return nil, nil, err
 	}
 	defer f.Close()
 


### PR DESCRIPTION
Test error conditions:

	* Manifest file cannot be read

	* Manifest file is invalid

This addresses issue #41.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@gmail.com>