### PR TITLE
Wrap error so the test prints the stack trace

### DIFF
--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -290,7 +290,7 @@ func getProjectConstraint(arg string, sm *gps.SourceMgr) (gps.ProjectConstraint,
 	}
 
 	if string(pr) != arg {
-		return constraint, fmt.Errorf("dependency path %s is not a project root, try %s instead", arg, pr)
+		return constraint, errors.Errorf("dependency path %s is not a project root, try %s instead", arg, pr)
 	}
 
 	constraint.Ident.ProjectRoot = gps.ProjectRoot(arg)
@@ -318,7 +318,7 @@ func getProjectConstraint(arg string, sm *gps.SourceMgr) (gps.ProjectConstraint,
 			}
 
 			if !found {
-				return constraint, fmt.Errorf("%s is not a valid version for the package %s", versionStr, arg)
+				return constraint, errors.Errorf("%s is not a valid version for the package %s", versionStr, arg)
 			}
 		}
 	}

--- a/cmd/dep/init.go
+++ b/cmd/dep/init.go
@@ -72,7 +72,7 @@ func (cmd *initCommand) Run(ctx *dep.Ctx, args []string) error {
 		return err
 	}
 	if mok {
-		return fmt.Errorf("manifest file %q already exists", mf)
+		return errors.Errorf("manifest file %q already exists", mf)
 	}
 	// Manifest file does not exist.
 
@@ -81,7 +81,7 @@ func (cmd *initCommand) Run(ctx *dep.Ctx, args []string) error {
 		return err
 	}
 	if lok {
-		return fmt.Errorf("invalid state: manifest %q does not exist, but lock %q does", mf, lf)
+		return errors.Errorf("invalid state: manifest %q does not exist, but lock %q does", mf, lf)
 	}
 
 	cpr, err := ctx.SplitAbsoluteProjectRoot(root)

--- a/cmd/dep/remove.go
+++ b/cmd/dep/remove.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"log"
 	"os"
 	"strings"
