### PR TITLE
cmd/dep: clarify ensure help text

### DIFF
--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -26,7 +26,7 @@ const ensureLongHelp = `
 Ensure is used to fetch project dependencies into the vendor folder, as well as
 to set version constraints for specific dependencies. It takes user input,
 solves the updated dependency graph of the project, writes any changes to the
-manifest and lock file, and places dependencies in the vendor folder.
+lock file, and places dependencies in the vendor folder.
 
 Package spec:
 


### PR DESCRIPTION
A very tiny (but important) update to the help text: `ensure` no longer modifies the manifest file.
