### PR TITLE
Adding a newline to the end of solve err

### DIFF
--- a/cmd/dep/init.go
+++ b/cmd/dep/init.go
@@ -204,7 +204,7 @@ func isStdLib(path string) bool {
 // TODO solve failures can be really creative - we need to be similarly creative
 // in handling them and informing the user appropriately
 func handleAllTheFailuresOfTheWorld(err error) {
-	fmt.Printf("solve error: %s", err)
+	fmt.Printf("solve error: %s\n", err)
 }
 
 func writeFile(path string, in json.Marshaler) error {


### PR DESCRIPTION
Fixes one of the aspects of https://github.com/golang/dep/issues/270