### PR TITLE
Write vendor, regardless of lock, if force is true

### DIFF
--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -153,7 +153,10 @@ func (cmd *ensureCommand) Run(ctx *dep.Ctx, args []string) error {
 	if err != nil {
 		return errors.Wrap(err, "ensure vendor is a directory")
 	}
-	writeV := !vendorExists && solution != nil
+	writeV := dep.VendorOnChanged
+	if !vendorExists && solution != nil {
+		writeV = dep.VendorAlways
+	}
 
 	var sw dep.SafeWriter
 	var manifest *dep.Manifest

--- a/cmd/dep/init.go
+++ b/cmd/dep/init.go
@@ -163,7 +163,7 @@ func (cmd *initCommand) Run(ctx *dep.Ctx, args []string) error {
 	vlogf("Writing manifest and lock files.")
 
 	var sw dep.SafeWriter
-	sw.Prepare(m, nil, l, true)
+	sw.Prepare(m, nil, l, dep.VendorAlways)
 	if err := sw.Write(root, sm); err != nil {
 		return errors.Wrap(err, "safe write of manifest and lock")
 	}

--- a/cmd/dep/init.go
+++ b/cmd/dep/init.go
@@ -163,7 +163,7 @@ func (cmd *initCommand) Run(ctx *dep.Ctx, args []string) error {
 	vlogf("Writing manifest and lock files.")
 
 	var sw dep.SafeWriter
-	sw.Prepare(m, l, nil, true)
+	sw.Prepare(m, nil, l, true)
 	if err := sw.Write(root, sm); err != nil {
 		return errors.Wrap(err, "safe write of manifest and lock")
 	}

--- a/cmd/dep/remove.go
+++ b/cmd/dep/remove.go
@@ -181,7 +181,7 @@ func (cmd *removeCommand) Run(ctx *dep.Ctx, args []string) error {
 
 	var sw dep.SafeWriter
 	newLock := dep.LockFromInterface(soln)
-	sw.Prepare(p.Manifest, p.Lock, newLock, false)
+	sw.Prepare(p.Manifest, p.Lock, newLock, dep.VendorOnChanged)
 	if err := sw.Write(p.AbsRoot, sm); err != nil {
 		return errors.Wrap(err, "grouped write of manifest, lock and vendor")
 	}

--- a/testdata/txn_writer/expected_diff_output.txt
+++ b/testdata/txn_writer/expected_diff_output.txt
@@ -1,3 +1,4 @@
+Memo: 595716d270828e763c811ef79c9c41f85b1d1bfbdfe85280036405c03772206c -> 2252a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e
 Add: [
     {
         "name": "github.com/stuff/realthing",

--- a/txn_writer.go
+++ b/txn_writer.go
@@ -358,12 +358,21 @@ func (sw *SafeWriter) PrintPreparedActions() error {
 	}
 
 	if sw.Payload.HasLock() {
-		fmt.Println("Would have written the following changes to lock.json:")
-		diff, err := sw.Payload.LockDiff.Format()
-		if err != nil {
-			return errors.Wrap(err, "ensure DryRun cannot serialize the lock diff")
+		if sw.Payload.LockDiff == nil {
+			fmt.Println("Would have written the following lock.json:")
+			l, err := sw.Payload.Lock.MarshalJSON()
+			if err != nil {
+				return errors.Wrap(err, "ensure DryRun cannot serialize lock")
+			}
+			fmt.Println(string(l))
+		} else {
+			fmt.Println("Would have written the following changes to lock.json:")
+			diff, err := sw.Payload.LockDiff.Format()
+			if err != nil {
+				return errors.Wrap(err, "ensure DryRun cannot serialize the lock diff")
+			}
+			fmt.Println(diff)
 		}
-		fmt.Println(diff)
 	}
 
 	if sw.Payload.HasVendor() {

--- a/txn_writer_test.go
+++ b/txn_writer_test.go
@@ -165,14 +165,14 @@ func TestSafeWriter_ManifestAndUnmodifiedLock(t *testing.T) {
 	pc.Load()
 
 	var sw SafeWriter
-	sw.Prepare(pc.Project.Manifest, pc.Project.Lock, nil, false)
+	sw.Prepare(pc.Project.Manifest, pc.Project.Lock, pc.Project.Lock, false)
 
 	// Verify prepared actions
 	if !sw.Payload.HasManifest() {
 		t.Fatal("Expected the payload to contain the manifest")
 	}
-	if !sw.Payload.HasLock() {
-		t.Fatal("Expected the payload to contain the lock")
+	if sw.Payload.HasLock() {
+		t.Fatal("Did not expect the payload to contain the lock")
 	}
 	if sw.Payload.HasVendor() {
 		t.Fatal("Did not expect the payload to contain the vendor directory")
@@ -208,7 +208,7 @@ func TestSafeWriter_ManifestAndUnmodifiedLockWithForceVendor(t *testing.T) {
 	pc.Load()
 
 	var sw SafeWriter
-	sw.Prepare(pc.Project.Manifest, pc.Project.Lock, nil, true)
+	sw.Prepare(pc.Project.Manifest, pc.Project.Lock, pc.Project.Lock, true)
 
 	// Verify prepared actions
 	if !sw.Payload.HasManifest() {
@@ -339,7 +339,7 @@ func TestSafeWriter_ForceVendorWhenVendorAlreadyExists(t *testing.T) {
 
 	var sw SafeWriter
 	// Populate vendor
-	sw.Prepare(nil, pc.Project.Lock, nil, true)
+	sw.Prepare(nil, pc.Project.Lock, pc.Project.Lock, true)
 	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager)
 	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 


### PR DESCRIPTION
I wasn't taking forcevendor into account properly when the diffs were the same (which is exactly what that flag was for...) 😞 

This fixes my misunderstanding about when lock and newlock should be set in the SafeWriter tests.  Previously, I thought I should only pass in newlock when the lock had changed, or was brand new, when actually it should be passed anytime there was an existing lock file. Due to the bad test, it was missing that a bare ensure with an existing lock file (and no vendor) should result in vendor being written.

This fixes #323.