### PR TITLE
Use gps.SourceManager instead of *gps.SourceMgr in cmd/dep

### DIFF
--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -190,7 +190,7 @@ func applyUpdateArgs(args []string, params *gps.SolveParameters) {
 	}
 }
 
-func applyEnsureArgs(args []string, overrides stringSlice, p *dep.Project, sm *gps.SourceMgr, params *gps.SolveParameters) error {
+func applyEnsureArgs(args []string, overrides stringSlice, p *dep.Project, sm gps.SourceManager, params *gps.SolveParameters) error {
 	var errs []error
 	for _, arg := range args {
 		pc, err := getProjectConstraint(arg, sm)
@@ -263,7 +263,7 @@ func (s *stringSlice) Set(value string) error {
 	return nil
 }
 
-func getProjectConstraint(arg string, sm *gps.SourceMgr) (gps.ProjectConstraint, error) {
+func getProjectConstraint(arg string, sm gps.SourceManager) (gps.ProjectConstraint, error) {
 	constraint := gps.ProjectConstraint{
 		Constraint: gps.Any(), // default to any; avoids panics later
 	}

--- a/cmd/dep/init.go
+++ b/cmd/dep/init.go
@@ -274,14 +274,14 @@ type projectData struct {
 	ondisk       map[gps.ProjectRoot]gps.Version // projects that were found on disk
 }
 
-func getProjectData(ctx *dep.Ctx, pkgT pkgtree.PackageTree, cpr string, sm *gps.SourceMgr) (projectData, error) {
+func getProjectData(ctx *dep.Ctx, pkgT pkgtree.PackageTree, cpr string, sm gps.SourceManager) (projectData, error) {
 	constraints := make(gps.ProjectConstraints)
 	dependencies := make(map[gps.ProjectRoot][]string)
 	packages := make(map[string]bool)
 	notondisk := make(map[gps.ProjectRoot]bool)
 	ondisk := make(map[gps.ProjectRoot]gps.Version)
 
-	syncDep := func(pr gps.ProjectRoot, sm *gps.SourceMgr) {
+	syncDep := func(pr gps.ProjectRoot, sm gps.SourceManager) {
 		message := "Cached"
 		if err := sm.SyncSourceFor(gps.ProjectIdentifier{ProjectRoot: pr}); err != nil {
 			message = "Unable to cache"

--- a/cmd/dep/status.go
+++ b/cmd/dep/status.go
@@ -234,7 +234,7 @@ type MissingStatus struct {
 	MissingPackages []string
 }
 
-func runStatusAll(out outputter, p *dep.Project, sm *gps.SourceMgr) error {
+func runStatusAll(out outputter, p *dep.Project, sm gps.SourceManager) error {
 	if p.Lock == nil {
 		// TODO if we have no lock file, do...other stuff
 		return nil
@@ -435,7 +435,7 @@ func formatVersion(v gps.Version) string {
 	return v.String()
 }
 
-func collectConstraints(ptree pkgtree.PackageTree, p *dep.Project, sm *gps.SourceMgr) map[string][]gps.Constraint {
+func collectConstraints(ptree pkgtree.PackageTree, p *dep.Project, sm gps.SourceManager) map[string][]gps.Constraint {
 	// TODO
 	return map[string][]gps.Constraint{}
 }

--- a/gps/manager_test.go
+++ b/gps/manager_test.go
@@ -23,8 +23,8 @@ import (
 var bd string
 
 // An analyzer that passes nothing back, but doesn't error. This is the naive
-// case - no constraints, no lock, and no errors. The SourceMgr will interpret
-// this as open/Any constraints on everything in the import graph.
+// case - no constraints, no lock, and no errors. The SourceManager will
+// interpret this as open/Any constraints on everything in the import graph.
 type naiveAnalyzer struct{}
 
 func (naiveAnalyzer) DeriveManifestAndLock(string, ProjectRoot) (Manifest, Lock, error) {
@@ -544,7 +544,7 @@ func TestMultiFetchThreadsafe(t *testing.T) {
 		//mkPI("bitbucket.org/sdboyer/nobm"),
 	}
 
-	do := func(name string, sm *SourceMgr) {
+	do := func(name string, sm SourceManager) {
 		t.Run(name, func(t *testing.T) {
 			// This gives us ten calls per op, per project, which should be(?)
 			// decently likely to reveal underlying concurrency problems

--- a/test_project_context_test.go
+++ b/test_project_context_test.go
@@ -20,7 +20,7 @@ type TestProjectContext struct {
 
 	Context       *Ctx
 	Project       *Project
-	SourceManager *gps.SourceMgr
+	SourceManager gps.SourceManager
 }
 
 // NewTestProjectContext creates a new on-disk test project


### PR DESCRIPTION
This is a refactor that shouldn't change behavior. It just gets `package main` to use interfaces instead of concrete implementations for `SourceManager`.

The idea here is to make it easier to write tests that mock the source manager's behavior. I have some tests of the status command I'd like to write to get it to support the `required` field.