### PR TITLE
Add examples to the main usage output

### DIFF
--- a/cmd/dep/main.go
+++ b/cmd/dep/main.go
@@ -60,6 +60,8 @@ func main() {
 	}
 
 	usage := func() {
+		fmt.Fprintln(os.Stderr, "dep is a tool for managing dependencies for Go projects")
+		fmt.Fprintln(os.Stderr)
 		fmt.Fprintln(os.Stderr, "Usage: dep <command>")
 		fmt.Fprintln(os.Stderr)
 		fmt.Fprintln(os.Stderr, "Commands:")

--- a/cmd/dep/main.go
+++ b/cmd/dep/main.go
@@ -41,19 +41,19 @@ func main() {
 	}
 
 	examples := [][2]string{
-		[2]string{
+		{
 			"dep init",
 			"set up a new project",
 		},
-		[2]string{
+		{
 			"dep ensure",
 			"install the project's dependencies",
 		},
-		[2]string{
+		{
 			"dep ensure -update",
 			"update the saved versions of all dependencies",
 		},
-		[2]string{
+		{
 			"dep ensure github.com/pkg/errors",
 			"add a dependency to the project",
 		},

--- a/cmd/dep/main.go
+++ b/cmd/dep/main.go
@@ -51,7 +51,7 @@ func main() {
 		},
 		{
 			"dep ensure -update",
-			"update the saved versions of all dependencies",
+			"update the locked versions of all dependencies",
 		},
 		{
 			"dep ensure github.com/pkg/errors",

--- a/cmd/dep/main.go
+++ b/cmd/dep/main.go
@@ -40,6 +40,25 @@ func main() {
 		&hashinCommand{},
 	}
 
+	examples := [][2]string{
+		[2]string{
+			"dep init",
+			"set up a new project",
+		},
+		[2]string{
+			"dep ensure",
+			"install the project's dependencies",
+		},
+		[2]string{
+			"dep ensure -update",
+			"update the saved versions of all dependencies",
+		},
+		[2]string{
+			"dep ensure github.com/pkg/errors",
+			"add a dependency to the project",
+		},
+	}
+
 	usage := func() {
 		fmt.Fprintln(os.Stderr, "Usage: dep <command>")
 		fmt.Fprintln(os.Stderr)
@@ -50,6 +69,12 @@ func main() {
 			if !cmd.Hidden() {
 				fmt.Fprintf(w, "\t%s\t%s\n", cmd.Name(), cmd.ShortHelp())
 			}
+		}
+		w.Flush()
+		fmt.Fprintln(os.Stderr)
+		fmt.Fprintln(os.Stderr, "Examples:")
+		for _, example := range examples {
+			fmt.Fprintf(w, "\t%s\t%s\n", example[0], example[1])
 		}
 		w.Flush()
 		fmt.Fprintln(os.Stderr)


### PR DESCRIPTION
Not sure if it's worth having an `examples` slice like this, or just hardcoding them. Would save a lot of lines. Depends if we want to make examples a first class citizen of the command object I guess. Ensure's current `dep ensure -examples` is rather hidden away atm, so we should maybe go that way. Anyway... This PR gives us:

```
▶ dep help            
dep is a tool for managing dependencies for Go projects

Usage: dep <command>

Commands:

  init    Initialize a new project with manifest and lock files
  status  Report the status of the project's dependencies
  ensure  Ensure a dependency is safely vendored in the project
  remove  Remove a dependency from the project

Examples:
  dep init                          set up a new project
  dep ensure                        install the project's dependencies
  dep ensure -update                update the saved versions of all dependencies
  dep ensure github.com/pkg/errors  add a dependency to the project

Use "dep help [command]" for more information about a command.
```