### PR TITLE
Add a note about extended help being available

### DIFF
--- a/cmd/dep/main.go
+++ b/cmd/dep/main.go
@@ -53,6 +53,7 @@ func main() {
 		}
 		w.Flush()
 		fmt.Fprintln(os.Stderr)
+		fmt.Fprintln(os.Stderr, "Use \"dep help [command]\" for more information about a command.")
 	}
 
 	cmdName, printCommandHelp, exit := parseArgs(os.Args)


### PR DESCRIPTION
Dep's extended help text is great, but not obvious to find. I spent a little time doing `dep --help`, `dep -h`, `dep help`, looking for more info. This change adds a small note to the usage text that points the user to `dep help subcommand`. I took the prose from the `go` command's usage text, so if you disagree with the wording, you are literally a heretic.

The usage changes from

```
▶ dep                                                           
Usage: dep <command>

Commands:

  init    Initialize a new project with manifest and lock files
  status  Report the status of the project's dependencies
  ensure  Ensure a dependency is safely vendored in the project
  remove  Remove a dependency from the project
```

to...

```
▶ dep                                                           
Usage: dep <command>

Commands:

  init    Initialize a new project with manifest and lock files
  status  Report the status of the project's dependencies
  ensure  Ensure a dependency is safely vendored in the project
  remove  Remove a dependency from the project

Use "dep help [command]" for more information about a command.
```