### PR TITLE
Use LockDiff from gps

### DIFF
--- a/lock.go
+++ b/lock.go
@@ -113,7 +113,7 @@ func (l *Lock) toRaw() rawLock {
 		}
 
 		v := lp.Version()
-		ld.Revision, ld.Branch, ld.Version = getVersionInfo(v)
+		ld.Revision, ld.Branch, ld.Version = gps.VersionComponentStrings(v)
 
 		raw.Projects[k] = ld
 	}
@@ -127,29 +127,6 @@ func (l *Lock) MarshalTOML() ([]byte, error) {
 	raw := l.toRaw()
 	result, err := toml.Marshal(raw)
 	return result, errors.Wrap(err, "Unable to marshal lock to TOML string")
-}
-
-// TODO(carolynvs) this should be moved to gps
-func getVersionInfo(v gps.Version) (revision string, branch string, version string) {
-	// Figure out how to get the underlying revision
-	switch tv := v.(type) {
-	case gps.UnpairedVersion:
-	// TODO we could error here, if we want to be very defensive about not
-	// allowing a lock to be written if without an immmutable revision
-	case gps.Revision:
-		revision = tv.String()
-	case gps.PairedVersion:
-		revision = tv.Underlying().String()
-	}
-
-	switch v.Type() {
-	case gps.IsBranch:
-		branch = v.String()
-	case gps.IsSemver, gps.IsVersion:
-		version = v.String()
-	}
-
-	return
 }
 
 // LockFromInterface converts an arbitrary gps.Lock to dep's representation of a

--- a/txn_writer_test.go
+++ b/txn_writer_test.go
@@ -514,42 +514,8 @@ func TestSafeWriter_DiffLocks(t *testing.T) {
 	if diff == nil {
 		t.Fatal("Expected the payload to contain a diff of the lock files")
 	}
-	if diff.HashDiff == nil {
-		t.Fatalf("Expected the lock diff to contain the updated hash: expected %s, got %s", pc.Project.Lock.Memo, updatedLock.Memo)
-	}
 
-	if len(diff.Add) != 2 {
-		t.Fatalf("Expected the lock diff to contain 2 added projects, got %d", len(diff.Add))
-	} else {
-		add1 := diff.Add[0]
-		if add1.Name != "github.com/sdboyer/deptest" {
-			t.Errorf("expected new project[0] github.com/sdboyer/deptest, got %s", add1.Name)
-		}
-		add2 := diff.Add[1]
-		if add2.Name != "github.com/stuff/realthing" {
-			t.Errorf("expected new project[1] github.com/stuff/realthing, got %s", add2.Name)
-		}
-	}
-
-	if len(diff.Remove) != 1 {
-		t.Fatalf("Expected the lock diff to contain 1 removed project, got %d", len(diff.Remove))
-	} else {
-		remove := diff.Remove[0]
-		if remove.Name != "github.com/stuff/placeholder" {
-			t.Fatalf("expected new project github.com/stuff/placeholder, got %s", remove.Name)
-		}
-	}
-
-	if len(diff.Modify) != 1 {
-		t.Fatalf("Expected the lock diff to contain 1 modified project, got %d", len(diff.Modify))
-	} else {
-		modify := diff.Modify[0]
-		if modify.Name != "github.com/foo/bar" {
-			t.Fatalf("expected new project github.com/foo/bar, got %s", modify.Name)
-		}
-	}
-
-	output, err := diff.Format()
+	output, err := formatLockDiff(*diff)
 	h.Must(err)
 	goldenOutput := "txn_writer/expected_diff_output.txt"
 	if err = pc.ShouldMatchGolden(goldenOutput, output); err != nil {


### PR DESCRIPTION
I've updated dep to use LockDiff from gps. I've also simplified the LockDiff test in dep to only focus on formatting the diff, now that the diff implementation lives in gps and deploy only implements formatting.

Fixes #312 