### PR TITLE
Add test case for ignored packages

### DIFF
--- a/cmd/dep/testdata/harness_tests/ensure/empty/case3/README.md
+++ b/cmd/dep/testdata/harness_tests/ensure/empty/case3/README.md
@@ -1,0 +1,2 @@
+Validate that packages imported in an ignored package are not
+included in the manifest or lock.

--- a/cmd/dep/testdata/harness_tests/ensure/empty/case3/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/ensure/empty/case3/final/Gopkg.lock
@@ -1,0 +1,7 @@
+memo = "e5c16e09ed6f0a1a2b3cf472c34b7fd50861dd070e81d5e623f72e8173f0c065"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/sdboyer/deptest"
+  packages = ["."]
+  revision = "3f4c3bea144e112a69bbe5d8d01c1b09a544253f"

--- a/cmd/dep/testdata/harness_tests/ensure/empty/case3/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/ensure/empty/case3/final/Gopkg.toml
@@ -1,0 +1,5 @@
+ignored = ["github.com/sdboyer/deptestdos"]
+
+[[dependencies]]
+  branch = "master"
+  name = "github.com/sdboyer/deptest"

--- a/cmd/dep/testdata/harness_tests/ensure/empty/case3/initial/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/ensure/empty/case3/initial/Gopkg.lock
@@ -1,0 +1,7 @@
+memo = "e5c16e09ed6f0a1a2b3cf472c34b7fd50861dd070e81d5e623f72e8173f0c065"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/sdboyer/deptest"
+  packages = ["."]
+  revision = "3f4c3bea144e112a69bbe5d8d01c1b09a544253f"

--- a/cmd/dep/testdata/harness_tests/ensure/empty/case3/initial/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/ensure/empty/case3/initial/Gopkg.toml
@@ -1,0 +1,5 @@
+ignored = ["github.com/sdboyer/deptestdos"]
+
+[[dependencies]]
+  branch = "master"
+  name = "github.com/sdboyer/deptest"

--- a/cmd/dep/testdata/harness_tests/ensure/empty/case3/initial/main.go
+++ b/cmd/dep/testdata/harness_tests/ensure/empty/case3/initial/main.go
@@ -1,0 +1,12 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	_ "github.com/sdboyer/deptest"
+)
+
+func main() {
+}

--- a/cmd/dep/testdata/harness_tests/ensure/empty/case3/initial/samples/samples.go
+++ b/cmd/dep/testdata/harness_tests/ensure/empty/case3/initial/samples/samples.go
@@ -1,0 +1,7 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package samples
+
+import _ "github.com/sdboyer/deptestdos"

--- a/cmd/dep/testdata/harness_tests/ensure/empty/case3/testcase.json
+++ b/cmd/dep/testdata/harness_tests/ensure/empty/case3/testcase.json
@@ -1,0 +1,8 @@
+{
+  "commands": [
+    ["ensure"]
+  ],
+  "vendor-final": [
+    "github.com/sdboyer/deptest"
+  ]
+}


### PR DESCRIPTION
Validate that packages imported in an ignored package are not included in the manifest or lock.