### PR TITLE
Respect dry run flag during dep ensure

### DIFF
--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -161,7 +161,8 @@ func (cmd *ensureCommand) Run(ctx *dep.Ctx, args []string) error {
 		manifest = p.Manifest
 	}
 
-	sw.Prepare(manifest, p.Lock, solution, writeV)
+	newLock := dep.LockFromInterface(solution)
+	sw.Prepare(manifest, p.Lock, newLock, writeV)
 	if cmd.dryRun {
 		return sw.PrintPreparedActions()
 	}

--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -147,25 +147,26 @@ func (cmd *ensureCommand) Run(ctx *dep.Ctx, args []string) error {
 		return errors.Wrap(err, "ensure Solve()")
 	}
 
-	sw := dep.SafeWriter{
-		Root:          p.AbsRoot,
-		Lock:          p.Lock,
-		NewLock:       solution,
-		SourceManager: sm,
-	}
-	if !cmd.update {
-		sw.Manifest = p.Manifest
-	}
-
 	// check if vendor exists, because if the locks are the same but
 	// vendor does not exist we should write vendor
-	vendorExists, err := dep.IsNonEmptyDir(filepath.Join(sw.Root, "vendor"))
+	vendorExists, err := dep.IsNonEmptyDir(filepath.Join(p.AbsRoot, "vendor"))
 	if err != nil {
 		return errors.Wrap(err, "ensure vendor is a directory")
 	}
 	writeV := !vendorExists && solution != nil
 
