### PR TITLE
Add gosimple linter to .travis.yml. Fix new staticcheck issue.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,14 @@ install:
   - echo "This is an override of the default install deps step in travis."
 before_script:
   - PKGS=$(go list ./... | grep -v /vendor/)
-  - go get -v honnef.co/go/tools/cmd/staticcheck
+  - go get -v honnef.co/go/tools/cmd/{gosimple,staticcheck}
 script:
   - go build -v ./cmd/dep
   - go vet $PKGS
   # Ignore the deprecation warning about filepath.HasPrefix (SA1019). This flag
   # can be removed when issue #296 is resolved.
   - staticcheck -ignore='github.com/golang/dep/context.go:SA1019 github.com/golang/dep/cmd/dep/init.go:SA1019' $PKGS
+  - gosimple $PKGS
   - test -z "$(gofmt -s -l . 2>&1 | grep -v vendor/ | tee /dev/stderr)"
   - go test -race $PKGS
   - go build ./hack/licenseok

--- a/cmd/dep/status.go
+++ b/cmd/dep/status.go
@@ -367,7 +367,7 @@ func runStatusAll(out outputter, p *dep.Project, sm *gps.SourceMgr) error {
 	rm, _ := ptree.ToReachMap(true, true, false, nil)
 
 	external := rm.Flatten(false)
-	roots := make(map[gps.ProjectRoot][]string)
+	roots := make(map[gps.ProjectRoot][]string, len(external))
 
 	type fail struct {
 		ex  string
@@ -389,7 +389,7 @@ func runStatusAll(out outputter, p *dep.Project, sm *gps.SourceMgr) error {
 
 	if len(errs) != 0 {
 		// TODO this is just a fix quick so staticcheck doesn't complain.
-		// Visually ceconciling failure to deduce project roots with the rest of
+		// Visually reconciling failure to deduce project roots with the rest of
 		// the mismatch output is a larger problem.
 		fmt.Fprintf(os.Stderr, "Failed to deduce project roots for import paths:\n")
 		for _, fail := range errs {

--- a/test/integration_testproj.go
+++ b/test/integration_testproj.go
@@ -150,8 +150,7 @@ func (p *IntegrationTestProject) DoRun(args []string) error {
 	if *PrintLogs {
 		p.t.Logf("running testdep %v", args)
 	}
-	var prog string
-	prog = filepath.Join(p.origWd, "testdep"+ExeSuffix)
+	prog := filepath.Join(p.origWd, "testdep"+ExeSuffix)
 	newargs := []string{args[0], "-v"}
 	newargs = append(newargs, args[1:]...)
 	cmd := exec.Command(prog, newargs...)


### PR DESCRIPTION
[`gosimple`](https://github.com/dominikh/go-tools/tree/master/cmd/gosimple) is a neat little code linter from the author of [`staticcheck`](https://github.com/dominikh/go-tools/tree/master/cmd/staticcheck). It catches code quality issues like the following:
```go
// should be if boolVar
if boolVar == true {}

// should be time.Since(x)               
time.Now().Sub(x)

// should be return err                        
if err != nil {
    return err
}
return nil 
```
[The full list of checks is available here](https://github.com/dominikh/go-tools/tree/master/cmd/gosimple#checks).

It only found one issue, which is _very_ good for a project this size. Kudos to all the contributors! 💯