### PR TITLE
Handle overlapping GOPATHs properly in NewContext

### DIFF
--- a/context.go
+++ b/context.go
@@ -34,11 +34,13 @@ func NewContext() (*Ctx, error) {
 	wd = filepath.FromSlash(wd)
 	ctx := &Ctx{}
 
+	gopathFound := false
 	for _, gp := range filepath.SplitList(buildContext.GOPATH) {
 		gp = filepath.FromSlash(gp)
 
-		if filepath.HasPrefix(wd, gp) {
+		if !gopathFound && filepath.HasPrefix(wd, gp) {
 			ctx.GOPATH = gp
+			gopathFound = true
 		}
 
 		ctx.GOPATHS = append(ctx.GOPATHS, gp)

--- a/context_test.go
+++ b/context_test.go
@@ -5,11 +5,13 @@
 package dep
 
 import (
+	"go/build"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+	"fmt"
 	"unicode"
 
 	"github.com/golang/dep/test"
@@ -30,6 +32,26 @@ func TestNewContextNoGOPATH(t *testing.T) {
 
 	if c != nil {
 		t.Fatalf("expected context to be nil, got: %#v", c)
+	}
+}
+
+func TestMultipleGopaths(t *testing.T) {
+	h := test.NewHelper(t)
+	defer h.Cleanup()
+
+	gp1 := "go/foo_new"
+	gp2 := "go/foo"
+
+	project := filepath.Join(gp1, "src/bar")
+	h.TempDir(project)
+	h.TempDir(gp2)
+	h.Cd(h.Path(project))
+
+	build.Default.GOPATH = fmt.Sprintf("%s:%s", h.Path(gp1), h.Path(gp2))
+	c, err := NewContext()
+	h.Must(err)
+	if c.GOPATH != h.Path(gp1) {
+		t.Fatalf("Incorrect GOPATH detected. Expected '%s', got '%s'", h.Path(gp1), c.GOPATH)
 	}
 }
 


### PR DESCRIPTION
If there are overlapping GOPATH's specified,
NewContext should pick up first match.

Otherwise this can lead to a situation where
NewContext will set GOPATH variable to the wrong
GOPATH.

Example:
GOPATH="/tmp/foo_new:/tmp/foo"
PWD="/tmp/foo_new/src/bar"

GOPATH for this project should be "/tmp/foo_new",
but before this commit it was accdentally set to
"/tmp/foo", because of the prefix match.