### PR TITLE
Tweaks to ensure's help text

### DIFF
--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -33,7 +33,7 @@ Package spec:
 
 Examples:
 
-  dep ensure                            Populate vendor from existing manifest and lock
+  dep ensure                            Populate vendor from existing manifest and then lock
   dep ensure github.com/pkg/foo@^1.0.1  Update a specific dependency to a specific version
 
 For more detailed usage examples, see dep ensure -examples.
@@ -44,7 +44,8 @@ dep ensure
     Solve the project's dependency graph, and place all dependencies in the
     vendor folder. If a dependency is in the lock file, use the version
     specified there. Otherwise, use the most recent version that can satisfy the
-    constraints in the manifest file.
+    constraints in the manifest file. Remove dependencies that are no longer needed
+    from the manifest file, and add any new ones.
 
 dep ensure -update
 

--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -33,7 +33,7 @@ Package spec:
 
 Examples:
 
-  dep ensure                            Populate vendor from existing manifest and then lock
+  dep ensure                            Compute required deps, lock them, and populate vendor
   dep ensure github.com/pkg/foo@^1.0.1  Update a specific dependency to a specific version
 
 For more detailed usage examples, see dep ensure -examples.


### PR DESCRIPTION
Minor modifications to the 'dep help ensure' text to explain that the command executes and then locks; it does not execute from the lock file itself. This was a stumbling block in my understanding of `dep ensure`.

Also added a note to the first example, mentioning that obsolete dependencies are removed from the manifest and new ones added in.