### PR TITLE
Rename the lock field "repo" to "source"

### DIFF
--- a/lock.go
+++ b/lock.go
@@ -28,12 +28,12 @@ type rawLock struct {
 }
 
 type lockedDep struct {
-	Name       string   `json:"name"`
-	Version    string   `json:"version,omitempty"`
-	Branch     string   `json:"branch,omitempty"`
-	Revision   string   `json:"revision"`
-	Repository string   `json:"repo,omitempty"`
-	Packages   []string `json:"packages"`
+	Name     string   `json:"name"`
+	Version  string   `json:"version,omitempty"`
+	Branch   string   `json:"branch,omitempty"`
+	Revision string   `json:"revision"`
+	Source   string   `json:"source,omitempty"`
+	Packages []string `json:"packages"`
 }
 
 func readLock(r io.Reader) (*Lock, error) {
@@ -69,7 +69,7 @@ func readLock(r io.Reader) (*Lock, error) {
 
 		id := gps.ProjectIdentifier{
 			ProjectRoot: gps.ProjectRoot(ld.Name),
-			Source:      ld.Repository,
+			Source:      ld.Source,
 		}
 		l.P[i] = gps.NewLockedProject(id, v, ld.Packages)
 	}
@@ -96,9 +96,9 @@ func (l *Lock) MarshalJSON() ([]byte, error) {
 	for k, lp := range l.P {
 		id := lp.Ident()
 		ld := lockedDep{
-			Name:       string(id.ProjectRoot),
-			Repository: id.Source,
-			Packages:   lp.Packages(),
+			Name:     string(id.ProjectRoot),
+			Source:   id.Source,
+			Packages: lp.Packages(),
 		}
 
 		v := lp.Version()

--- a/test_project_context_test.go
+++ b/test_project_context_test.go
@@ -35,7 +35,7 @@ func NewTestProjectContext(h *test.Helper, projectName string) *TestProjectConte
 	h.Cd(pc.Project.AbsRoot)
 	h.Setenv("GOPATH", pc.tempDir)
 
-	// Setup a Source Manager
+	// Set up a Source Manager
 	var err error
 	pc.Context = &Ctx{GOPATH: pc.tempDir}
 	pc.SourceManager, err = pc.Context.SourceManager()

--- a/testdata/txn_writer/expected_diff_output.txt
+++ b/testdata/txn_writer/expected_diff_output.txt
@@ -21,7 +21,7 @@ Remove: [
 Modify: [
     {
         "name": "github.com/foo/bar",
-        "repo": "+ http://github.example.com/foo/bar",
+        "source": "+ http://github.example.com/foo/bar",
         "version": "+ 1.2.0",
         "branch": "- master",
         "revision": "f24338400f072ef18125ae0fbe6b06fe6d1783e7 -> 2a3a211e171803acb82d1d5d42ceb53228f51751",

--- a/testdata/txn_writer/updated_lock.json
+++ b/testdata/txn_writer/updated_lock.json
@@ -3,7 +3,7 @@
   "projects": [
     {
       "name": "github.com/foo/bar",
-      "repo": "http://github.example.com/foo/bar",
+      "source": "http://github.example.com/foo/bar",
       "version": "1.2.0",
       "revision": "2a3a211e171803acb82d1d5d42ceb53228f51751",
       "packages": [

--- a/txn_writer.go
+++ b/txn_writer.go
@@ -112,7 +112,7 @@ func (diff *LockDiff) Format() (string, error) {
 // TODO(carolynvs) this should be moved to gps
 type LockedProjectDiff struct {
 	Name     gps.ProjectRoot `json:"name"`
-	Source   *StringDiff     `json:"repo,omitempty"`
+	Source   *StringDiff     `json:"source,omitempty"`
 	Version  *StringDiff     `json:"version,omitempty"`
 	Branch   *StringDiff     `json:"branch,omitempty"`
 	Revision *StringDiff     `json:"revision,omitempty"`


### PR DESCRIPTION
I wasn't sure if we needed more discussion about #308 (renaming repo to source in the lock file)? It would be a breaking change.