### PR TITLE
Remove unused function writeFile from init.go

### DIFF
--- a/cmd/dep/init.go
+++ b/cmd/dep/init.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
@@ -199,22 +198,6 @@ func isStdLib(path string) bool {
 // in handling them and informing the user appropriately
 func handleAllTheFailuresOfTheWorld(err error) {
 	fmt.Printf("solve error: %s\n", err)
-}
-
-func writeFile(path string, in json.Marshaler) error {
-	f, err := os.Create(path)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	b, err := in.MarshalJSON()
-	if err != nil {
-		return err
-	}
-
-	_, err = f.Write(b)
-	return err
 }
 
 func hasImportPathPrefix(s, prefix string) bool {


### PR DESCRIPTION
While getting familiar with the dep source I came across this unused function that seems to have been left behind after the refactor in 0acfd38 .