### PR TITLE
Move logging functions into internal package

### DIFF
--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/golang/dep"
+	"github.com/golang/dep/internal"
 	"github.com/pkg/errors"
 	"github.com/sdboyer/gps"
 	"github.com/sdboyer/gps/pkgtree"
@@ -205,7 +206,7 @@ func applyEnsureArgs(args []string, overrides stringSlice, p *dep.Project, sm *g
 			// TODO(sdboyer): for this case - or just in general - do we want to
 			// add project args to the requires list temporarily for this run?
 			if _, has := p.Manifest.Dependencies[pc.Ident.ProjectRoot]; !has {
-				logf("No constraint or alternate source specified for %q, omitting from manifest", pc.Ident.ProjectRoot)
+				internal.Logf("No constraint or alternate source specified for %q, omitting from manifest", pc.Ident.ProjectRoot)
 			}
 			// If it's already in the manifest, no need to log
 			continue

--- a/cmd/dep/main.go
+++ b/cmd/dep/main.go
@@ -14,6 +14,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/golang/dep"
+	"github.com/golang/dep/internal"
 )
 
 var (
@@ -114,6 +115,8 @@ func main() {
 				os.Exit(1)
 			}
 
+			internal.Verbose = *verbose
+
 			// Set up the dep context.
 			ctx, err := dep.NewContext()
 			if err != nil {
@@ -167,7 +170,7 @@ func resetUsage(fs *flag.FlagSet, name, args, longHelp string) {
 	}
 }
 
-// parseArgs determines the name of the dep command and wether the user asked for
+// parseArgs determines the name of the dep command and whether the user asked for
 // help to be printed.
 func parseArgs(args []string) (cmdName string, printCmdUsage bool, exit bool) {
 	isHelpArg := func() bool {
@@ -191,16 +194,4 @@ func parseArgs(args []string) (cmdName string, printCmdUsage bool, exit bool) {
 		}
 	}
 	return cmdName, printCmdUsage, exit
-}
-
-func logf(format string, args ...interface{}) {
-	// TODO: something else?
-	fmt.Fprintf(os.Stderr, "dep: "+format+"\n", args...)
-}
-
-func vlogf(format string, args ...interface{}) {
-	if !*verbose {
-		return
-	}
-	logf(format, args...)
 }

--- a/cmd/dep/remove.go
+++ b/cmd/dep/remove.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/golang/dep"
+	"github.com/golang/dep/internal"
 	"github.com/pkg/errors"
 	"github.com/sdboyer/gps"
 	"github.com/sdboyer/gps/pkgtree"
@@ -91,7 +92,7 @@ func (cmd *removeCommand) Run(ctx *dep.Ctx, args []string) error {
 				// not being able to detect the root for an import path that's
 				// actually in the import list is a deeper problem. However,
 				// it's not our direct concern here, so we just warn.
-				logf("could not infer root for %q", pr)
+				internal.Logf("could not infer root for %q", pr)
 				continue
 			}
 			otherroots[pr] = true
@@ -106,7 +107,7 @@ func (cmd *removeCommand) Run(ctx *dep.Ctx, args []string) error {
 		}
 
 		if len(rm) == 0 {
-			logf("nothing to do")
+			internal.Logf("nothing to do")
 			return nil
 		}
 	} else {

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -1,0 +1,25 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package internal
+
+import (
+	"fmt"
+	"os"
+)
+
+// Verbose specifies if verbose logging is enabled.
+var Verbose bool
+
+func Logf(format string, args ...interface{}) {
+	// TODO: something else?
+	fmt.Fprintf(os.Stderr, "dep: "+format+"\n", args...)
+}
+
+func Vlogf(format string, args ...interface{}) {
+	if !Verbose {
+		return
+	}
+	Logf(format, args...)
+}


### PR DESCRIPTION
This lets other internal packages, like [glide import](https://github.com/golang/dep/issues/380#issuecomment-296344734), write verbose messages for debugging.