-	return errors.Wrap(sw.WriteAllSafe(writeV), "grouped write of manifest, lock and vendor")
+	var sw dep.SafeWriter
+	var manifest *dep.Manifest
+	if !cmd.update {
+		manifest = p.Manifest
+	}
+
+	sw.Prepare(manifest, p.Lock, solution, writeV)
+	if cmd.dryRun {
+		return sw.PrintPreparedActions()
+	}
+
+	return errors.Wrap(sw.Write(p.AbsRoot, sm), "grouped write of manifest, lock and vendor")
 }
 
 func applyUpdateArgs(args []string, params *gps.SolveParameters) {

--- a/cmd/dep/remove.go
+++ b/cmd/dep/remove.go
@@ -180,7 +180,8 @@ func (cmd *removeCommand) Run(ctx *dep.Ctx, args []string) error {
 	}
 
 	var sw dep.SafeWriter
-	sw.Prepare(p.Manifest, p.Lock, soln, false)
+	newLock := dep.LockFromInterface(soln)
+	sw.Prepare(p.Manifest, p.Lock, newLock, false)
 	if err := sw.Write(p.AbsRoot, sm); err != nil {
 		return errors.Wrap(err, "grouped write of manifest, lock and vendor")
 	}

--- a/cmd/dep/remove.go
+++ b/cmd/dep/remove.go
@@ -179,15 +179,9 @@ func (cmd *removeCommand) Run(ctx *dep.Ctx, args []string) error {
 		return err
 	}
 
-	sw := dep.SafeWriter{
-		Root:          p.AbsRoot,
-		Manifest:      p.Manifest,
-		Lock:          p.Lock,
-		NewLock:       soln,
-		SourceManager: sm,
-	}
-
-	if err := sw.WriteAllSafe(false); err != nil {
+	var sw dep.SafeWriter
+	sw.Prepare(p.Manifest, p.Lock, soln, false)
+	if err := sw.Write(p.AbsRoot, sm); err != nil {
 		return errors.Wrap(err, "grouped write of manifest, lock and vendor")
 	}
 	return nil

--- a/cmd/dep/testdata/harness_tests/ensure/update/case2/final/lock.json
+++ b/cmd/dep/testdata/harness_tests/ensure/update/case2/final/lock.json
@@ -1,0 +1,21 @@
+{
+    "memo": "9a5243dd3fa20feeaa20398e7283d6c566532e2af1aae279a010df34793761c5",
+    "projects": [
+        {
+            "name": "github.com/sdboyer/deptest",
+            "version": "v0.8.0",
+            "revision": "ff2948a2ac8f538c4ecd55962e919d1e13e74baf",
+            "packages": [
+                "."
+            ]
+        },
+        {
+            "name": "github.com/sdboyer/deptestdos",
+            "version": "v2.0.0",
+            "revision": "5c607206be5decd28e6263ffffdcee067266015e",
+            "packages": [
+                "."
+            ]
+        }
+    ]
+}

--- a/cmd/dep/testdata/harness_tests/ensure/update/case2/final/manifest.json
+++ b/cmd/dep/testdata/harness_tests/ensure/update/case2/final/manifest.json
@@ -1,0 +1,7 @@
+{
+    "dependencies": {
+        "github.com/sdboyer/deptest": {
+            "version": "~0.8.0"
+        }
+    }
+}

--- a/cmd/dep/testdata/harness_tests/ensure/update/case2/initial/lock.json
+++ b/cmd/dep/testdata/harness_tests/ensure/update/case2/initial/lock.json
@@ -1,0 +1,21 @@
+{
+    "memo": "9a5243dd3fa20feeaa20398e7283d6c566532e2af1aae279a010df34793761c5",
+    "projects": [
+        {
+            "name": "github.com/sdboyer/deptest",
+            "version": "v0.8.0",
+            "revision": "ff2948a2ac8f538c4ecd55962e919d1e13e74baf",
+            "packages": [
+                "."
+            ]
+        },
+        {
+            "name": "github.com/sdboyer/deptestdos",
+            "version": "v2.0.0",
+            "revision": "5c607206be5decd28e6263ffffdcee067266015e",
+            "packages": [
+                "."
+            ]
+        }
+    ]
+}

--- a/cmd/dep/testdata/harness_tests/ensure/update/case2/initial/main.go
+++ b/cmd/dep/testdata/harness_tests/ensure/update/case2/initial/main.go
@@ -1,0 +1,18 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"github.com/sdboyer/deptest"
+	"github.com/sdboyer/deptestdos"
+)
+
+func main() {
+	err := nil
+	if err != nil {
+		deptest.Map["yo yo!"]
+	}
+	deptestdos.diMeLo("whatev")
+}

--- a/cmd/dep/testdata/harness_tests/ensure/update/case2/initial/manifest.json
+++ b/cmd/dep/testdata/harness_tests/ensure/update/case2/initial/manifest.json
@@ -1,0 +1,7 @@
+{
+    "dependencies": {
+        "github.com/sdboyer/deptest": {
+            "version": "~0.8.0"
+        }
+    }
+}

--- a/cmd/dep/testdata/harness_tests/ensure/update/case2/testcase.json
+++ b/cmd/dep/testdata/harness_tests/ensure/update/case2/testcase.json
@@ -1,0 +1,6 @@
+{
+  "commands": [
+    ["init"],
+    ["ensure", "-n", "-update", "github.com/sdboyer/deptest"]
+  ]
+}

--- a/lock.go
+++ b/lock.go
@@ -102,16 +102,7 @@ func (l *Lock) MarshalJSON() ([]byte, error) {
 		}
 
 		v := lp.Version()
-		// Figure out how to get the underlying revision
-		switch tv := v.(type) {
-		case gps.UnpairedVersion:
-			// TODO we could error here, if we want to be very defensive about not
-			// allowing a lock to be written if without an immmutable revision
-		case gps.Revision:
-			ld.Revision = tv.String()
-		case gps.PairedVersion:
-			ld.Revision = tv.Underlying().String()
-		}
+		ld.Revision = GetRevisionFromVersion(v)
 
 		switch v.Type() {
 		case gps.IsBranch:
@@ -132,6 +123,20 @@ func (l *Lock) MarshalJSON() ([]byte, error) {
 	err := enc.Encode(raw)
 
 	return buf.Bytes(), err
+}
+
+func GetRevisionFromVersion(v gps.Version) string {
+	// Figure out how to get the underlying revision
+	switch tv := v.(type) {
+	case gps.UnpairedVersion:
+	// TODO we could error here, if we want to be very defensive about not
+	// allowing a lock to be written if without an immmutable revision
+	case gps.Revision:
+		return tv.String()
+	case gps.PairedVersion:
+		return tv.Underlying().String()
+	}
+	return ""
 }
 
 // LockFromInterface converts an arbitrary gps.Lock to dep's representation of a

--- a/lock.go
+++ b/lock.go
@@ -184,14 +184,3 @@ func (s SortedLockedProjects) Less(i, j int) bool {
 
 	return l.Source < r.Source
 }
-
-// locksAreEquivalent compares two locks to see if they differ. If EITHER lock
-// is nil, or their memos do not match, or any projects differ, then false is
-// returned.
-func locksAreEquivalent(l, r *Lock) bool {
-	if l == nil || r == nil {
-		return false
-	}
-
-	return gps.LocksAreEq(l, r, true)
-}

--- a/lock_test.go
+++ b/lock_test.go
@@ -19,7 +19,9 @@ func TestReadLock(t *testing.T) {
 	defer h.Cleanup()
 
 	golden := "lock/golden0.json"
-	got, err := readLock(h.GetTestFile(golden))
+	g0f := h.GetTestFile(golden)
+	defer g0f.Close()
+	got, err := readLock(g0f)
 	if err != nil {
 		t.Fatalf("Should have read Lock correctly, but got err %q", err)
 	}
@@ -41,7 +43,9 @@ func TestReadLock(t *testing.T) {
 	}
 
 	golden = "lock/golden1.json"
-	got, err = readLock(h.GetTestFile(golden))
+	g1f := h.GetTestFile(golden)
+	defer g1f.Close()
+	got, err = readLock(g1f)
 	if err != nil {
 		t.Fatalf("Should have read Lock correctly, but got err %q", err)
 	}
@@ -141,7 +145,9 @@ func TestReadLockErrors(t *testing.T) {
 	}
 
 	for _, tst := range tests {
-		_, err = readLock(h.GetTestFile(tst.file))
+		lf := h.GetTestFile(tst.file)
+		defer lf.Close()
+		_, err = readLock(lf)
 		if err == nil {
 			t.Errorf("Reading lock with %s should have caused error, but did not", tst.name)
 		} else if !strings.Contains(err.Error(), tst.name) {

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -17,7 +17,9 @@ func TestReadManifest(t *testing.T) {
 	h := test.NewHelper(t)
 	defer h.Cleanup()
 
-	got, err := readManifest(h.GetTestFile("manifest/golden.json"))
+	mf := h.GetTestFile("manifest/golden.json")
+	defer mf.Close()
+	got, err := readManifest(mf)
 	if err != nil {
 		t.Fatalf("Should have read Manifest correctly, but got err %q", err)
 	}
@@ -106,7 +108,9 @@ func TestReadManifestErrors(t *testing.T) {
 	}
 
 	for _, tst := range tests {
-		_, err = readManifest(h.GetTestFile(tst.file))
+		mf := h.GetTestFile(tst.file)
+		defer mf.Close()
+		_, err = readManifest(mf)
 		if err == nil {
 			t.Errorf("Reading manifest with %s should have caused error, but did not", tst.name)
 		} else if !strings.Contains(err.Error(), tst.name) {

--- a/test/test.go
+++ b/test/test.go
@@ -458,7 +458,9 @@ func (h *Helper) GetTestFile(src string) io.ReadCloser {
 // GetTestFileString reads a file from the testdata directory into memory.  src is
 // relative to ./testdata.
 func (h *Helper) GetTestFileString(src string) string {
-	content, err := ioutil.ReadAll(h.GetTestFile(src))
+	srcf := h.GetTestFile(src)
+	defer srcf.Close()
+	content, err := ioutil.ReadAll(srcf)
 	if err != nil {
 		h.t.Fatalf("%+v", err)
 	}

--- a/test/test.go
+++ b/test/test.go
@@ -68,7 +68,7 @@ func (h *Helper) Must(err error) {
 // check gives a test non-fatal error if err is not nil.
 func (h *Helper) check(err error) {
 	if err != nil {
-		h.t.Error(err)
+		h.t.Errorf("%+v", err)
 	}
 }
 
@@ -112,10 +112,12 @@ func (h *Helper) Cd(dir string) {
 		h.wd = h.pwd()
 	}
 	abs, err := filepath.Abs(dir)
-	h.Must(os.Chdir(dir))
 	if err == nil {
 		h.Setenv("PWD", abs)
 	}
+
+	err = os.Chdir(dir)
+	h.Must(errors.Wrapf(err, "Unable to cd to %s", dir))
 }
 
 // Setenv sets an environment variable to use when running the test go
@@ -452,7 +454,7 @@ func (h *Helper) GetTestFile(src string) io.ReadCloser {
 func (h *Helper) GetTestFileString(src string) string {
 	content, err := ioutil.ReadAll(h.GetTestFile(src))
 	if err != nil {
-		panic(err)
+		h.t.Fatalf("%+v", err)
 	}
 	return string(content)
 }
@@ -498,7 +500,7 @@ func (h *Helper) Path(name string) string {
 	// Ensure it's the absolute, symlink-less path we're returning
 	abs, err := filepath.EvalSymlinks(joined)
 	if err != nil {
-		h.t.Fatalf("internal testsuite error: could not get absolute path for dir(%q), err %q", joined, err)
+		h.t.Fatalf("%+v", errors.Wrapf(err, "internal testsuite error: could not get absolute path for dir(%q)", joined))
 	}
 	return abs
 }

--- a/test/test.go
+++ b/test/test.go
@@ -439,14 +439,20 @@ func (h *Helper) WriteTestFile(src string, content string) error {
 	return err
 }
 
+// GetTestFile reads a file into memory
+func (h *Helper) GetFile(path string) io.ReadCloser {
+	content, err := os.Open(path)
+	if err != nil {
+		h.t.Fatalf("%+v", errors.Wrapf(err, "Unable to open file: %s", path))
+	}
+	return content
+}
+
 // GetTestFile reads a file from the testdata directory into memory.  src is
 // relative to ./testdata.
 func (h *Helper) GetTestFile(src string) io.ReadCloser {
-	content, err := os.Open(filepath.Join(h.origWd, "testdata", src))
-	if err != nil {
-		panic(err)
-	}
-	return content
+	fullPath := filepath.Join(h.origWd, "testdata", src)
+	return h.GetFile(fullPath)
 }
 
 // GetTestFileString reads a file from the testdata directory into memory.  src is

--- a/test/test.go
+++ b/test/test.go
@@ -513,9 +513,18 @@ func (h *Helper) Path(name string) string {
 
 // MustExist fails if path does not exist.
 func (h *Helper) MustExist(path string) {
-	if !h.Exist(path) {
-		h.t.Fatalf("%+v", errors.Errorf("%s does not exist but should", path))
+	if err := h.ShouldExist(path); err != nil {
+		h.t.Fatalf("%+v", err)
 	}
+}
+
+// ShouldExist returns an error if path does not exist.
+func (h *Helper) ShouldExist(path string) error {
+	if !h.Exist(path) {
+		return errors.Errorf("%s does not exist but should", path)
+	}
+
+	return nil
 }
 
 // Exist returns whether or not a path exists
@@ -532,9 +541,18 @@ func (h *Helper) Exist(path string) bool {
 
 // MustNotExist fails if path exists.
 func (h *Helper) MustNotExist(path string) {
-	if h.Exist(path) {
-		h.t.Fatalf("%+v", errors.Errorf("%s exists but should not", path))
+	if err := h.ShouldNotExist(path); err != nil {
+		h.t.Fatalf("%+v", err)
 	}
+}
+
+// ShouldNotExist returns an error if path exists.
+func (h *Helper) ShouldNotExist(path string) error {
+	if h.Exist(path) {
+		return errors.Errorf("%s exists but should not", path)
+	}
+
+	return nil
 }
 
 // Cleanup cleans up a test that runs testgo.

--- a/test_project_context_test.go
+++ b/test_project_context_test.go
@@ -59,13 +59,17 @@ func (pc *TestProjectContext) Load() {
 	var m *Manifest
 	mp := pc.getManifestPath()
 	if pc.h.Exist(mp) {
-		m, err = readManifest(pc.h.GetFile(mp))
+		mf := pc.h.GetFile(mp)
+		defer mf.Close()
+		m, err = readManifest(mf)
 		pc.h.Must(err)
 	}
 	var l *Lock
 	lp := pc.getLockPath()
 	if pc.h.Exist(lp) {
-		l, err = readLock(pc.h.GetFile(lp))
+		lf := pc.h.GetFile(lp)
+		defer lf.Close()
+		l, err = readLock(lf)
 		pc.h.Must(err)
 	}
 	pc.Project.Manifest = m

--- a/test_project_context_test.go
+++ b/test_project_context_test.go
@@ -96,8 +96,7 @@ func (pc *TestProjectContext) getVendorPath() string {
 // Updates the golden file when -UpdateGolden flag is present.
 func (pc *TestProjectContext) LockShouldMatchGolden(goldenLockPath string) error {
 	got := pc.h.ReadLock()
-	want := pc.h.GetTestFileString(goldenLockPath)
-	return pc.shouldMatchGolden(goldenLockPath, want, got)
+	return pc.ShouldMatchGolden(goldenLockPath, got)
 }
 
 // LockShouldNotExist returns an error when the lock exists.
@@ -110,8 +109,7 @@ func (pc *TestProjectContext) LockShouldNotExist() error {
 // Updates the golden file when -UpdateGolden flag is present
 func (pc *TestProjectContext) ManifestShouldMatchGolden(goldenManifestPath string) error {
 	got := pc.h.ReadManifest()
-	want := pc.h.GetTestFileString(goldenManifestPath)
-	return pc.shouldMatchGolden(goldenManifestPath, want, got)
+	return pc.ShouldMatchGolden(goldenManifestPath, got)
 }
 
 // ManifestShouldNotExist returns an error when the lock exists.
@@ -122,7 +120,8 @@ func (pc *TestProjectContext) ManifestShouldNotExist() error {
 // ShouldMatchGolden returns an error when a file does not match the golden file.
 // goldenFile is the path to the golden file, relative to the testdata directory
 // Updates the golden file when -UpdateGolden flag is present
-func (pc *TestProjectContext) shouldMatchGolden(goldenFile string, want string, got string) error {
+func (pc *TestProjectContext) ShouldMatchGolden(goldenFile string, got string) error {
+	want := pc.h.GetTestFileString(goldenFile)
 	if want != got {
 		if *test.UpdateGolden {
 			if err := pc.h.WriteTestFile(goldenFile, got); err != nil {

--- a/test_project_context_test.go
+++ b/test_project_context_test.go
@@ -1,0 +1,157 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package dep
+
+import (
+	"path/filepath"
+
+	"github.com/golang/dep/test"
+	"github.com/pkg/errors"
+	"github.com/sdboyer/gps"
+)
+
+// TestProjectContext groups together test project files and helps test them
+type TestProjectContext struct {
+	h              *test.Helper
+	tempDir        string // Full path to the temp directory
+	tempProjectDir string // Relative path of the project under the temp directory
+
+	Context       *Ctx
+	Project       *Project
+	SourceManager *gps.SourceMgr
+}
+
+// NewTestProjectContext creates a new on-disk test project
+func NewTestProjectContext(h *test.Helper, projectName string) *TestProjectContext {
+	pc := &TestProjectContext{h: h}
+
+	// Create the test project directory
+	pc.tempProjectDir = filepath.Join("src", projectName)
+	h.TempDir(pc.tempProjectDir)
+	pc.tempDir = h.Path(".")
+	pc.Project = &Project{AbsRoot: filepath.Join(pc.tempDir, pc.tempProjectDir)}
+	h.Cd(pc.Project.AbsRoot)
+	h.Setenv("GOPATH", pc.tempDir)
+
+	// Setup a Source Manager
+	var err error
+	pc.Context = &Ctx{GOPATH: pc.tempDir}
+	pc.SourceManager, err = pc.Context.SourceManager()
+	h.Must(errors.Wrap(err, "Unable to create a SourceManager"))
+
+	return pc
+}
+
+// CopyFile copies a file from the testdata directory into the project
+// projectPath is the destination file path, relative to the project directory
+// testdataPath is the source path, relative to the testdata directory
+func (pc *TestProjectContext) CopyFile(projectPath string, testdataPath string) string {
+	path := filepath.Join(pc.tempProjectDir, projectPath)
+	pc.h.TempCopy(path, testdataPath)
+	return path
+}
+
+func (pc *TestProjectContext) Load() {
+	// TODO(carolynvs): Can't use Ctx.LoadProject until dep doesn't require a manifest.json at the project root or it also looks for lock.json
+	var err error
+	var m *Manifest
+	mp := pc.getManifestPath()
+	if pc.h.Exist(mp) {
+		m, err = readManifest(pc.h.GetFile(mp))
+		pc.h.Must(err)
+	}
+	var l *Lock
+	lp := pc.getLockPath()
+	if pc.h.Exist(lp) {
+		l, err = readLock(pc.h.GetFile(lp))
+		pc.h.Must(err)
+	}
+	pc.Project.Manifest = m
+	pc.Project.Lock = l
+}
+
+// GetLockPath returns the full path to the lock
+func (pc *TestProjectContext) getLockPath() string {
+	return filepath.Join(pc.Project.AbsRoot, LockName)
+}
+
+// GetManifestPath returns the full path to the manifest
+func (pc *TestProjectContext) getManifestPath() string {
+	return filepath.Join(pc.Project.AbsRoot, ManifestName)
+}
+
+// GetVendorPath returns the full path to the vendor directory
+func (pc *TestProjectContext) getVendorPath() string {
+	return filepath.Join(pc.Project.AbsRoot, "vendor")
+}
+
+// LockShouldMatchGolden returns an error when the lock does not match the golden lock.
+// goldenLockPath is the path to the golden lock file relative to the testdata directory
+// Updates the golden file when -UpdateGolden flag is present.
+func (pc *TestProjectContext) LockShouldMatchGolden(goldenLockPath string) error {
+	got := pc.h.ReadLock()
+	want := pc.h.GetTestFileString(goldenLockPath)
+	return pc.shouldMatchGolden(goldenLockPath, want, got)
+}
+
+// LockShouldNotExist returns an error when the lock exists.
+func (pc *TestProjectContext) LockShouldNotExist() error {
+	return pc.h.ShouldNotExist(pc.getLockPath())
+}
+
+// ManifestShouldMatchGolden returns an error when the manifest does not match the golden manifest.
+// goldenManifestPath is the path to the golden manifest file, relative to the testdata directory
+// Updates the golden file when -UpdateGolden flag is present
+func (pc *TestProjectContext) ManifestShouldMatchGolden(goldenManifestPath string) error {
+	got := pc.h.ReadManifest()
+	want := pc.h.GetTestFileString(goldenManifestPath)
+	return pc.shouldMatchGolden(goldenManifestPath, want, got)
+}
+
+// ManifestShouldNotExist returns an error when the lock exists.
+func (pc *TestProjectContext) ManifestShouldNotExist() error {
+	return pc.h.ShouldNotExist(pc.getManifestPath())
+}
+
+// ShouldMatchGolden returns an error when a file does not match the golden file.
+// goldenFile is the path to the golden file, relative to the testdata directory
+// Updates the golden file when -UpdateGolden flag is present
+func (pc *TestProjectContext) shouldMatchGolden(goldenFile string, want string, got string) error {
+	if want != got {
+		if *test.UpdateGolden {
+			if err := pc.h.WriteTestFile(goldenFile, got); err != nil {
+				return errors.Wrapf(err, "Unable to write updated golden file %s", goldenFile)
+			}
+		} else {
+			return errors.Errorf("expected %s, got %s", want, got)
+		}
+	}
+
+	return nil
+}
+
+// VendorShouldExist returns an error when the vendor directory does not exist.
+func (pc *TestProjectContext) VendorShouldExist() error {
+	return pc.h.ShouldExist(pc.getVendorPath())
+}
+
+// VendorFileShouldExist returns an error when the specified file does not exist in vendor.
+// filePath is the relative path to the file within vendor
+func (pc *TestProjectContext) VendorFileShouldExist(filePath string) error {
+	fullPath := filepath.Join(pc.getVendorPath(), filePath)
+	return pc.h.ShouldExist(fullPath)
+}
+
+// VendorShouldNotExist returns an error when the vendor directory exists.
+func (pc *TestProjectContext) VendorShouldNotExist() error {
+	return pc.h.ShouldNotExist(pc.getVendorPath())
+}
+
+// Release cleans up after test objects created by this instance
+func (pc *TestProjectContext) Release() {
+	if pc.SourceManager != nil {
+		pc.SourceManager.Release()
+	}
+}

--- a/testdata/txn_writer/expected_diff_output.txt
+++ b/testdata/txn_writer/expected_diff_output.txt
@@ -9,7 +9,14 @@ Add: [
     }
 ]
 Remove: [
-    "github.com/stuff/placeholder"
+    {
+        "name": "github.com/stuff/placeholder",
+        "version": "2.0.0",
+        "revision": "6694017eeb4e20fd277b049bf29dba4895c97234",
+        "packages": [
+            "."
+        ]
+    }
 ]
 Modify: [
     {

--- a/testdata/txn_writer/expected_diff_output.txt
+++ b/testdata/txn_writer/expected_diff_output.txt
@@ -1,0 +1,26 @@
+Add: [
+    {
+        "name": "github.com/stuff/realthing",
+        "version": "2.0.0",
+        "revision": "1f02e52d6bac308da54ab84a234c58a98ca82347",
+        "packages": [
+            "."
+        ]
+    }
+]
+Remove: [
+    "github.com/stuff/placeholder"
+]
+Modify: [
+    {
+        "name": "github.com/foo/bar",
+        "repo": "+ http://github.example.com/foo/bar",
+        "version": "+ 1.2.0",
+        "branch": "- master",
+        "revision": "f24338400f072ef18125ae0fbe6b06fe6d1783e7 -> 2a3a211e171803acb82d1d5d42ceb53228f51751",
+        "packages": [
+            "- placeholder",
+            "+ thing"
+        ]
+    }
+]

--- a/testdata/txn_writer/original_lock.json
+++ b/testdata/txn_writer/original_lock.json
@@ -1,0 +1,22 @@
+{
+  "memo": "595716d270828e763c811ef79c9c41f85b1d1bfbdfe85280036405c03772206c",
+  "projects": [
+    {
+      "name": "github.com/foo/bar",
+      "branch": "master",
+      "revision": "f24338400f072ef18125ae0fbe6b06fe6d1783e7",
+      "packages": [
+        "placeholder",
+        "util"
+      ]
+    },
+    {
+      "name": "github.com/stuff/placeholder",
+      "version": "2.0.0",
+      "revision": "6694017eeb4e20fd277b049bf29dba4895c97234",
+      "packages": [
+        "."
+      ]
+    }
+  ]
+}

--- a/testdata/txn_writer/updated_lock.json
+++ b/testdata/txn_writer/updated_lock.json
@@ -1,0 +1,23 @@
+{
+  "memo": "2252a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e",
+  "projects": [
+    {
+      "name": "github.com/foo/bar",
+      "repo": "http://github.example.com/foo/bar",
+      "version": "1.2.0",
+      "revision": "2a3a211e171803acb82d1d5d42ceb53228f51751",
+      "packages": [
+        "thing",
+        "util"
+      ]
+    },
+    {
+      "name": "github.com/stuff/realthing",
+      "version": "2.0.0",
+      "revision": "1f02e52d6bac308da54ab84a234c58a98ca82347",
+      "packages": [
+        "."
+      ]
+    }
+  ]
+}

--- a/txn_writer.go
+++ b/txn_writer.go
@@ -112,7 +112,7 @@ func (diff *LockDiff) Format() (string, error) {
 // TODO(carolynvs) this should be moved to gps
 type LockedProjectDiff struct {
 	Name       gps.ProjectRoot `json:"name"`
-	Repository *StringDiff     `json:"repo,omitempty"`
+	Source   *StringDiff     `json:"repo,omitempty"`
 	Version    *StringDiff     `json:"version,omitempty"`
 	Branch     *StringDiff     `json:"branch,omitempty"`
 	Revision   *StringDiff     `json:"revision,omitempty"`
@@ -501,7 +501,7 @@ func diffProjects(lp1 gps.LockedProject, lp2 gps.LockedProject) *LockedProjectDi
 	s1 := lp1.Ident().Source
 	s2 := lp2.Ident().Source
 	if s1 != s2 {
-		diff.Repository = &StringDiff{Previous: s1, Current: s2}
+		diff.Source = &StringDiff{Previous: s1, Current: s2}
 	}
 
 	r1, b1, v1 := getVersionInfo(lp1.Version())
@@ -564,7 +564,7 @@ func diffProjects(lp1 gps.LockedProject, lp2 gps.LockedProject) *LockedProjectDi
 		diff.Packages = append(diff.Packages, add)
 	}
 
-	if diff.Repository == nil && diff.Version == nil && diff.Revision == nil && len(diff.Packages) == 0 {
+	if diff.Source == nil && diff.Version == nil && diff.Revision == nil && len(diff.Packages) == 0 {
 		return nil // The projects are equivalent
 	}
 	return &diff

--- a/txn_writer.go
+++ b/txn_writer.go
@@ -21,85 +21,132 @@ import (
 // It is not impervious to errors (writing to disk is hard), but it should
 // guard against non-arcane failure conditions.
 type SafeWriter struct {
-	Root          string    // absolute path of root dir in which to write
-	Manifest      *Manifest // the manifest to write, if any
-	Lock          *Lock     // the old lock, if any
-	NewLock       gps.Lock  // the new lock, if any
-	SourceManager gps.SourceManager
+	Payload *SafeWriterPayload
 }
 
-// WriteAllSafe writes out some combination of config yaml, lock, and a vendor
-// tree, to a temp dir, then moves them into place if and only if all the write
-// operations succeeded. It also does its best to roll back if any moves fail.
-//
-// This mostly guarantees that dep cannot exit with a partial write that would
-// leave an undefined state on disk.
-//
-// - If a sw.Manifest is provided, it will be written to the standard manifest file
-//   name beneath sw.Root
-// - If sw.Lock is provided without an sw.NewLock, it will be written to the standard
-//   lock file name in the root dir, but vendor will NOT be written
-// - If sw.Lock and sw.NewLock are both provided and are equivalent, then neither lock
-//   nor vendor will be written
-// - If sw.Lock and sw.NewLock are both provided and are not equivalent,
-//   the nl will be written to the same location as above, and a vendor
-//   tree will be written to sw.Root/vendor
-// - If sw.NewLock is provided and sw.Lockock is not, it will write both a lock
-//   and vendor dir in the same way
-// - If the forceVendor param is true, then vendor will be unconditionally
-//   written out based on sw.NewLock if present, else sw.Lock, else error.
-//
-// Any of m, l, or nl can be omitted; the grouped write operation will continue
-// for whichever inputs are present. A SourceManager is only required if vendor
-// is being written.
-func (sw SafeWriter) WriteAllSafe(forceVendor bool) error {
-	// Decide which writes we need to do
-	var writeM, writeL, writeV bool
-	writeV = forceVendor
+// SafeWriterPayload represents the actions SafeWriter will execute when SafeWriter.Write is called.
+type SafeWriterPayload struct {
+	Manifest         *Manifest
+	Lock             *Lock
+	LockDiff         *LockDiff
+	ForceWriteVendor bool
+}
 
-	if sw.Manifest != nil {
-		writeM = true
+func (payload *SafeWriterPayload) HasLock() bool {
+	return payload.Lock != nil
+}
+
+func (payload *SafeWriterPayload) HasManifest() bool {
+	return payload.Manifest != nil
+}
+
+func (payload *SafeWriterPayload) HasVendor() bool {
+	// TODO(carolynvs) this can be calculated based on if we are writing the lock
+	// init -> switch to newlock
+	// ensure checks existence, why not move that into the prep?
+	return payload.ForceWriteVendor
+}
+
+// LockDiff is the set of differences between an existing lock file and an updated lock file.
+// TODO(carolynvs) this should be moved to gps
+type LockDiff struct {
+	Add    []gps.LockedProject
+	Remove []gps.LockedProject
+	Modify []LockedProjectDiff
+}
+
+// LockedProjectDiff contains the before and after snapshot of a project reference.
+// TODO(carolynvs) this should be moved to gps
+type LockedProjectDiff struct {
+	Current gps.LockedProject // Current represents the project reference as defined in the existing lock file.
+	Updated gps.LockedProject // Updated represents the desired project reference.
+}
+
+// Prepare to write a set of config yaml, lock and vendor tree.
+//
+// - If manifest is provided, it will be written to the standard manifest file
+//   name beneath root.
+// - If lock is provided it will be written to the standard
+//   lock file name in the root dir, but vendor will NOT be written
+// - If lock and newLock are both provided and are equivalent, then neither lock
+//   nor vendor will be written
+// - If lock and newLock are both provided and are not equivalent,
+//   the newLock will be written to the same location as above, and a vendor
+//   tree will be written to the vendor directory
+// - If newLock is provided and lock is not, it will write both a lock
+//   and the vendor directory in the same way
+// - If the forceVendor param is true, then vendor/ will be unconditionally
+//   written out based on newLock if present, else lock, else error.
+func (sw *SafeWriter) Prepare(manifest *Manifest, lock *Lock, newLock gps.Lock, forceVendor bool) {
+	sw.Payload = &SafeWriterPayload{
+		Manifest:         manifest,
+		ForceWriteVendor: forceVendor,
 	}
 
-	if sw.NewLock != nil {
-		if sw.Lock == nil {
-			writeL, writeV = true, true
+	if newLock != nil {
+		rlf := LockFromInterface(newLock)
+		if lock == nil {
+			sw.Payload.Lock = rlf
+			sw.Payload.ForceWriteVendor = true
 		} else {
-			rlf := LockFromInterface(sw.NewLock)
-			if !locksAreEquivalent(rlf, sw.Lock) {
-				writeL, writeV = true, true
+			if !locksAreEquivalent(rlf, lock) {
+				sw.Payload.Lock = rlf
+				sw.Payload.ForceWriteVendor = true
 			}
 		}
-	} else if sw.Lock != nil {
-		writeL = true
+	} else if lock != nil {
+		sw.Payload.Lock = lock
 	}
+}
 
-	if sw.Root == "" {
+func (payload SafeWriterPayload) validate(root string, sm gps.SourceManager) error {
+	if root == "" {
 		return errors.New("root path must be non-empty")
 	}
-	if is, err := IsDir(sw.Root); !is {
+	if is, err := IsDir(root); !is {
 		if err != nil {
 			return err
 		}
-		return fmt.Errorf("root path %q does not exist", sw.Root)
+		return fmt.Errorf("root path %q does not exist", root)
 	}
 
-	if !writeM && !writeL && !writeV {
+	if payload.HasVendor() && sm == nil {
+		return errors.New("must provide a SourceManager if writing out a vendor dir")
+	}
+
+	if payload.HasVendor() && payload.Lock == nil {
+		return errors.New("must provide a lock in order to write out vendor")
+	}
+
+	return nil
+}
+
+// Write saves some combination of config yaml, lock, and a vendor tree.
+// root is the absolute path of root dir in which to write.
+// sm is only required if vendor is being written.
+//
+// It first writes to a temp dir, then moves them in place if and only if all the write
+// operations succeeded. It also does its best to roll back if any moves fail.
+// This mostly guarantees that dep cannot exit with a partial write that would
+// leave an undefined state on disk.
+func (sw *SafeWriter) Write(root string, sm gps.SourceManager) error {
+	if sw.Payload == nil {
+		return errors.New("Cannot call SafeWriter.Write before SafeWriter.Prepare")
+	}
+
+	err := sw.Payload.validate(root, sm)
+	if err != nil {
+		return err
+	}
+
+	if !sw.Payload.HasManifest() && !sw.Payload.HasLock() && !sw.Payload.HasVendor() {
 		// nothing to do
 		return nil
 	}
 
-	if writeV && sw.SourceManager == nil {
-		return errors.New("must provide a SourceManager if writing out a vendor dir")
-	}
-
-	if writeV && sw.Lock == nil && sw.NewLock == nil {
-		return errors.New("must provide a lock in order to write out vendor")
-	}
-
-	mpath := filepath.Join(sw.Root, ManifestName)
-	lpath := filepath.Join(sw.Root, LockName)
-	vpath := filepath.Join(sw.Root, "vendor")
+	mpath := filepath.Join(root, ManifestName)
+	lpath := filepath.Join(root, LockName)
+	vpath := filepath.Join(root, "vendor")
 
 	td, err := ioutil.TempDir(os.TempDir(), "dep")
 	if err != nil {
@@ -107,35 +154,20 @@ func (sw SafeWriter) WriteAllSafe(forceVendor bool) error {
 	}
 	defer os.RemoveAll(td)
 
-	if writeM {
-		if err := writeFile(filepath.Join(td, ManifestName), sw.Manifest); err != nil {
+	if sw.Payload.HasManifest() {
+		if err := writeFile(filepath.Join(td, ManifestName), sw.Payload.Manifest); err != nil {
 			return errors.Wrap(err, "failed to write manifest file to temp dir")
 		}
 	}
 
-	if writeL {
-		if sw.NewLock == nil {
-			// the new lock is nil but the flag is on, so we must be writing
-			// the other one
-			if err := writeFile(filepath.Join(td, LockName), sw.Lock); err != nil {
-				return errors.Wrap(err, "failed to write lock file to temp dir")
-			}
-		} else {
-			rlf := LockFromInterface(sw.NewLock)
-			if err := writeFile(filepath.Join(td, LockName), rlf); err != nil {
-				return errors.Wrap(err, "failed to write lock file to temp dir")
-			}
+	if sw.Payload.HasLock() {
+		if err := writeFile(filepath.Join(td, LockName), sw.Payload.Lock); err != nil {
+			return errors.Wrap(err, "failed to write lock file to temp dir")
 		}
 	}
 
-	if writeV {
-		// Prefer the nl, but take the l if only that's available, as could be the
-		// case if true was passed for forceVendor.
-		l := sw.NewLock
-		if l == nil {
-			l = sw.Lock
-		}
-		err = gps.WriteDepTree(filepath.Join(td, "vendor"), l, sw.SourceManager, true)
+	if sw.Payload.HasVendor() {
+		err = gps.WriteDepTree(filepath.Join(td, "vendor"), sw.Payload.Lock, sm, true)
 		if err != nil {
 			return errors.Wrap(err, "error while writing out vendor tree")
 		}
@@ -150,7 +182,7 @@ func (sw SafeWriter) WriteAllSafe(forceVendor bool) error {
 	var failerr error
 	var vendorbak string
 
-	if writeM {
+	if sw.Payload.HasManifest() {
 		if _, err := os.Stat(mpath); err == nil {
 			// Move out the old one.
 			tmploc := filepath.Join(td, ManifestName+".orig")
@@ -168,7 +200,7 @@ func (sw SafeWriter) WriteAllSafe(forceVendor bool) error {
 		}
 	}
 
-	if writeL {
+	if sw.Payload.HasLock() {
 		if _, err := os.Stat(lpath); err == nil {
 			// Move out the old one.
 			tmploc := filepath.Join(td, LockName+".orig")
@@ -187,7 +219,7 @@ func (sw SafeWriter) WriteAllSafe(forceVendor bool) error {
 		}
 	}
 
-	if writeV {
+	if sw.Payload.HasVendor() {
 		if _, err := os.Stat(vpath); err == nil {
 			// Move out the old vendor dir. just do it into an adjacent dir, to
 			// try to mitigate the possibility of a pointless cross-filesystem
@@ -215,7 +247,7 @@ func (sw SafeWriter) WriteAllSafe(forceVendor bool) error {
 
 	// Renames all went smoothly. The deferred os.RemoveAll will get the temp
 	// dir, but if we wrote vendor, we have to clean that up directly
-	if writeV {
+	if sw.Payload.HasVendor() {
 		// Nothing we can really do about an error at this point, so ignore it
 		os.RemoveAll(vendorbak)
 	}
@@ -229,4 +261,39 @@ fail:
 		renameWithFallback(pair.from, pair.to)
 	}
 	return failerr
+}
+
+func (sw *SafeWriter) PrintPreparedActions() error {
+	if sw.Payload.HasManifest() {
+		fmt.Println("Would have written the following manifest.json:")
+		m, err := sw.Payload.Manifest.MarshalJSON()
+		if err != nil {
+			return errors.Wrap(err, "ensure DryRun cannot read manifest")
+		}
+		fmt.Println(string(m))
+	}
+
+	if sw.Payload.HasLock() {
+		fmt.Println("Would have written the following lock.json:")
+		m, err := sw.Payload.Lock.MarshalJSON()
+		if err != nil {
+			return errors.Wrap(err, "ensure DryRun cannot read lock")
+		}
+		fmt.Println(string(m))
+	}
+
+	if sw.Payload.HasVendor() {
+		fmt.Println("Would have written the following projects to the vendor directory:")
+		for _, project := range sw.Payload.Lock.Projects() {
+			prj := project.Ident()
+			rev := GetRevisionFromVersion(project.Version())
+			if prj.Source == "" {
+				fmt.Printf("%s@%s\n", prj.ProjectRoot, rev)
+			} else {
+				fmt.Printf("%s -> %s@%s\n", prj.ProjectRoot, prj.Source, rev)
+			}
+		}
+	}
+
+	return nil
 }

--- a/txn_writer_test.go
+++ b/txn_writer_test.go
@@ -415,8 +415,8 @@ func TestSafeWriter_DiffLocks(t *testing.T) {
 		t.Fatalf("Expected the lock diff to contain 1 removed project, got %d", len(diff.Remove))
 	} else {
 		remove := diff.Remove[0]
-		if remove != "github.com/stuff/placeholder" {
-			t.Fatalf("expected new project github.com/stuff/placeholder, got %s", remove)
+		if remove.Name != "github.com/stuff/placeholder" {
+			t.Fatalf("expected new project github.com/stuff/placeholder, got %s", remove.Name)
 		}
 	}
 

--- a/txn_writer_test.go
+++ b/txn_writer_test.go
@@ -7,10 +7,10 @@ package dep
 import (
 	"os"
 	"path/filepath"
-	"strconv"
 	"testing"
 
 	"github.com/golang/dep/test"
+	"github.com/pkg/errors"
 )
 
 func TestTxnWriterBadInputs(t *testing.T) {
@@ -18,190 +18,327 @@ func TestTxnWriterBadInputs(t *testing.T) {
 	defer h.Cleanup()
 
 	h.TempDir("txnwriter")
-	td := h.Path(".")
+	root := h.Path(".")
 
 	var sw SafeWriter
+	pc, err := NewContext()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sm, err := pc.SourceManager()
+	defer sm.Release()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sw.Prepare(nil, nil, nil, false)
 
 	// no root
-	if err := sw.WriteAllSafe(false); err == nil {
-		t.Errorf("should have errored without a root path, but did not")
-	}
-	sw.Root = td
-
-	if err := sw.WriteAllSafe(false); err != nil {
-		t.Errorf("write with only root should be fine, just a no-op, but got err %q", err)
-	}
-	if err := sw.WriteAllSafe(true); err == nil {
-		t.Errorf("should fail because no source manager was provided for writing vendor")
+	if err := sw.Write("", nil); err == nil {
+		t.Fatalf("should have errored without a root path, but did not")
 	}
 
-	if err := sw.WriteAllSafe(true); err == nil {
-		t.Errorf("should fail because no lock was provided from which to write vendor")
+	// noop
+	if err := sw.Write(root, nil); err != nil {
+		t.Fatalf("write with only root should be fine, just a no-op, but got err %q", err)
 	}
+
+	// force vendor with missing source manager
+	sw.Prepare(nil, nil, nil, true)
+	if !sw.Payload.HasVendor() {
+		t.Fatalf("writeV not propogated")
+	}
+	if err := sw.Write(root, nil); err == nil {
+		t.Fatalf("should fail because no source manager was provided for writing vendor")
+	}
+
+	// force vendor with missing lock
+	if err := sw.Write(root, sm); err == nil {
+		t.Fatalf("should fail because no lock was provided from which to write vendor")
+	}
+
 	// now check dir validation
-	sw.Root = filepath.Join(td, "nonexistent")
-	if err := sw.WriteAllSafe(false); err == nil {
-		t.Errorf("should have errored with nonexistent dir for root path, but did not")
+	sw.Prepare(nil, nil, nil, false)
+	missingroot := filepath.Join(root, "nonexistent")
+	if err := sw.Write(missingroot, sm); err == nil {
+		t.Fatalf("should have errored with nonexistent dir for root path, but did not")
 	}
 
-	sw.Root = filepath.Join(td, "myfile")
-	srcf, err := os.Create(sw.Root)
+	fileroot := filepath.Join(root, "myfile")
+	srcf, err := os.Create(fileroot)
 	if err != nil {
 		t.Fatal(err)
 	}
 	srcf.Close()
-	if err := sw.WriteAllSafe(false); err == nil {
-		t.Errorf("should have errored when root path is a file, but did not")
+	if err := sw.Write(fileroot, sm); err == nil {
+		t.Fatalf("should have errored when root path is a file, but did not")
 	}
 }
 
-func TestTxnWriter(t *testing.T) {
+const safeWriterProject = "safewritertest"
+const safeWriterGoldenManifest = "txn_writer/expected_manifest.json"
+const safeWriterGoldenLock = "txn_writer/expected_lock.json"
+
+func TestSafeWriter_ManifestOnly(t *testing.T) {
 	test.NeedsExternalNetwork(t)
 	test.NeedsGit(t)
 
 	h := test.NewHelper(t)
 	defer h.Cleanup()
 
-	h.TempDir("")
-	defer h.Cleanup()
-
-	c := &Ctx{
-		GOPATH: h.Path("."),
-	}
-	sm, err := c.SourceManager()
-	defer sm.Release()
-	h.Must(err)
+	pc := NewTestProjectContext(h, safeWriterProject)
+	defer pc.Release()
+	pc.CopyFile(ManifestName, safeWriterGoldenManifest)
+	pc.Load()
 
 	var sw SafeWriter
-	var mpath, lpath, vpath string
-	var count int
-	reset := func() {
-		pr := filepath.Join("src", "txnwriter"+strconv.Itoa(count))
-		h.TempDir(pr)
+	sw.Prepare(pc.Project.Manifest, nil, nil, false)
 
-		sw = SafeWriter{
-			Root:          h.Path(pr),
-			SourceManager: sm,
-		}
-		h.Cd(sw.Root)
-
-		mpath = filepath.Join(sw.Root, ManifestName)
-		lpath = filepath.Join(sw.Root, LockName)
-		vpath = filepath.Join(sw.Root, "vendor")
-
-		count++
+	// Verify prepared actions
+	if !sw.Payload.HasManifest() {
+		t.Fatal("Expected the payload to contain the manifest")
 	}
-	reset()
-
-	// super basic manifest and lock
-	goldenm := "txn_writer/expected_manifest.json"
-	goldenl := "txn_writer/expected_lock.json"
-	wantm := h.GetTestFileString(goldenm)
-	wantl := h.GetTestFileString(goldenl)
-
-	m, err := readManifest(h.GetTestFile(goldenm))
-	h.Must(err)
-	l, err := readLock(h.GetTestFile(goldenl))
-	h.Must(err)
-
-	// Just write manifest
-	sw.Manifest = m
-	h.Must(sw.WriteAllSafe(false))
-	h.MustExist(mpath)
-	h.MustNotExist(lpath)
-	h.MustNotExist(vpath)
-
-	gotm := h.ReadManifest()
-	if wantm != gotm {
-		if *test.UpdateGolden {
-			wantm = gotm
-			if err = h.WriteTestFile(goldenm, gotm); err != nil {
-				t.Fatal(err)
-			}
-		} else {
-			t.Fatalf("expected %s, got %s", wantm, gotm)
-		}
+	if sw.Payload.HasLock() {
+		t.Fatal("Did not expect the payload to contain the lock")
+	}
+	if sw.Payload.HasVendor() {
+		t.Fatal("Did not expect the payload to contain the vendor directory")
 	}
 
-	// Manifest and lock, but no vendor
-	sw.Lock = l
-	h.Must(sw.WriteAllSafe(false))
-	h.MustExist(mpath)
-	h.MustExist(lpath)
-	h.MustNotExist(vpath)
+	// Write changes
+	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager)
+	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
-	gotm = h.ReadManifest()
-	if wantm != gotm {
-		t.Fatalf("expected %s, got %s", wantm, gotm)
+	// Verify file system changes
+	if err := pc.ManifestShouldMatchGolden(safeWriterGoldenManifest); err != nil {
+		t.Fatal(err)
+	}
+	if err := pc.LockShouldNotExist(); err != nil {
+		t.Fatal(err)
+	}
+	if err := pc.VendorShouldNotExist(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSafeWriter_ManifestAndUnmodifiedLock(t *testing.T) {
+	test.NeedsExternalNetwork(t)
+	test.NeedsGit(t)
+
+	h := test.NewHelper(t)
+	defer h.Cleanup()
+
+	pc := NewTestProjectContext(h, safeWriterProject)
+	defer pc.Release()
+	pc.CopyFile(ManifestName, safeWriterGoldenManifest)
+	pc.CopyFile(LockName, safeWriterGoldenLock)
+	pc.Load()
+
+	var sw SafeWriter
+	sw.Prepare(pc.Project.Manifest, pc.Project.Lock, nil, false)
+
+	// Verify prepared actions
+	if !sw.Payload.HasManifest() {
+		t.Fatal("Expected the payload to contain the manifest")
+	}
+	if !sw.Payload.HasLock() {
+		t.Fatal("Expected the payload to contain the lock")
+	}
+	if sw.Payload.HasVendor() {
+		t.Fatal("Did not expect the payload to contain the vendor directory")
 	}
 
-	gotl := h.ReadLock()
-	if wantl != gotl {
-		if *test.UpdateGolden {
-			wantl = gotl
-			if err = h.WriteTestFile(goldenl, gotl); err != nil {
-				t.Fatal(err)
-			}
-		} else {
-			t.Fatalf("expected %s, got %s", wantl, gotl)
-		}
+	// Write changes
+	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager)
+	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
+
+	// Verify file system changes
+	if err := pc.ManifestShouldMatchGolden(safeWriterGoldenManifest); err != nil {
+		t.Fatal(err)
+	}
+	if err := pc.LockShouldMatchGolden(safeWriterGoldenLock); err != nil {
+		t.Fatal(err)
+	}
+	if err := pc.VendorShouldNotExist(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSafeWriter_ManifestAndUnmodifiedLockWithForceVendor(t *testing.T) {
+	test.NeedsExternalNetwork(t)
+	test.NeedsGit(t)
+
+	h := test.NewHelper(t)
+	defer h.Cleanup()
+
+	pc := NewTestProjectContext(h, safeWriterProject)
+	defer pc.Release()
+	pc.CopyFile(ManifestName, safeWriterGoldenManifest)
+	pc.CopyFile(LockName, safeWriterGoldenLock)
+	pc.Load()
+
+	var sw SafeWriter
+	sw.Prepare(pc.Project.Manifest, pc.Project.Lock, nil, true)
+
+	// Verify prepared actions
+	if !sw.Payload.HasManifest() {
+		t.Fatal("Expected the payload to contain the manifest")
+	}
+	if !sw.Payload.HasLock() {
+		t.Fatal("Expected the payload to contain the lock")
+	}
+	if !sw.Payload.HasVendor() {
+		t.Fatal("Expected the payload to the vendor directory")
 	}
 
-	h.Must(sw.WriteAllSafe(true))
-	h.MustExist(mpath)
-	h.MustExist(lpath)
-	h.MustExist(vpath)
-	h.MustExist(filepath.Join(vpath, "github.com", "sdboyer", "dep-test"))
+	// Write changes
+	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager)
+	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
-	gotm = h.ReadManifest()
-	if wantm != gotm {
-		t.Fatalf("expected %s, got %s", wantm, gotm)
+	// Verify file system changes
+	if err := pc.ManifestShouldMatchGolden(safeWriterGoldenManifest); err != nil {
+		t.Fatal(err)
+	}
+	if err := pc.LockShouldMatchGolden(safeWriterGoldenLock); err != nil {
+		t.Fatal(err)
+	}
+	if err := pc.VendorShouldExist(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSafeWriter_UnmodifiedLock(t *testing.T) {
+	test.NeedsExternalNetwork(t)
+	test.NeedsGit(t)
+
+	h := test.NewHelper(t)
+	defer h.Cleanup()
+
+	pc := NewTestProjectContext(h, safeWriterProject)
+	defer pc.Release()
+	pc.CopyFile(LockName, safeWriterGoldenLock)
+	pc.Load()
+
+	var sw SafeWriter
+	sw.Prepare(nil, pc.Project.Lock, pc.Project.Lock, false)
+
+	// Verify prepared actions
+	if sw.Payload.HasManifest() {
+		t.Fatal("Did not expect the payload to contain the manifest")
+	}
+	if sw.Payload.HasLock() {
+		t.Fatal("Did not expect the payload to contain the lock")
+	}
+	if sw.Payload.HasVendor() {
+		t.Fatal("Did not expect the payload to contain the vendor directory")
 	}
 
-	gotl = h.ReadLock()
-	if wantl != gotl {
-		t.Fatalf("expected %s, got %s", wantl, gotl)
-	}
+	// Write changes
+	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager)
+	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
-	// start fresh, ignoring the manifest now
-	reset()
-	sw.Lock = l
-	sw.NewLock = l
-
-	h.Must(sw.WriteAllSafe(false))
+	// Verify file system changes
 	// locks are equivalent, so nothing gets written
-	h.MustNotExist(mpath)
-	h.MustNotExist(lpath)
-	h.MustNotExist(vpath)
+	if err := pc.ManifestShouldNotExist(); err != nil {
+		t.Fatal(err)
+	}
+	if err := pc.VendorShouldNotExist(); err != nil {
+		t.Fatal(err)
+	}
+}
 
-	l2 := new(Lock)
-	*l2 = *l
-	// zero out the input hash to ensure non-equivalency
-	l2.Memo = []byte{}
-	sw.Lock = l2
-	h.Must(sw.WriteAllSafe(true))
-	h.MustNotExist(mpath)
-	h.MustExist(lpath)
-	h.MustExist(vpath)
-	h.MustExist(filepath.Join(vpath, "github.com", "sdboyer", "dep-test"))
+func TestSafeWriter_ModifiedLockForceVendor(t *testing.T) {
+	test.NeedsExternalNetwork(t)
+	test.NeedsGit(t)
 
-	gotl = h.ReadLock()
-	if wantl != gotl {
-		t.Fatalf("expected %s, got %s", wantl, gotl)
+	h := test.NewHelper(t)
+	defer h.Cleanup()
+
+	pc := NewTestProjectContext(h, safeWriterProject)
+	defer pc.Release()
+	pc.CopyFile(LockName, safeWriterGoldenLock)
+	pc.Load()
+
+	var sw SafeWriter
+	originalLock := new(Lock)
+	*originalLock = *pc.Project.Lock
+	originalLock.Memo = []byte{} // zero out the input hash to ensure non-equivalency
+	sw.Prepare(nil, originalLock, pc.Project.Lock, true)
+
+	// Verify prepared actions
+	if sw.Payload.HasManifest() {
+		t.Fatal("Did not expect the payload to contain the manifest")
+	}
+	if !sw.Payload.HasLock() {
+		t.Fatal("Expected the payload to contain the lock")
+	}
+	if !sw.Payload.HasVendor() {
+		t.Fatal("Expected the payload to the vendor directory")
 	}
 
-	// repeat op to ensure good behavior when vendor dir already exists
-	sw.Lock = nil
-	h.Must(sw.WriteAllSafe(true))
-	h.MustNotExist(mpath)
-	h.MustExist(lpath)
-	h.MustExist(vpath)
-	h.MustExist(filepath.Join(vpath, "github.com", "sdboyer", "dep-test"))
+	// Write changes
+	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager)
+	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
-	gotl = h.ReadLock()
-	if wantl != gotl {
-		t.Fatalf("expected %s, got %s", wantl, gotl)
+	// Verify file system changes
+	if err := pc.ManifestShouldNotExist(); err != nil {
+		t.Fatal(err)
+	}
+	if err := pc.LockShouldMatchGolden(safeWriterGoldenLock); err != nil {
+		t.Fatal(err)
+	}
+	if err := pc.VendorShouldExist(); err != nil {
+		t.Fatal(err)
+	}
+	if err := pc.VendorFileShouldExist("github.com/sdboyer/dep-test"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSafeWriter_ForceVendorWhenVendorAlreadyExists(t *testing.T) {
+	test.NeedsExternalNetwork(t)
+	test.NeedsGit(t)
+
+	h := test.NewHelper(t)
+	defer h.Cleanup()
+
+	pc := NewTestProjectContext(h, safeWriterProject)
+	defer pc.Release()
+	pc.CopyFile(LockName, safeWriterGoldenLock)
+	pc.Load()
+
+	var sw SafeWriter
+	// Populate vendor
+	sw.Prepare(nil, pc.Project.Lock, nil, true)
+	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager)
+	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
+
+	// Verify prepared actions
+	sw.Prepare(nil, nil, pc.Project.Lock, true)
+	if sw.Payload.HasManifest() {
+		t.Fatal("Did not expect the payload to contain the manifest")
+	}
+	if !sw.Payload.HasLock() {
+		t.Fatal("Expected the payload to contain the lock")
+	}
+	if !sw.Payload.HasVendor() {
+		t.Fatal("Expected the payload to the vendor directory")
 	}
 
-	// TODO test txn rollback cases. maybe we can force errors with chmodding?
+	err = sw.Write(pc.Project.AbsRoot, pc.SourceManager)
+	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
+
+	// Verify file system changes
+	if err := pc.ManifestShouldNotExist(); err != nil {
+		t.Fatal(err)
+	}
+	if err := pc.LockShouldMatchGolden(safeWriterGoldenLock); err != nil {
+		t.Fatal(err)
+	}
+	if err := pc.VendorShouldExist(); err != nil {
+		t.Fatal(err)
+	}
+	if err := pc.VendorFileShouldExist("github.com/sdboyer/dep-test"); err != nil {
+		t.Fatal(err)
+	}
 }


### PR DESCRIPTION
This fixes #145.

When I first looked at this, turning on `-v` by default when `-n` is present, seemed like an easy win. However the verbose output from the `gps` solver wasn't really what I was looking for in a dry-run, I wanted to know what ensure would do, not what it evaluated. So I added output which clearly shows what will be written to the filesystem when the command is run without `-n`.

```
$ dep ensure -n
Would have written the following manifest.json:
{
    "dependencies": {
        "github.com/Masterminds/semver": {
            "branch": "2.x"
        },
        "github.com/Masterminds/vcs": {
            "version": "^1.8.0"
        },
        "github.com/pkg/errors": {
            "version": ">=0.8.0, <1.0.0"
        },
        "github.com/sdboyer/gps": {
            "branch": "master"
        }
    }
}

Would have written the following lock.json:
{
    "memo": "48f086eeb4e1871e10660af8a9ca7a46f72abea12df8843e62c3a1db46960d5f",
    "projects": [
        {
            "name": "github.com/Masterminds/semver",
            "branch": "2.x",
            "revision": "94ad6eaf8457cf85a68c9b53fa42e9b1b8683783",
            "packages": [
                "."
            ]
        },
        {
            "name": "github.com/Masterminds/vcs",
            "version": "v1.8.0",
            "revision": "fbe9fb6ad5b5f35b3e82a7c21123cfc526cbf895",
            "packages": [
                "."
            ]
        },
        {
            "name": "github.com/armon/go-radix",
            "branch": "master",
            "revision": "4239b77079c7b5d1243b7b4736304ce8ddb6f0f2",
            "packages": [
                "."
            ]
        },
        {
            "name": "github.com/pkg/errors",
            "version": "v0.8.0",
            "revision": "645ef00459ed84a119197bfb8d8205042c6df63d",
            "packages": [
                "."
            ]
        },
        {
            "name": "github.com/sdboyer/gps",
            "branch": "master",
            "revision": "7fb04c97d99da000c0b8f4ff153936d2354ae828",
            "packages": [
                "."
            ]
        }
    ]
}

Would have written the following projects to the vendor directory:
github.com/Masterminds/semver@94ad6eaf8457cf85a68c9b53fa42e9b1b8683783
github.com/armon/go-radix@4239b77079c7b5d1243b7b4736304ce8ddb6f0f2
github.com/Masterminds/vcs@fbe9fb6ad5b5f35b3e82a7c21123cfc526cbf895
github.com/sdboyer/gps@7fb04c97d99da000c0b8f4ff153936d2354ae828
github.com/pkg/errors@645ef00459ed84a119197bfb8d8205042c6df63d
```