### PR TITLE
Set a ProjectAnalyzer when solving for dep status

### DIFF
--- a/cmd/dep/integration_test.go
+++ b/cmd/dep/integration_test.go
@@ -53,7 +53,10 @@ func TestIntegration(t *testing.T) {
 				// Run commands
 				testProj.RecordImportPaths()
 				for _, args := range testCase.Commands {
-					testProj.DoRun(args)
+					err = testProj.DoRun(args)
+					if err != nil {
+						t.Fatalf("%v", err)
+					}
 				}
 
 				// Check final manifest and lock

--- a/cmd/dep/status.go
+++ b/cmd/dep/status.go
@@ -249,6 +249,7 @@ func runStatusAll(out outputter, p *dep.Project, sm *gps.SourceMgr) error {
 
 	// Set up a solver in order to check the InputHash.
 	params := gps.SolveParameters{
+		ProjectAnalyzer: dep.Analyzer{},
 		RootDir:         p.AbsRoot,
 		RootPackageTree: ptree,
 		Manifest:        p.Manifest,

--- a/cmd/dep/testdata/harness_tests/ensure/update/case1/testcase.json
+++ b/cmd/dep/testdata/harness_tests/ensure/update/case1/testcase.json
@@ -1,6 +1,5 @@
 {
   "commands": [
-    ["init"],
     ["ensure", "-update", "github.com/sdboyer/deptest"]
   ],
   "vendor-final": [

--- a/cmd/dep/testdata/harness_tests/ensure/update/case2/testcase.json
+++ b/cmd/dep/testdata/harness_tests/ensure/update/case2/testcase.json
@@ -1,6 +1,5 @@
 {
   "commands": [
-    ["init"],
     ["ensure", "-n", "-update", "github.com/sdboyer/deptest"]
   ],
   "vendor-final": []

--- a/cmd/dep/testdata/harness_tests/status/case1/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/status/case1/final/Gopkg.lock
@@ -1,0 +1,13 @@
+memo = "88d2718cda70cce45158f953d2c6ead79c1db38e67e9704aff72be8fddb096e7"
+
+[[projects]]
+  name = "github.com/sdboyer/deptest"
+  packages = ["."]
+  revision = "ff2948a2ac8f538c4ecd55962e919d1e13e74baf"
+  version = "v0.8.0"
+
+[[projects]]
+  name = "github.com/sdboyer/deptestdos"
+  packages = ["."]
+  revision = "5c607206be5decd28e6263ffffdcee067266015e"
+  version = "v2.0.0"

--- a/cmd/dep/testdata/harness_tests/status/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/status/case1/final/Gopkg.toml
@@ -1,0 +1,4 @@
+
+[[dependencies]]
+  name = "github.com/sdboyer/deptest"
+  version = ">=0.8.0, <1.0.0"

--- a/cmd/dep/testdata/harness_tests/status/case1/initial/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/status/case1/initial/Gopkg.lock
@@ -1,0 +1,13 @@
+memo = "9a5243dd3fa20feeaa20398e7283d6c566532e2af1aae279a010df34793761c5"
+
+[[projects]]
+  name = "github.com/sdboyer/deptest"
+  version = "v0.8.0"
+  revision = "ff2948a2ac8f538c4ecd55962e919d1e13e74baf"
+  packages = ["."]
+            
+[[projects]]
+  name = "github.com/sdboyer/deptestdos"
+  version = "v2.0.0"
+  revision = "5c607206be5decd28e6263ffffdcee067266015e"
+  packages = ["."]

--- a/cmd/dep/testdata/harness_tests/status/case1/initial/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/status/case1/initial/Gopkg.toml
@@ -1,0 +1,3 @@
+[[dependencies]]
+  name = "github.com/sdboyer/deptest"
+  version = "^0.8.0"

--- a/cmd/dep/testdata/harness_tests/status/case1/initial/main.go
+++ b/cmd/dep/testdata/harness_tests/status/case1/initial/main.go
@@ -1,0 +1,18 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"github.com/sdboyer/deptest"
+	"github.com/sdboyer/deptestdos"
+)
+
+func main() {
+	err := nil
+	if err != nil {
+		deptest.Map["yo yo!"]
+	}
+	deptestdos.diMeLo("whatev")
+}

--- a/cmd/dep/testdata/harness_tests/status/case1/testcase.json
+++ b/cmd/dep/testdata/harness_tests/status/case1/testcase.json
@@ -1,0 +1,10 @@
+{
+  "commands": [
+    ["ensure"],
+    ["status"]
+  ],
+  "vendor-final": [
+    "github.com/sdboyer/deptest",
+    "github.com/sdboyer/deptestdos"
+  ]
+}

--- a/test/test.go
+++ b/test/test.go
@@ -187,7 +187,7 @@ func (h *Helper) DoRun(args []string) error {
 		}
 	}
 	h.ran = true
-	return status
+	return errors.Wrapf(status, "Error running %s\n%s", strings.Join(newargs, " "), h.stderr.String())
 }
 
 // run runs the test go command, and expects it to succeed.


### PR DESCRIPTION
* Fixes #384 which was introduced when we bumped gps to v0.16.
* Adds integration test for `dep status`
* Fixes problem with test harness where the test would pass when one of the commands fails. Which found some other tests that were actually failing, so I fixed those too. This is in this PR because without it, the "failing" test I added for status incorrectly passes. 😄 

Let me know if this needs to be split into 2 PRs.