### PR TITLE
Scrub clean in staticcheck. Add staticcheck to .travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,31 @@
 ---
-  language: go
-  sudo: false
-  notifications:
-    email: false
-  matrix:
-    include:
-      - os: linux
-        go: 1.7.x
-      - os: linux
-        go: 1.8.x
-      - os: linux
-        go: tip
-      - os: osx
-        go: 1.8.x
-  install:
-    - echo "This is an override of the default install deps step in travis."
-  script:
-    - go build -v ./cmd/dep
-    - go vet $(go list ./... | grep -v vendor)
-    - test -z "$(gofmt -s -l . 2>&1 | grep -v vendor | tee /dev/stderr)"
-    - go test -race $(go list ./... | grep -v vendor)
-    - go build ./hack/licenseok
-    - find . -path ./vendor -prune -o -type f -name "*.go" -printf '%P\n' | xargs ./licenseok
-    - ./hack/validate-vendor.bash
+language: go
+sudo: false
+notifications:
+  email: false
+matrix:
+  include:
+    - os: linux
+      go: 1.7.x
+    - os: linux
+      go: 1.8.x
+    - os: linux
+      go: tip
+    - os: osx
+      go: 1.8.x
+install:
+  - echo "This is an override of the default install deps step in travis."
+before_script:
+  - PKGS=$(go list ./... | grep -v /vendor/)
+  - go get -v honnef.co/go/tools/cmd/staticcheck
+script:
+  - go build -v ./cmd/dep
+  - go vet $PKGS
+  # Ignore the deprecation warning about filepath.HasPrefix (SA1019). This flag
+  # can be removed when issue #296 is resolved.
+  - staticcheck -ignore='github.com/golang/dep/context.go:SA1019 github.com/golang/dep/cmd/dep/init.go:SA1019' $PKGS
+  - test -z "$(gofmt -s -l . 2>&1 | grep -v vendor/ | tee /dev/stderr)"
+  - go test -race $PKGS
+  - go build ./hack/licenseok
+  - find . -path ./vendor -prune -o -type f -name "*.go" -printf '%P\n' | xargs ./licenseok
+  - ./hack/validate-vendor.bash

--- a/test/integration_testcase.go
+++ b/test/integration_testcase.go
@@ -78,6 +78,9 @@ func (tc *IntegrationTestCase) Cleanup() {
 		j = bytes.Replace(j, cmds, n, -1)
 		j = append(j, '\n')
 		err = ioutil.WriteFile(filepath.Join(tc.rootPath, "testcase.json"), j, 0666)
+		if err != nil {
+			tc.t.Errorf("Failed to update testcase %s: %s", tc.name, err)
+		}
 	}
 }
 

--- a/txn_writer.go
+++ b/txn_writer.go
@@ -464,8 +464,8 @@ func diffLocks(l1 gps.Lock, l2 gps.Lock) *LockDiff {
 				diff.Add = append(diff.Add, add)
 				i2next = i2 + 1 // Don't evaluate to this again
 				continue        // Keep looking for a matching project
-			case +1: // Project has been removed, handled below
-				break
+			case +1:
+				// Project has been removed, handled below
 			}
 
 			break // Done evaluating this project, move onto the next


### PR DESCRIPTION
[`staticcheck`](https://github.com/dominikh/go-tools/tree/master/cmd/staticcheck) is an awesome static analyzer that's described by the author as "`go vet` on steroids". IMHO it should be a part of every Go project. It's like having an extra full-time bug-finding engineer on the team. [The list of bugs it can catch is quite extensive](https://github.com/dominikh/go-tools/tree/master/cmd/staticcheck#checks).

The good news is: `staticcheck` didn't find any serious bugs in `dep`. :tada: Well done, guys! Nice coding 😄

The minor issues it did find are...
1. a missing `err` check
1. use of [a deprecated stdlib func](https://codereview.appspot.com/5712045)
1. an ineffective, but innocent `break` statement that was intended as a no-op

These are small issues, but I think there's a clear benefit in catching _future_ bugs before they're merged.