@@ -70,7 +69,7 @@ func (cmd *removeCommand) Run(ctx *dep.Ctx, args []string) error {
 
 	if cmd.unused {
 		if len(args) > 0 {
-			return fmt.Errorf("remove takes no arguments when running with -unused")
+			return errors.Errorf("remove takes no arguments when running with -unused")
 		}
 
 		reachlist := reachmap.Flatten(false)
@@ -126,7 +125,7 @@ func (cmd *removeCommand) Run(ctx *dep.Ctx, args []string) error {
 			if string(pr) != arg {
 				// don't be magical with subpaths, otherwise we muddy the waters
 				// between project roots and import paths
-				return fmt.Errorf("%q is not a project root, but %q is - is that what you want to remove?", arg, pr)
+				return errors.Errorf("%q is not a project root, but %q is - is that what you want to remove?", arg, pr)
 			}
 
 			/*
@@ -147,14 +146,14 @@ func (cmd *removeCommand) Run(ctx *dep.Ctx, args []string) error {
 			}
 
 			if _, indeps := p.Manifest.Dependencies[gps.ProjectRoot(arg)]; !indeps {
-				return fmt.Errorf("%q is not present in the manifest, cannot remove it", arg)
+				return errors.Errorf("%q is not present in the manifest, cannot remove it", arg)
 			}
 
 			if len(pkgimport) > 0 && !cmd.force {
 				if len(pkgimport) == 1 {
-					return fmt.Errorf("not removing %q because it is imported by %q (pass -force to override)", arg, pkgimport[0])
+					return errors.Errorf("not removing %q because it is imported by %q (pass -force to override)", arg, pkgimport[0])
 				}
-				return fmt.Errorf("not removing %q because it is imported by:\n\t%s (pass -force to override)", arg, strings.Join(pkgimport, "\n\t"))
+				return errors.Errorf("not removing %q because it is imported by:\n\t%s (pass -force to override)", arg, strings.Join(pkgimport, "\n\t"))
 			}
 
 			delete(p.Manifest.Dependencies, gps.ProjectRoot(arg))

--- a/cmd/dep/status.go
+++ b/cmd/dep/status.go
@@ -16,6 +16,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/golang/dep"
+	"github.com/pkg/errors"
 	"github.com/sdboyer/gps"
 )
 
@@ -166,7 +167,7 @@ func (cmd *statusCommand) Run(ctx *dep.Ctx, args []string) error {
 	var out outputter
 	switch {
 	case cmd.detailed:
-		return fmt.Errorf("not implemented")
+		return errors.Errorf("not implemented")
 	case cmd.json:
 		out = &jsonOutput{
 			w: os.Stdout,
@@ -205,7 +206,7 @@ func runStatusAll(out outputter, p *dep.Project, sm *gps.SourceMgr) error {
 	// code from the current project.
 	ptree, err := gps.ListPackages(p.AbsRoot, string(p.ImportRoot))
 	if err != nil {
-		return fmt.Errorf("analysis of local packages failed: %v", err)
+		return errors.Errorf("analysis of local packages failed: %v", err)
 	}
 
 	// Set up a solver in order to check the InputHash.
@@ -222,7 +223,7 @@ func runStatusAll(out outputter, p *dep.Project, sm *gps.SourceMgr) error {
 
 	s, err := gps.Prepare(params, sm)
 	if err != nil {
-		return fmt.Errorf("could not set up solver for input hashing: %s", err)
+		return errors.Errorf("could not set up solver for input hashing: %s", err)
 	}
 
 	cm := collectConstraints(ptree, p, sm)

--- a/context.go
+++ b/context.go
@@ -5,7 +5,6 @@
 package dep
 
 import (
-	"fmt"
 	"go/build"
 	"os"
 	"path/filepath"
@@ -86,7 +85,7 @@ func (c *Ctx) LoadProject(path string) (*Project, error) {
 	if err != nil {
 		if os.IsNotExist(err) {
 			// TODO: list possible solutions? (dep init, cd $project)
-			return nil, fmt.Errorf("no %v found in project root %v", ManifestName, p.AbsRoot)
+			return nil, errors.Errorf("no %v found in project root %v", ManifestName, p.AbsRoot)
 		}
 		// Unable to read the manifest file
 		return nil, err
@@ -95,7 +94,7 @@ func (c *Ctx) LoadProject(path string) (*Project, error) {
 
 	p.Manifest, err = readManifest(mf)
 	if err != nil {
-		return nil, fmt.Errorf("error while parsing %s: %s", mp, err)
+		return nil, errors.Errorf("error while parsing %s: %s", mp, err)
 	}
 
 	lp := filepath.Join(p.AbsRoot, LockName)
@@ -106,13 +105,13 @@ func (c *Ctx) LoadProject(path string) (*Project, error) {
 			return p, nil
 		}
 		// But if a lock does exist and we can't open it, that's a problem
-		return nil, fmt.Errorf("could not open %s: %s", lp, err)
+		return nil, errors.Errorf("could not open %s: %s", lp, err)
 	}
 	defer lf.Close()
 
 	p.Lock, err = readLock(lf)
 	if err != nil {
-		return nil, fmt.Errorf("error while parsing %s: %s", lp, err)
+		return nil, errors.Errorf("error while parsing %s: %s", lp, err)
 	}
 
 	return p, nil
@@ -131,7 +130,7 @@ func (c *Ctx) SplitAbsoluteProjectRoot(path string) (string, error) {
 		return filepath.ToSlash(path[len(srcprefix):]), nil
 	}
 
-	return "", fmt.Errorf("%s not in any $GOPATH", path)
+	return "", errors.Errorf("%s not in any $GOPATH", path)
 }
 
 // absoluteProjectRoot determines the absolute path to the project root
@@ -144,7 +143,7 @@ func (c *Ctx) absoluteProjectRoot(path string) (string, error) {
 		return "", errors.Wrapf(err, "checking if %s is a directory", posspath)
 	}
 	if !dirOK {
-		return "", fmt.Errorf("%s does not exist", posspath)
+		return "", errors.Errorf("%s does not exist", posspath)
 	}
 	return posspath, nil
 }
@@ -182,7 +181,7 @@ func (c *Ctx) VersionInWorkspace(root gps.ProjectRoot) (gps.Version, error) {
 			return gps.NewVersion(ver).Is(gps.Revision(rev)), nil
 		}
 
-		return nil, fmt.Errorf("version for root %s does not start with a v: %q", pr, ver)
+		return nil, errors.Errorf("version for root %s does not start with a v: %q", pr, ver)
 	}
 
 	// Look for the current branch.

--- a/lock.go
+++ b/lock.go
@@ -8,10 +8,10 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"io"
 	"sort"
 
+	"github.com/pkg/errors"
 	"github.com/sdboyer/gps"
 )
 
@@ -45,7 +45,7 @@ func readLock(r io.Reader) (*Lock, error) {
 
 	b, err := hex.DecodeString(rl.Memo)
 	if err != nil {
-		return nil, fmt.Errorf("invalid hash digest in lock's memo field")
+		return nil, errors.Errorf("invalid hash digest in lock's memo field")
 	}
 	l := &Lock{
 		Memo: b,
@@ -58,13 +58,13 @@ func readLock(r io.Reader) (*Lock, error) {
 		var v gps.Version = r
 		if ld.Version != "" {
 			if ld.Branch != "" {
-				return nil, fmt.Errorf("lock file specified both a branch (%s) and version (%s) for %s", ld.Branch, ld.Version, ld.Name)
+				return nil, errors.Errorf("lock file specified both a branch (%s) and version (%s) for %s", ld.Branch, ld.Version, ld.Name)
 			}
 			v = gps.NewVersion(ld.Version).Is(r)
 		} else if ld.Branch != "" {
 			v = gps.NewBranch(ld.Branch).Is(r)
 		} else if r == "" {
-			return nil, fmt.Errorf("lock file has entry for %s, but specifies no branch or version", ld.Name)
+			return nil, errors.Errorf("lock file has entry for %s, but specifies no branch or version", ld.Name)
 		}
 
 		id := gps.ProjectIdentifier{

--- a/manifest.go
+++ b/manifest.go
@@ -7,9 +7,9 @@ package dep
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io"
 
+	"github.com/pkg/errors"
 	"github.com/sdboyer/gps"
 )
 
@@ -82,12 +82,12 @@ func readManifest(r io.Reader) (*Manifest, error) {
 func toProps(n string, p possibleProps) (pp gps.ProjectProperties, err error) {
 	if p.Branch != "" {
 		if p.Version != "" || p.Revision != "" {
-			return pp, fmt.Errorf("multiple constraints specified for %s, can only specify one", n)
+			return pp, errors.Errorf("multiple constraints specified for %s, can only specify one", n)
 		}
 		pp.Constraint = gps.NewBranch(p.Branch)
 	} else if p.Version != "" {
 		if p.Revision != "" {
-			return pp, fmt.Errorf("multiple constraints specified for %s, can only specify one", n)
+			return pp, errors.Errorf("multiple constraints specified for %s, can only specify one", n)
 		}
 
 		// always semver if we can

--- a/project.go
+++ b/project.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/pkg/errors"
 	"github.com/sdboyer/gps"
 )
 
@@ -17,7 +18,7 @@ var errProjectNotFound = fmt.Errorf("could not find project %s, use dep init to 
 func findProjectRootFromWD() (string, error) {
 	path, err := os.Getwd()
 	if err != nil {
-		return "", fmt.Errorf("could not get working directory: %s", err)
+		return "", errors.Errorf("could not get working directory: %s", err)
 	}
 	return findProjectRoot(path)
 }

--- a/test_project_context_test.go
+++ b/test_project_context_test.go
@@ -62,7 +62,7 @@ func (pc *TestProjectContext) Load() {
 		mf := pc.h.GetFile(mp)
 		defer mf.Close()
 		m, err = readManifest(mf)
-		pc.h.Must(err)
+		pc.h.Must(errors.Wrapf(err, "Unable to read manifest at %s", mp))
 	}
 	var l *Lock
 	lp := pc.getLockPath()
@@ -70,7 +70,7 @@ func (pc *TestProjectContext) Load() {
 		lf := pc.h.GetFile(lp)
 		defer lf.Close()
 		l, err = readLock(lf)
-		pc.h.Must(err)
+		pc.h.Must(errors.Wrapf(err, "Unable to read lock at %s", lp))
 	}
 	pc.Project.Manifest = m
 	pc.Project.Lock = l

--- a/txn_writer.go
+++ b/txn_writer.go
@@ -210,7 +210,7 @@ func (payload SafeWriterPayload) validate(root string, sm gps.SourceManager) err
 		if err != nil {
 			return err
 		}
-		return fmt.Errorf("root path %q does not exist", root)
+		return errors.Errorf("root path %q does not exist", root)
 	}
 
 	if payload.HasVendor() && sm == nil {


### PR DESCRIPTION
Found another that snuck past my initial sweep for calls to `test.Helper.Must` without a stacktrace.