### PR TITLE
Expand example Gopkg.toml text; always add on init

### DIFF
--- a/cmd/dep/testdata/harness_tests/ensure/empty/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/ensure/empty/case1/final/Gopkg.toml
@@ -1,27 +1,24 @@
 
-## EXAMPLE (these lines may be deleted)
-#
+## Gopkg.toml example (these lines may be deleted)
+
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
 ## project. Use it when your project needs a package it doesn't explicitly import -
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
-#
-#
+
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
-#
-#
-# [[dependencies]]
+
 ## Dependencies define constraints on dependent projects. They are respected by
 ## dep whether coming from the Gopkg.toml of the current project or a dependency.
-#
+# [[dependencies]]
 ## Required: the root import path of the project being constrained.
 # name = "github.com/user/project"
 #
-## Optional, but recommended: the version constraint to enforce for the project.
+## Recommended: the version constraint to enforce for the project.
 ## Only one of "branch", "version" or "revision" can be specified.
 # version = "1.0.0"
 # branch = "master"
@@ -29,15 +26,13 @@
 #
 ## Optional: an alternate location (URL or import path) for the project's source.
 # source = "https://github.com/myfork/package.git"
-#
-#
-# [[overrides]]
+
 ## Overrides have the same structure as [[dependencies]], but supercede all
 ## [[dependencies]] declarations from all projects. Only the current project's
 ## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer. Use them only as a last resort.
-#
+# [[overrides]]
 ## Required: the root import path of the project being constrained.
 # name = "github.com/user/project"
 #

--- a/cmd/dep/testdata/harness_tests/ensure/empty/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/ensure/empty/case1/final/Gopkg.toml
@@ -1,27 +1,5 @@
 
-## EXAMPLES & DOCS - safe to delete!
-#
-## Dependencies define constraints on how dependent projects should be
-## incorporated into Gopkg.lock. They are respected by dep whether
-## this project is the current project, or if it's a dependency.
-# [[dependencies]]
-## Required: the root import path of the project being constrained
-# name = "github.com/user/project"
-## Optional: an alternate location (URL or import path) for the project's source
-# source = "https://github.com/myfork/package.git"
-## Optional, but recommended: the version constraint to enforce for the project.
-## Only one of "branch", "version" or "revision" can be specified.
-# version = "1.0.0"
-# branch = "master"
-## Note: revision will depend on your repository type; git and hg have SHA1s,
-## bzr a 3-part id, svn a revision number.
-# revision = "abc123"
-#
-## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
-## all [[dependencies]] declarations from all projects. Only the current project's
-## [[overrides]] are applied.
-##
-## Overrides are a sledgehammer, and should be used only as a last resort.
+## EXAMPLE (these lines may be deleted)
 #
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
@@ -29,9 +7,51 @@
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
 #
+#
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
+#
+#
+# [[dependencies]]
+## Dependencies define constraints on dependent projects. They are respected by
+## dep whether coming from the Gopkg.toml of the current project or a dependency.
+#
+## Required: the root import path of the project being constrained.
+# name = "github.com/user/project"
+#
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+# revision = "abc123"
+#
+## Optional: an alternate location (URL or import path) for the project's source.
+# source = "https://github.com/myfork/package.git"
+#
+#
+# [[overrides]]
+## Overrides have the same structure as [[dependencies]], but supercede all
+## [[dependencies]] declarations from all projects. Only the current project's
+## [[overrides]] are applied.
+##
+## Overrides are a sledgehammer. Use them only as a last resort.
+#
+## Required: the root import path of the project being constrained.
+# name = "github.com/user/project"
+#
+## Optional: specifying a version constraint override will cause all other
+## constraints on this project to be ignored; only the overriden constraint
+## need be satisfied.
+## Again, only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+# revision = "abc123"
+#
+## Optional: specifying an alternate source location as an override will
+## enforce that the alternate location is used for that project, regardless of
+## what source location any dependent projects specify.
+# source = "https://github.com/myfork/package.git"
 
 

--- a/cmd/dep/testdata/harness_tests/ensure/empty/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/ensure/empty/case1/final/Gopkg.toml
@@ -1,4 +1,7 @@
 
+
+## EXAMPLES & DOCS - safe to delete!
+
 ## Dependencies define constraints on how dependent projects should be
 ## incorporated into Gopkg.lock. They are respected by dep whether
 ## this project is the current project, or if it's a dependency.
@@ -15,27 +18,16 @@
 ## bzr a 3-part id, svn a revision number.
 # revision = "abc123"
 
-## Overrides have the same structure as [[dependencies]], but supercede all
-## [[dependencies]] declarations from all projects. However, only the current
-## project's overrides will apply.
+## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
+## all [[dependencies]] declarations from all projects. Only the current project's
+## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer, and should be used only as a last resort.
-# [[overrides]]
-## Required: the root import path of the project being constrained
-# name = "github.com/user/project"
-## Optional: an alternate location (URL or import path) for the project's source
-# source = "https://github.com/myfork/package.git"
-## Optional, but recommended: the version constraint to enforce for the project.
-## Only one of "branch", "version" or "revision" can be specified.
-# version = "1.0.0"
-# branch = "master"
-## Note: revision will depend on your repository type; git and hg have SHA1s,
-## bzr a 3-part id, svn a revision number.
-# revision = "abc123"
 
 ## "required" lists a set of packages (not projects) that must be included in
-## Gopkg.lock. This has the same effect as directly importing a package, but
-## can be used to require "main" packages.
+## Gopkg.lock. This list is merged with the set of packages imported by the current
+## project. Use it when your project needs a package it doesn't explicitly import -
+## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
 
 ## "ignored" lists a set of packages (not projects) that are ignored when

--- a/cmd/dep/testdata/harness_tests/ensure/empty/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/ensure/empty/case1/final/Gopkg.toml
@@ -1,9 +1,44 @@
 
-# Example:
+## Dependencies define constraints on how dependent projects should be
+## incorporated into Gopkg.lock. They are respected by dep whether
+## this project is the current project, or if it's a dependency.
 # [[dependencies]]
+## Required: the root import path of the project being constrained
+# name = "github.com/user/project"
+## Optional: an alternate location (URL or import path) for the project's source
 # source = "https://github.com/myfork/package.git"
-# branch = "master"
-# name = "github.com/vendor/package"
-# Note: revision will depend on your repository type, i.e git, svc, bzr etc...
-# revision = "abc123"
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
 # version = "1.0.0"
+# branch = "master"
+## Note: revision will depend on your repository type; git and hg have SHA1s,
+## bzr a 3-part id, svn a revision number.
+# revision = "abc123"
+
+## Overrides have the same structure as [[dependencies]], but supercede all
+## [[dependencies]] declarations from all projects. However, only the current
+## project's overrides will apply.
+##
+## Overrides are a sledgehammer, and should be used only as a last resort.
+# [[overrides]]
+## Required: the root import path of the project being constrained
+# name = "github.com/user/project"
+## Optional: an alternate location (URL or import path) for the project's source
+# source = "https://github.com/myfork/package.git"
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+## Note: revision will depend on your repository type; git and hg have SHA1s,
+## bzr a 3-part id, svn a revision number.
+# revision = "abc123"
+
+## "required" lists a set of packages (not projects) that must be included in
+## Gopkg.lock. This has the same effect as directly importing a package, but
+## can be used to require "main" packages.
+# required = ["github.com/user/thing/cmd/thing"]
+
+## "ignored" lists a set of packages (not projects) that are ignored when
+## dep statically analyzes source code. Ignored packages can be in this project,
+## or in a dependency.
+# ignored = ["github.com/user/project/badpkg"]

--- a/cmd/dep/testdata/harness_tests/ensure/empty/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/ensure/empty/case1/final/Gopkg.toml
@@ -1,7 +1,6 @@
 
-
 ## EXAMPLES & DOCS - safe to delete!
-
+#
 ## Dependencies define constraints on how dependent projects should be
 ## incorporated into Gopkg.lock. They are respected by dep whether
 ## this project is the current project, or if it's a dependency.
@@ -17,20 +16,22 @@
 ## Note: revision will depend on your repository type; git and hg have SHA1s,
 ## bzr a 3-part id, svn a revision number.
 # revision = "abc123"
-
+#
 ## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
 ## all [[dependencies]] declarations from all projects. Only the current project's
 ## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer, and should be used only as a last resort.
-
+#
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
 ## project. Use it when your project needs a package it doesn't explicitly import -
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
-
+#
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
+
+

--- a/cmd/dep/testdata/harness_tests/ensure/empty/case2/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/ensure/empty/case2/final/Gopkg.toml
@@ -1,27 +1,24 @@
 
-## EXAMPLE (these lines may be deleted)
-#
+## Gopkg.toml example (these lines may be deleted)
+
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
 ## project. Use it when your project needs a package it doesn't explicitly import -
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
-#
-#
+
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
-#
-#
-# [[dependencies]]
+
 ## Dependencies define constraints on dependent projects. They are respected by
 ## dep whether coming from the Gopkg.toml of the current project or a dependency.
-#
+# [[dependencies]]
 ## Required: the root import path of the project being constrained.
 # name = "github.com/user/project"
 #
-## Optional, but recommended: the version constraint to enforce for the project.
+## Recommended: the version constraint to enforce for the project.
 ## Only one of "branch", "version" or "revision" can be specified.
 # version = "1.0.0"
 # branch = "master"
@@ -29,15 +26,13 @@
 #
 ## Optional: an alternate location (URL or import path) for the project's source.
 # source = "https://github.com/myfork/package.git"
-#
-#
-# [[overrides]]
+
 ## Overrides have the same structure as [[dependencies]], but supercede all
 ## [[dependencies]] declarations from all projects. Only the current project's
 ## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer. Use them only as a last resort.
-#
+# [[overrides]]
 ## Required: the root import path of the project being constrained.
 # name = "github.com/user/project"
 #

--- a/cmd/dep/testdata/harness_tests/ensure/empty/case2/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/ensure/empty/case2/final/Gopkg.toml
@@ -1,11 +1,6 @@
 
-[[dependencies]]
-  name = "github.com/sdboyer/deptest"
-  version = "^0.8.0"
-
-
 ## EXAMPLES & DOCS - safe to delete!
-
+#
 ## Dependencies define constraints on how dependent projects should be
 ## incorporated into Gopkg.lock. They are respected by dep whether
 ## this project is the current project, or if it's a dependency.
@@ -21,20 +16,26 @@
 ## Note: revision will depend on your repository type; git and hg have SHA1s,
 ## bzr a 3-part id, svn a revision number.
 # revision = "abc123"
-
+#
 ## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
 ## all [[dependencies]] declarations from all projects. Only the current project's
 ## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer, and should be used only as a last resort.
-
+#
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
 ## project. Use it when your project needs a package it doesn't explicitly import -
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
-
+#
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
+
+
+
+[[dependencies]]
+  name = "github.com/sdboyer/deptest"
+  version = "^0.8.0"

--- a/cmd/dep/testdata/harness_tests/ensure/empty/case2/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/ensure/empty/case2/final/Gopkg.toml
@@ -2,3 +2,47 @@
 [[dependencies]]
   name = "github.com/sdboyer/deptest"
   version = "^0.8.0"
+
+## Dependencies define constraints on how dependent projects should be
+## incorporated into Gopkg.lock. They are respected by dep whether
+## this project is the current project, or if it's a dependency.
+# [[dependencies]]
+## Required: the root import path of the project being constrained
+# name = "github.com/user/project"
+## Optional: an alternate location (URL or import path) for the project's source
+# source = "https://github.com/myfork/package.git"
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+## Note: revision will depend on your repository type; git and hg have SHA1s,
+## bzr a 3-part id, svn a revision number.
+# revision = "abc123"
+
+## Overrides have the same structure as [[dependencies]], but supercede all
+## [[dependencies]] declarations from all projects. However, only the current
+## project's overrides will apply.
+##
+## Overrides are a sledgehammer, and should be used only as a last resort.
+# [[overrides]]
+## Required: the root import path of the project being constrained
+# name = "github.com/user/project"
+## Optional: an alternate location (URL or import path) for the project's source
+# source = "https://github.com/myfork/package.git"
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+## Note: revision will depend on your repository type; git and hg have SHA1s,
+## bzr a 3-part id, svn a revision number.
+# revision = "abc123"
+
+## "required" lists a set of packages (not projects) that must be included in
+## Gopkg.lock. This has the same effect as directly importing a package, but
+## can be used to require "main" packages.
+# required = ["github.com/user/thing/cmd/thing"]
+
+## "ignored" lists a set of packages (not projects) that are ignored when
+## dep statically analyzes source code. Ignored packages can be in this project,
+## or in a dependency.
+# ignored = ["github.com/user/project/badpkg"]

--- a/cmd/dep/testdata/harness_tests/ensure/empty/case2/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/ensure/empty/case2/final/Gopkg.toml
@@ -3,6 +3,9 @@
   name = "github.com/sdboyer/deptest"
   version = "^0.8.0"
 
+
+## EXAMPLES & DOCS - safe to delete!
+
 ## Dependencies define constraints on how dependent projects should be
 ## incorporated into Gopkg.lock. They are respected by dep whether
 ## this project is the current project, or if it's a dependency.
@@ -19,27 +22,16 @@
 ## bzr a 3-part id, svn a revision number.
 # revision = "abc123"
 
-## Overrides have the same structure as [[dependencies]], but supercede all
-## [[dependencies]] declarations from all projects. However, only the current
-## project's overrides will apply.
+## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
+## all [[dependencies]] declarations from all projects. Only the current project's
+## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer, and should be used only as a last resort.
-# [[overrides]]
-## Required: the root import path of the project being constrained
-# name = "github.com/user/project"
-## Optional: an alternate location (URL or import path) for the project's source
-# source = "https://github.com/myfork/package.git"
-## Optional, but recommended: the version constraint to enforce for the project.
-## Only one of "branch", "version" or "revision" can be specified.
-# version = "1.0.0"
-# branch = "master"
-## Note: revision will depend on your repository type; git and hg have SHA1s,
-## bzr a 3-part id, svn a revision number.
-# revision = "abc123"
 
 ## "required" lists a set of packages (not projects) that must be included in
-## Gopkg.lock. This has the same effect as directly importing a package, but
-## can be used to require "main" packages.
+## Gopkg.lock. This list is merged with the set of packages imported by the current
+## project. Use it when your project needs a package it doesn't explicitly import -
+## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
 
 ## "ignored" lists a set of packages (not projects) that are ignored when

--- a/cmd/dep/testdata/harness_tests/ensure/empty/case2/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/ensure/empty/case2/final/Gopkg.toml
@@ -1,27 +1,5 @@
 
-## EXAMPLES & DOCS - safe to delete!
-#
-## Dependencies define constraints on how dependent projects should be
-## incorporated into Gopkg.lock. They are respected by dep whether
-## this project is the current project, or if it's a dependency.
-# [[dependencies]]
-## Required: the root import path of the project being constrained
-# name = "github.com/user/project"
-## Optional: an alternate location (URL or import path) for the project's source
-# source = "https://github.com/myfork/package.git"
-## Optional, but recommended: the version constraint to enforce for the project.
-## Only one of "branch", "version" or "revision" can be specified.
-# version = "1.0.0"
-# branch = "master"
-## Note: revision will depend on your repository type; git and hg have SHA1s,
-## bzr a 3-part id, svn a revision number.
-# revision = "abc123"
-#
-## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
-## all [[dependencies]] declarations from all projects. Only the current project's
-## [[overrides]] are applied.
-##
-## Overrides are a sledgehammer, and should be used only as a last resort.
+## EXAMPLE (these lines may be deleted)
 #
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
@@ -29,10 +7,52 @@
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
 #
+#
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
+#
+#
+# [[dependencies]]
+## Dependencies define constraints on dependent projects. They are respected by
+## dep whether coming from the Gopkg.toml of the current project or a dependency.
+#
+## Required: the root import path of the project being constrained.
+# name = "github.com/user/project"
+#
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+# revision = "abc123"
+#
+## Optional: an alternate location (URL or import path) for the project's source.
+# source = "https://github.com/myfork/package.git"
+#
+#
+# [[overrides]]
+## Overrides have the same structure as [[dependencies]], but supercede all
+## [[dependencies]] declarations from all projects. Only the current project's
+## [[overrides]] are applied.
+##
+## Overrides are a sledgehammer. Use them only as a last resort.
+#
+## Required: the root import path of the project being constrained.
+# name = "github.com/user/project"
+#
+## Optional: specifying a version constraint override will cause all other
+## constraints on this project to be ignored; only the overriden constraint
+## need be satisfied.
+## Again, only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+# revision = "abc123"
+#
+## Optional: specifying an alternate source location as an override will
+## enforce that the alternate location is used for that project, regardless of
+## what source location any dependent projects specify.
+# source = "https://github.com/myfork/package.git"
 
 
 

--- a/cmd/dep/testdata/harness_tests/ensure/empty/case3/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/ensure/empty/case3/final/Gopkg.toml
@@ -1,27 +1,24 @@
 
-## EXAMPLE (these lines may be deleted)
-#
+## Gopkg.toml example (these lines may be deleted)
+
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
 ## project. Use it when your project needs a package it doesn't explicitly import -
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
-#
-#
+
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
-#
-#
-# [[dependencies]]
+
 ## Dependencies define constraints on dependent projects. They are respected by
 ## dep whether coming from the Gopkg.toml of the current project or a dependency.
-#
+# [[dependencies]]
 ## Required: the root import path of the project being constrained.
 # name = "github.com/user/project"
 #
-## Optional, but recommended: the version constraint to enforce for the project.
+## Recommended: the version constraint to enforce for the project.
 ## Only one of "branch", "version" or "revision" can be specified.
 # version = "1.0.0"
 # branch = "master"
@@ -29,15 +26,13 @@
 #
 ## Optional: an alternate location (URL or import path) for the project's source.
 # source = "https://github.com/myfork/package.git"
-#
-#
-# [[overrides]]
+
 ## Overrides have the same structure as [[dependencies]], but supercede all
 ## [[dependencies]] declarations from all projects. Only the current project's
 ## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer. Use them only as a last resort.
-#
+# [[overrides]]
 ## Required: the root import path of the project being constrained.
 # name = "github.com/user/project"
 #

--- a/cmd/dep/testdata/harness_tests/ensure/empty/case3/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/ensure/empty/case3/final/Gopkg.toml
@@ -4,6 +4,9 @@ ignored = ["github.com/sdboyer/deptestdos"]
   branch = "master"
   name = "github.com/sdboyer/deptest"
 
+
+## EXAMPLES & DOCS - safe to delete!
+
 ## Dependencies define constraints on how dependent projects should be
 ## incorporated into Gopkg.lock. They are respected by dep whether
 ## this project is the current project, or if it's a dependency.
@@ -20,27 +23,16 @@ ignored = ["github.com/sdboyer/deptestdos"]
 ## bzr a 3-part id, svn a revision number.
 # revision = "abc123"
 
-## Overrides have the same structure as [[dependencies]], but supercede all
-## [[dependencies]] declarations from all projects. However, only the current
-## project's overrides will apply.
+## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
+## all [[dependencies]] declarations from all projects. Only the current project's
+## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer, and should be used only as a last resort.
-# [[overrides]]
-## Required: the root import path of the project being constrained
-# name = "github.com/user/project"
-## Optional: an alternate location (URL or import path) for the project's source
-# source = "https://github.com/myfork/package.git"
-## Optional, but recommended: the version constraint to enforce for the project.
-## Only one of "branch", "version" or "revision" can be specified.
-# version = "1.0.0"
-# branch = "master"
-## Note: revision will depend on your repository type; git and hg have SHA1s,
-## bzr a 3-part id, svn a revision number.
-# revision = "abc123"
 
 ## "required" lists a set of packages (not projects) that must be included in
-## Gopkg.lock. This has the same effect as directly importing a package, but
-## can be used to require "main" packages.
+## Gopkg.lock. This list is merged with the set of packages imported by the current
+## project. Use it when your project needs a package it doesn't explicitly import -
+## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
 
 ## "ignored" lists a set of packages (not projects) that are ignored when

--- a/cmd/dep/testdata/harness_tests/ensure/empty/case3/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/ensure/empty/case3/final/Gopkg.toml
@@ -3,3 +3,47 @@ ignored = ["github.com/sdboyer/deptestdos"]
 [[dependencies]]
   branch = "master"
   name = "github.com/sdboyer/deptest"
+
+## Dependencies define constraints on how dependent projects should be
+## incorporated into Gopkg.lock. They are respected by dep whether
+## this project is the current project, or if it's a dependency.
+# [[dependencies]]
+## Required: the root import path of the project being constrained
+# name = "github.com/user/project"
+## Optional: an alternate location (URL or import path) for the project's source
+# source = "https://github.com/myfork/package.git"
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+## Note: revision will depend on your repository type; git and hg have SHA1s,
+## bzr a 3-part id, svn a revision number.
+# revision = "abc123"
+
+## Overrides have the same structure as [[dependencies]], but supercede all
+## [[dependencies]] declarations from all projects. However, only the current
+## project's overrides will apply.
+##
+## Overrides are a sledgehammer, and should be used only as a last resort.
+# [[overrides]]
+## Required: the root import path of the project being constrained
+# name = "github.com/user/project"
+## Optional: an alternate location (URL or import path) for the project's source
+# source = "https://github.com/myfork/package.git"
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+## Note: revision will depend on your repository type; git and hg have SHA1s,
+## bzr a 3-part id, svn a revision number.
+# revision = "abc123"
+
+## "required" lists a set of packages (not projects) that must be included in
+## Gopkg.lock. This has the same effect as directly importing a package, but
+## can be used to require "main" packages.
+# required = ["github.com/user/thing/cmd/thing"]
+
+## "ignored" lists a set of packages (not projects) that are ignored when
+## dep statically analyzes source code. Ignored packages can be in this project,
+## or in a dependency.
+# ignored = ["github.com/user/project/badpkg"]

--- a/cmd/dep/testdata/harness_tests/ensure/empty/case3/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/ensure/empty/case3/final/Gopkg.toml
@@ -1,27 +1,5 @@
 
-## EXAMPLES & DOCS - safe to delete!
-#
-## Dependencies define constraints on how dependent projects should be
-## incorporated into Gopkg.lock. They are respected by dep whether
-## this project is the current project, or if it's a dependency.
-# [[dependencies]]
-## Required: the root import path of the project being constrained
-# name = "github.com/user/project"
-## Optional: an alternate location (URL or import path) for the project's source
-# source = "https://github.com/myfork/package.git"
-## Optional, but recommended: the version constraint to enforce for the project.
-## Only one of "branch", "version" or "revision" can be specified.
-# version = "1.0.0"
-# branch = "master"
-## Note: revision will depend on your repository type; git and hg have SHA1s,
-## bzr a 3-part id, svn a revision number.
-# revision = "abc123"
-#
-## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
-## all [[dependencies]] declarations from all projects. Only the current project's
-## [[overrides]] are applied.
-##
-## Overrides are a sledgehammer, and should be used only as a last resort.
+## EXAMPLE (these lines may be deleted)
 #
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
@@ -29,10 +7,52 @@
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
 #
+#
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
+#
+#
+# [[dependencies]]
+## Dependencies define constraints on dependent projects. They are respected by
+## dep whether coming from the Gopkg.toml of the current project or a dependency.
+#
+## Required: the root import path of the project being constrained.
+# name = "github.com/user/project"
+#
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+# revision = "abc123"
+#
+## Optional: an alternate location (URL or import path) for the project's source.
+# source = "https://github.com/myfork/package.git"
+#
+#
+# [[overrides]]
+## Overrides have the same structure as [[dependencies]], but supercede all
+## [[dependencies]] declarations from all projects. Only the current project's
+## [[overrides]] are applied.
+##
+## Overrides are a sledgehammer. Use them only as a last resort.
+#
+## Required: the root import path of the project being constrained.
+# name = "github.com/user/project"
+#
+## Optional: specifying a version constraint override will cause all other
+## constraints on this project to be ignored; only the overriden constraint
+## need be satisfied.
+## Again, only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+# revision = "abc123"
+#
+## Optional: specifying an alternate source location as an override will
+## enforce that the alternate location is used for that project, regardless of
+## what source location any dependent projects specify.
+# source = "https://github.com/myfork/package.git"
 
 
 ignored = ["github.com/sdboyer/deptestdos"]

--- a/cmd/dep/testdata/harness_tests/ensure/empty/case3/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/ensure/empty/case3/final/Gopkg.toml
@@ -1,12 +1,6 @@
-ignored = ["github.com/sdboyer/deptestdos"]
-
-[[dependencies]]
-  branch = "master"
-  name = "github.com/sdboyer/deptest"
-
 
 ## EXAMPLES & DOCS - safe to delete!
-
+#
 ## Dependencies define constraints on how dependent projects should be
 ## incorporated into Gopkg.lock. They are respected by dep whether
 ## this project is the current project, or if it's a dependency.
@@ -22,20 +16,27 @@ ignored = ["github.com/sdboyer/deptestdos"]
 ## Note: revision will depend on your repository type; git and hg have SHA1s,
 ## bzr a 3-part id, svn a revision number.
 # revision = "abc123"
-
+#
 ## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
 ## all [[dependencies]] declarations from all projects. Only the current project's
 ## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer, and should be used only as a last resort.
-
+#
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
 ## project. Use it when your project needs a package it doesn't explicitly import -
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
-
+#
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
+
+
+ignored = ["github.com/sdboyer/deptestdos"]
+
+[[dependencies]]
+  branch = "master"
+  name = "github.com/sdboyer/deptest"

--- a/cmd/dep/testdata/harness_tests/ensure/override/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/ensure/override/case1/final/Gopkg.toml
@@ -1,27 +1,24 @@
 
-## EXAMPLE (these lines may be deleted)
-#
+## Gopkg.toml example (these lines may be deleted)
+
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
 ## project. Use it when your project needs a package it doesn't explicitly import -
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
-#
-#
+
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
-#
-#
-# [[dependencies]]
+
 ## Dependencies define constraints on dependent projects. They are respected by
 ## dep whether coming from the Gopkg.toml of the current project or a dependency.
-#
+# [[dependencies]]
 ## Required: the root import path of the project being constrained.
 # name = "github.com/user/project"
 #
-## Optional, but recommended: the version constraint to enforce for the project.
+## Recommended: the version constraint to enforce for the project.
 ## Only one of "branch", "version" or "revision" can be specified.
 # version = "1.0.0"
 # branch = "master"
@@ -29,15 +26,13 @@
 #
 ## Optional: an alternate location (URL or import path) for the project's source.
 # source = "https://github.com/myfork/package.git"
-#
-#
-# [[overrides]]
+
 ## Overrides have the same structure as [[dependencies]], but supercede all
 ## [[dependencies]] declarations from all projects. Only the current project's
 ## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer. Use them only as a last resort.
-#
+# [[overrides]]
 ## Required: the root import path of the project being constrained.
 # name = "github.com/user/project"
 #

--- a/cmd/dep/testdata/harness_tests/ensure/override/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/ensure/override/case1/final/Gopkg.toml
@@ -2,3 +2,47 @@
 [[overrides]]
   name = "github.com/sdboyer/deptest"
   version = "1.0.0"
+
+## Dependencies define constraints on how dependent projects should be
+## incorporated into Gopkg.lock. They are respected by dep whether
+## this project is the current project, or if it's a dependency.
+# [[dependencies]]
+## Required: the root import path of the project being constrained
+# name = "github.com/user/project"
+## Optional: an alternate location (URL or import path) for the project's source
+# source = "https://github.com/myfork/package.git"
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+## Note: revision will depend on your repository type; git and hg have SHA1s,
+## bzr a 3-part id, svn a revision number.
+# revision = "abc123"
+
+## Overrides have the same structure as [[dependencies]], but supercede all
+## [[dependencies]] declarations from all projects. However, only the current
+## project's overrides will apply.
+##
+## Overrides are a sledgehammer, and should be used only as a last resort.
+# [[overrides]]
+## Required: the root import path of the project being constrained
+# name = "github.com/user/project"
+## Optional: an alternate location (URL or import path) for the project's source
+# source = "https://github.com/myfork/package.git"
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+## Note: revision will depend on your repository type; git and hg have SHA1s,
+## bzr a 3-part id, svn a revision number.
+# revision = "abc123"
+
+## "required" lists a set of packages (not projects) that must be included in
+## Gopkg.lock. This has the same effect as directly importing a package, but
+## can be used to require "main" packages.
+# required = ["github.com/user/thing/cmd/thing"]
+
+## "ignored" lists a set of packages (not projects) that are ignored when
+## dep statically analyzes source code. Ignored packages can be in this project,
+## or in a dependency.
+# ignored = ["github.com/user/project/badpkg"]

--- a/cmd/dep/testdata/harness_tests/ensure/override/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/ensure/override/case1/final/Gopkg.toml
@@ -1,11 +1,6 @@
 
-[[overrides]]
-  name = "github.com/sdboyer/deptest"
-  version = "1.0.0"
-
-
 ## EXAMPLES & DOCS - safe to delete!
-
+#
 ## Dependencies define constraints on how dependent projects should be
 ## incorporated into Gopkg.lock. They are respected by dep whether
 ## this project is the current project, or if it's a dependency.
@@ -21,20 +16,26 @@
 ## Note: revision will depend on your repository type; git and hg have SHA1s,
 ## bzr a 3-part id, svn a revision number.
 # revision = "abc123"
-
+#
 ## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
 ## all [[dependencies]] declarations from all projects. Only the current project's
 ## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer, and should be used only as a last resort.
-
+#
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
 ## project. Use it when your project needs a package it doesn't explicitly import -
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
-
+#
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
+
+
+
+[[overrides]]
+  name = "github.com/sdboyer/deptest"
+  version = "1.0.0"

--- a/cmd/dep/testdata/harness_tests/ensure/override/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/ensure/override/case1/final/Gopkg.toml
@@ -3,6 +3,9 @@
   name = "github.com/sdboyer/deptest"
   version = "1.0.0"
 
+
+## EXAMPLES & DOCS - safe to delete!
+
 ## Dependencies define constraints on how dependent projects should be
 ## incorporated into Gopkg.lock. They are respected by dep whether
 ## this project is the current project, or if it's a dependency.
@@ -19,27 +22,16 @@
 ## bzr a 3-part id, svn a revision number.
 # revision = "abc123"
 
-## Overrides have the same structure as [[dependencies]], but supercede all
-## [[dependencies]] declarations from all projects. However, only the current
-## project's overrides will apply.
+## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
+## all [[dependencies]] declarations from all projects. Only the current project's
+## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer, and should be used only as a last resort.
-# [[overrides]]
-## Required: the root import path of the project being constrained
-# name = "github.com/user/project"
-## Optional: an alternate location (URL or import path) for the project's source
-# source = "https://github.com/myfork/package.git"
-## Optional, but recommended: the version constraint to enforce for the project.
-## Only one of "branch", "version" or "revision" can be specified.
-# version = "1.0.0"
-# branch = "master"
-## Note: revision will depend on your repository type; git and hg have SHA1s,
-## bzr a 3-part id, svn a revision number.
-# revision = "abc123"
 
 ## "required" lists a set of packages (not projects) that must be included in
-## Gopkg.lock. This has the same effect as directly importing a package, but
-## can be used to require "main" packages.
+## Gopkg.lock. This list is merged with the set of packages imported by the current
+## project. Use it when your project needs a package it doesn't explicitly import -
+## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
 
 ## "ignored" lists a set of packages (not projects) that are ignored when

--- a/cmd/dep/testdata/harness_tests/ensure/override/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/ensure/override/case1/final/Gopkg.toml
@@ -1,27 +1,5 @@
 
-## EXAMPLES & DOCS - safe to delete!
-#
-## Dependencies define constraints on how dependent projects should be
-## incorporated into Gopkg.lock. They are respected by dep whether
-## this project is the current project, or if it's a dependency.
-# [[dependencies]]
-## Required: the root import path of the project being constrained
-# name = "github.com/user/project"
-## Optional: an alternate location (URL or import path) for the project's source
-# source = "https://github.com/myfork/package.git"
-## Optional, but recommended: the version constraint to enforce for the project.
-## Only one of "branch", "version" or "revision" can be specified.
-# version = "1.0.0"
-# branch = "master"
-## Note: revision will depend on your repository type; git and hg have SHA1s,
-## bzr a 3-part id, svn a revision number.
-# revision = "abc123"
-#
-## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
-## all [[dependencies]] declarations from all projects. Only the current project's
-## [[overrides]] are applied.
-##
-## Overrides are a sledgehammer, and should be used only as a last resort.
+## EXAMPLE (these lines may be deleted)
 #
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
@@ -29,10 +7,52 @@
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
 #
+#
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
+#
+#
+# [[dependencies]]
+## Dependencies define constraints on dependent projects. They are respected by
+## dep whether coming from the Gopkg.toml of the current project or a dependency.
+#
+## Required: the root import path of the project being constrained.
+# name = "github.com/user/project"
+#
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+# revision = "abc123"
+#
+## Optional: an alternate location (URL or import path) for the project's source.
+# source = "https://github.com/myfork/package.git"
+#
+#
+# [[overrides]]
+## Overrides have the same structure as [[dependencies]], but supercede all
+## [[dependencies]] declarations from all projects. Only the current project's
+## [[overrides]] are applied.
+##
+## Overrides are a sledgehammer. Use them only as a last resort.
+#
+## Required: the root import path of the project being constrained.
+# name = "github.com/user/project"
+#
+## Optional: specifying a version constraint override will cause all other
+## constraints on this project to be ignored; only the overriden constraint
+## need be satisfied.
+## Again, only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+# revision = "abc123"
+#
+## Optional: specifying an alternate source location as an override will
+## enforce that the alternate location is used for that project, regardless of
+## what source location any dependent projects specify.
+# source = "https://github.com/myfork/package.git"
 
 
 

--- a/cmd/dep/testdata/harness_tests/init/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/case1/final/Gopkg.toml
@@ -1,27 +1,24 @@
 
-## EXAMPLE (these lines may be deleted)
-#
+## Gopkg.toml example (these lines may be deleted)
+
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
 ## project. Use it when your project needs a package it doesn't explicitly import -
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
-#
-#
+
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
-#
-#
-# [[dependencies]]
+
 ## Dependencies define constraints on dependent projects. They are respected by
 ## dep whether coming from the Gopkg.toml of the current project or a dependency.
-#
+# [[dependencies]]
 ## Required: the root import path of the project being constrained.
 # name = "github.com/user/project"
 #
-## Optional, but recommended: the version constraint to enforce for the project.
+## Recommended: the version constraint to enforce for the project.
 ## Only one of "branch", "version" or "revision" can be specified.
 # version = "1.0.0"
 # branch = "master"
@@ -29,15 +26,13 @@
 #
 ## Optional: an alternate location (URL or import path) for the project's source.
 # source = "https://github.com/myfork/package.git"
-#
-#
-# [[overrides]]
+
 ## Overrides have the same structure as [[dependencies]], but supercede all
 ## [[dependencies]] declarations from all projects. Only the current project's
 ## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer. Use them only as a last resort.
-#
+# [[overrides]]
 ## Required: the root import path of the project being constrained.
 # name = "github.com/user/project"
 #

--- a/cmd/dep/testdata/harness_tests/init/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/case1/final/Gopkg.toml
@@ -7,6 +7,9 @@
   name = "github.com/sdboyer/deptestdos"
   revision = "a0196baa11ea047dd65037287451d36b861b00ea"
 
+
+## EXAMPLES & DOCS - safe to delete!
+
 ## Dependencies define constraints on how dependent projects should be
 ## incorporated into Gopkg.lock. They are respected by dep whether
 ## this project is the current project, or if it's a dependency.
@@ -23,27 +26,16 @@
 ## bzr a 3-part id, svn a revision number.
 # revision = "abc123"
 
-## Overrides have the same structure as [[dependencies]], but supercede all
-## [[dependencies]] declarations from all projects. However, only the current
-## project's overrides will apply.
+## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
+## all [[dependencies]] declarations from all projects. Only the current project's
+## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer, and should be used only as a last resort.
-# [[overrides]]
-## Required: the root import path of the project being constrained
-# name = "github.com/user/project"
-## Optional: an alternate location (URL or import path) for the project's source
-# source = "https://github.com/myfork/package.git"
-## Optional, but recommended: the version constraint to enforce for the project.
-## Only one of "branch", "version" or "revision" can be specified.
-# version = "1.0.0"
-# branch = "master"
-## Note: revision will depend on your repository type; git and hg have SHA1s,
-## bzr a 3-part id, svn a revision number.
-# revision = "abc123"
 
 ## "required" lists a set of packages (not projects) that must be included in
-## Gopkg.lock. This has the same effect as directly importing a package, but
-## can be used to require "main" packages.
+## Gopkg.lock. This list is merged with the set of packages imported by the current
+## project. Use it when your project needs a package it doesn't explicitly import -
+## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
 
 ## "ignored" lists a set of packages (not projects) that are ignored when

--- a/cmd/dep/testdata/harness_tests/init/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/case1/final/Gopkg.toml
@@ -6,3 +6,47 @@
 [[dependencies]]
   name = "github.com/sdboyer/deptestdos"
   revision = "a0196baa11ea047dd65037287451d36b861b00ea"
+
+## Dependencies define constraints on how dependent projects should be
+## incorporated into Gopkg.lock. They are respected by dep whether
+## this project is the current project, or if it's a dependency.
+# [[dependencies]]
+## Required: the root import path of the project being constrained
+# name = "github.com/user/project"
+## Optional: an alternate location (URL or import path) for the project's source
+# source = "https://github.com/myfork/package.git"
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+## Note: revision will depend on your repository type; git and hg have SHA1s,
+## bzr a 3-part id, svn a revision number.
+# revision = "abc123"
+
+## Overrides have the same structure as [[dependencies]], but supercede all
+## [[dependencies]] declarations from all projects. However, only the current
+## project's overrides will apply.
+##
+## Overrides are a sledgehammer, and should be used only as a last resort.
+# [[overrides]]
+## Required: the root import path of the project being constrained
+# name = "github.com/user/project"
+## Optional: an alternate location (URL or import path) for the project's source
+# source = "https://github.com/myfork/package.git"
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+## Note: revision will depend on your repository type; git and hg have SHA1s,
+## bzr a 3-part id, svn a revision number.
+# revision = "abc123"
+
+## "required" lists a set of packages (not projects) that must be included in
+## Gopkg.lock. This has the same effect as directly importing a package, but
+## can be used to require "main" packages.
+# required = ["github.com/user/thing/cmd/thing"]
+
+## "ignored" lists a set of packages (not projects) that are ignored when
+## dep statically analyzes source code. Ignored packages can be in this project,
+## or in a dependency.
+# ignored = ["github.com/user/project/badpkg"]

--- a/cmd/dep/testdata/harness_tests/init/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/case1/final/Gopkg.toml
@@ -1,27 +1,5 @@
 
-## EXAMPLES & DOCS - safe to delete!
-#
-## Dependencies define constraints on how dependent projects should be
-## incorporated into Gopkg.lock. They are respected by dep whether
-## this project is the current project, or if it's a dependency.
-# [[dependencies]]
-## Required: the root import path of the project being constrained
-# name = "github.com/user/project"
-## Optional: an alternate location (URL or import path) for the project's source
-# source = "https://github.com/myfork/package.git"
-## Optional, but recommended: the version constraint to enforce for the project.
-## Only one of "branch", "version" or "revision" can be specified.
-# version = "1.0.0"
-# branch = "master"
-## Note: revision will depend on your repository type; git and hg have SHA1s,
-## bzr a 3-part id, svn a revision number.
-# revision = "abc123"
-#
-## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
-## all [[dependencies]] declarations from all projects. Only the current project's
-## [[overrides]] are applied.
-##
-## Overrides are a sledgehammer, and should be used only as a last resort.
+## EXAMPLE (these lines may be deleted)
 #
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
@@ -29,10 +7,52 @@
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
 #
+#
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
+#
+#
+# [[dependencies]]
+## Dependencies define constraints on dependent projects. They are respected by
+## dep whether coming from the Gopkg.toml of the current project or a dependency.
+#
+## Required: the root import path of the project being constrained.
+# name = "github.com/user/project"
+#
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+# revision = "abc123"
+#
+## Optional: an alternate location (URL or import path) for the project's source.
+# source = "https://github.com/myfork/package.git"
+#
+#
+# [[overrides]]
+## Overrides have the same structure as [[dependencies]], but supercede all
+## [[dependencies]] declarations from all projects. Only the current project's
+## [[overrides]] are applied.
+##
+## Overrides are a sledgehammer. Use them only as a last resort.
+#
+## Required: the root import path of the project being constrained.
+# name = "github.com/user/project"
+#
+## Optional: specifying a version constraint override will cause all other
+## constraints on this project to be ignored; only the overriden constraint
+## need be satisfied.
+## Again, only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+# revision = "abc123"
+#
+## Optional: specifying an alternate source location as an override will
+## enforce that the alternate location is used for that project, regardless of
+## what source location any dependent projects specify.
+# source = "https://github.com/myfork/package.git"
 
 
 

--- a/cmd/dep/testdata/harness_tests/init/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/case1/final/Gopkg.toml
@@ -1,15 +1,6 @@
 
-[[dependencies]]
-  name = "github.com/sdboyer/deptest"
-  version = ">=0.8.0, <1.0.0"
-
-[[dependencies]]
-  name = "github.com/sdboyer/deptestdos"
-  revision = "a0196baa11ea047dd65037287451d36b861b00ea"
-
-
 ## EXAMPLES & DOCS - safe to delete!
-
+#
 ## Dependencies define constraints on how dependent projects should be
 ## incorporated into Gopkg.lock. They are respected by dep whether
 ## this project is the current project, or if it's a dependency.
@@ -25,20 +16,30 @@
 ## Note: revision will depend on your repository type; git and hg have SHA1s,
 ## bzr a 3-part id, svn a revision number.
 # revision = "abc123"
-
+#
 ## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
 ## all [[dependencies]] declarations from all projects. Only the current project's
 ## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer, and should be used only as a last resort.
-
+#
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
 ## project. Use it when your project needs a package it doesn't explicitly import -
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
-
+#
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
+
+
+
+[[dependencies]]
+  name = "github.com/sdboyer/deptest"
+  version = ">=0.8.0, <1.0.0"
+
+[[dependencies]]
+  name = "github.com/sdboyer/deptestdos"
+  revision = "a0196baa11ea047dd65037287451d36b861b00ea"

--- a/cmd/dep/testdata/harness_tests/init/case2/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/case2/final/Gopkg.toml
@@ -1,27 +1,24 @@
 
-## EXAMPLE (these lines may be deleted)
-#
+## Gopkg.toml example (these lines may be deleted)
+
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
 ## project. Use it when your project needs a package it doesn't explicitly import -
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
-#
-#
+
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
-#
-#
-# [[dependencies]]
+
 ## Dependencies define constraints on dependent projects. They are respected by
 ## dep whether coming from the Gopkg.toml of the current project or a dependency.
-#
+# [[dependencies]]
 ## Required: the root import path of the project being constrained.
 # name = "github.com/user/project"
 #
-## Optional, but recommended: the version constraint to enforce for the project.
+## Recommended: the version constraint to enforce for the project.
 ## Only one of "branch", "version" or "revision" can be specified.
 # version = "1.0.0"
 # branch = "master"
@@ -29,15 +26,13 @@
 #
 ## Optional: an alternate location (URL or import path) for the project's source.
 # source = "https://github.com/myfork/package.git"
-#
-#
-# [[overrides]]
+
 ## Overrides have the same structure as [[dependencies]], but supercede all
 ## [[dependencies]] declarations from all projects. Only the current project's
 ## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer. Use them only as a last resort.
-#
+# [[overrides]]
 ## Required: the root import path of the project being constrained.
 # name = "github.com/user/project"
 #

--- a/cmd/dep/testdata/harness_tests/init/case2/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/case2/final/Gopkg.toml
@@ -3,6 +3,9 @@
   name = "github.com/sdboyer/deptest"
   version = ">=0.8.0, <1.0.0"
 
+
+## EXAMPLES & DOCS - safe to delete!
+
 ## Dependencies define constraints on how dependent projects should be
 ## incorporated into Gopkg.lock. They are respected by dep whether
 ## this project is the current project, or if it's a dependency.
@@ -19,27 +22,16 @@
 ## bzr a 3-part id, svn a revision number.
 # revision = "abc123"
 
-## Overrides have the same structure as [[dependencies]], but supercede all
-## [[dependencies]] declarations from all projects. However, only the current
-## project's overrides will apply.
+## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
+## all [[dependencies]] declarations from all projects. Only the current project's
+## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer, and should be used only as a last resort.
-# [[overrides]]
-## Required: the root import path of the project being constrained
-# name = "github.com/user/project"
-## Optional: an alternate location (URL or import path) for the project's source
-# source = "https://github.com/myfork/package.git"
-## Optional, but recommended: the version constraint to enforce for the project.
-## Only one of "branch", "version" or "revision" can be specified.
-# version = "1.0.0"
-# branch = "master"
-## Note: revision will depend on your repository type; git and hg have SHA1s,
-## bzr a 3-part id, svn a revision number.
-# revision = "abc123"
 
 ## "required" lists a set of packages (not projects) that must be included in
-## Gopkg.lock. This has the same effect as directly importing a package, but
-## can be used to require "main" packages.
+## Gopkg.lock. This list is merged with the set of packages imported by the current
+## project. Use it when your project needs a package it doesn't explicitly import -
+## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
 
 ## "ignored" lists a set of packages (not projects) that are ignored when

--- a/cmd/dep/testdata/harness_tests/init/case2/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/case2/final/Gopkg.toml
@@ -1,11 +1,6 @@
 
-[[dependencies]]
-  name = "github.com/sdboyer/deptest"
-  version = ">=0.8.0, <1.0.0"
-
-
 ## EXAMPLES & DOCS - safe to delete!
-
+#
 ## Dependencies define constraints on how dependent projects should be
 ## incorporated into Gopkg.lock. They are respected by dep whether
 ## this project is the current project, or if it's a dependency.
@@ -21,20 +16,26 @@
 ## Note: revision will depend on your repository type; git and hg have SHA1s,
 ## bzr a 3-part id, svn a revision number.
 # revision = "abc123"
-
+#
 ## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
 ## all [[dependencies]] declarations from all projects. Only the current project's
 ## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer, and should be used only as a last resort.
-
+#
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
 ## project. Use it when your project needs a package it doesn't explicitly import -
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
-
+#
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
+
+
+
+[[dependencies]]
+  name = "github.com/sdboyer/deptest"
+  version = ">=0.8.0, <1.0.0"

--- a/cmd/dep/testdata/harness_tests/init/case2/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/case2/final/Gopkg.toml
@@ -1,27 +1,5 @@
 
-## EXAMPLES & DOCS - safe to delete!
-#
-## Dependencies define constraints on how dependent projects should be
-## incorporated into Gopkg.lock. They are respected by dep whether
-## this project is the current project, or if it's a dependency.
-# [[dependencies]]
-## Required: the root import path of the project being constrained
-# name = "github.com/user/project"
-## Optional: an alternate location (URL or import path) for the project's source
-# source = "https://github.com/myfork/package.git"
-## Optional, but recommended: the version constraint to enforce for the project.
-## Only one of "branch", "version" or "revision" can be specified.
-# version = "1.0.0"
-# branch = "master"
-## Note: revision will depend on your repository type; git and hg have SHA1s,
-## bzr a 3-part id, svn a revision number.
-# revision = "abc123"
-#
-## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
-## all [[dependencies]] declarations from all projects. Only the current project's
-## [[overrides]] are applied.
-##
-## Overrides are a sledgehammer, and should be used only as a last resort.
+## EXAMPLE (these lines may be deleted)
 #
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
@@ -29,10 +7,52 @@
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
 #
+#
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
+#
+#
+# [[dependencies]]
+## Dependencies define constraints on dependent projects. They are respected by
+## dep whether coming from the Gopkg.toml of the current project or a dependency.
+#
+## Required: the root import path of the project being constrained.
+# name = "github.com/user/project"
+#
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+# revision = "abc123"
+#
+## Optional: an alternate location (URL or import path) for the project's source.
+# source = "https://github.com/myfork/package.git"
+#
+#
+# [[overrides]]
+## Overrides have the same structure as [[dependencies]], but supercede all
+## [[dependencies]] declarations from all projects. Only the current project's
+## [[overrides]] are applied.
+##
+## Overrides are a sledgehammer. Use them only as a last resort.
+#
+## Required: the root import path of the project being constrained.
+# name = "github.com/user/project"
+#
+## Optional: specifying a version constraint override will cause all other
+## constraints on this project to be ignored; only the overriden constraint
+## need be satisfied.
+## Again, only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+# revision = "abc123"
+#
+## Optional: specifying an alternate source location as an override will
+## enforce that the alternate location is used for that project, regardless of
+## what source location any dependent projects specify.
+# source = "https://github.com/myfork/package.git"
 
 
 

--- a/cmd/dep/testdata/harness_tests/init/case2/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/case2/final/Gopkg.toml
@@ -2,3 +2,47 @@
 [[dependencies]]
   name = "github.com/sdboyer/deptest"
   version = ">=0.8.0, <1.0.0"
+
+## Dependencies define constraints on how dependent projects should be
+## incorporated into Gopkg.lock. They are respected by dep whether
+## this project is the current project, or if it's a dependency.
+# [[dependencies]]
+## Required: the root import path of the project being constrained
+# name = "github.com/user/project"
+## Optional: an alternate location (URL or import path) for the project's source
+# source = "https://github.com/myfork/package.git"
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+## Note: revision will depend on your repository type; git and hg have SHA1s,
+## bzr a 3-part id, svn a revision number.
+# revision = "abc123"
+
+## Overrides have the same structure as [[dependencies]], but supercede all
+## [[dependencies]] declarations from all projects. However, only the current
+## project's overrides will apply.
+##
+## Overrides are a sledgehammer, and should be used only as a last resort.
+# [[overrides]]
+## Required: the root import path of the project being constrained
+# name = "github.com/user/project"
+## Optional: an alternate location (URL or import path) for the project's source
+# source = "https://github.com/myfork/package.git"
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+## Note: revision will depend on your repository type; git and hg have SHA1s,
+## bzr a 3-part id, svn a revision number.
+# revision = "abc123"
+
+## "required" lists a set of packages (not projects) that must be included in
+## Gopkg.lock. This has the same effect as directly importing a package, but
+## can be used to require "main" packages.
+# required = ["github.com/user/thing/cmd/thing"]
+
+## "ignored" lists a set of packages (not projects) that are ignored when
+## dep statically analyzes source code. Ignored packages can be in this project,
+## or in a dependency.
+# ignored = ["github.com/user/project/badpkg"]

--- a/cmd/dep/testdata/harness_tests/init/case3/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/case3/final/Gopkg.toml
@@ -1,27 +1,24 @@
 
-## EXAMPLE (these lines may be deleted)
-#
+## Gopkg.toml example (these lines may be deleted)
+
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
 ## project. Use it when your project needs a package it doesn't explicitly import -
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
-#
-#
+
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
-#
-#
-# [[dependencies]]
+
 ## Dependencies define constraints on dependent projects. They are respected by
 ## dep whether coming from the Gopkg.toml of the current project or a dependency.
-#
+# [[dependencies]]
 ## Required: the root import path of the project being constrained.
 # name = "github.com/user/project"
 #
-## Optional, but recommended: the version constraint to enforce for the project.
+## Recommended: the version constraint to enforce for the project.
 ## Only one of "branch", "version" or "revision" can be specified.
 # version = "1.0.0"
 # branch = "master"
@@ -29,15 +26,13 @@
 #
 ## Optional: an alternate location (URL or import path) for the project's source.
 # source = "https://github.com/myfork/package.git"
-#
-#
-# [[overrides]]
+
 ## Overrides have the same structure as [[dependencies]], but supercede all
 ## [[dependencies]] declarations from all projects. Only the current project's
 ## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer. Use them only as a last resort.
-#
+# [[overrides]]
 ## Required: the root import path of the project being constrained.
 # name = "github.com/user/project"
 #

--- a/cmd/dep/testdata/harness_tests/init/case3/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/case3/final/Gopkg.toml
@@ -7,6 +7,9 @@
   name = "github.com/sdboyer/deptestdos"
   revision = "a0196baa11ea047dd65037287451d36b861b00ea"
 
+
+## EXAMPLES & DOCS - safe to delete!
+
 ## Dependencies define constraints on how dependent projects should be
 ## incorporated into Gopkg.lock. They are respected by dep whether
 ## this project is the current project, or if it's a dependency.
@@ -23,27 +26,16 @@
 ## bzr a 3-part id, svn a revision number.
 # revision = "abc123"
 
-## Overrides have the same structure as [[dependencies]], but supercede all
-## [[dependencies]] declarations from all projects. However, only the current
-## project's overrides will apply.
+## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
+## all [[dependencies]] declarations from all projects. Only the current project's
+## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer, and should be used only as a last resort.
-# [[overrides]]
-## Required: the root import path of the project being constrained
-# name = "github.com/user/project"
-## Optional: an alternate location (URL or import path) for the project's source
-# source = "https://github.com/myfork/package.git"
-## Optional, but recommended: the version constraint to enforce for the project.
-## Only one of "branch", "version" or "revision" can be specified.
-# version = "1.0.0"
-# branch = "master"
-## Note: revision will depend on your repository type; git and hg have SHA1s,
-## bzr a 3-part id, svn a revision number.
-# revision = "abc123"
 
 ## "required" lists a set of packages (not projects) that must be included in
-## Gopkg.lock. This has the same effect as directly importing a package, but
-## can be used to require "main" packages.
+## Gopkg.lock. This list is merged with the set of packages imported by the current
+## project. Use it when your project needs a package it doesn't explicitly import -
+## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
 
 ## "ignored" lists a set of packages (not projects) that are ignored when

--- a/cmd/dep/testdata/harness_tests/init/case3/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/case3/final/Gopkg.toml
@@ -6,3 +6,47 @@
 [[dependencies]]
   name = "github.com/sdboyer/deptestdos"
   revision = "a0196baa11ea047dd65037287451d36b861b00ea"
+
+## Dependencies define constraints on how dependent projects should be
+## incorporated into Gopkg.lock. They are respected by dep whether
+## this project is the current project, or if it's a dependency.
+# [[dependencies]]
+## Required: the root import path of the project being constrained
+# name = "github.com/user/project"
+## Optional: an alternate location (URL or import path) for the project's source
+# source = "https://github.com/myfork/package.git"
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+## Note: revision will depend on your repository type; git and hg have SHA1s,
+## bzr a 3-part id, svn a revision number.
+# revision = "abc123"
+
+## Overrides have the same structure as [[dependencies]], but supercede all
+## [[dependencies]] declarations from all projects. However, only the current
+## project's overrides will apply.
+##
+## Overrides are a sledgehammer, and should be used only as a last resort.
+# [[overrides]]
+## Required: the root import path of the project being constrained
+# name = "github.com/user/project"
+## Optional: an alternate location (URL or import path) for the project's source
+# source = "https://github.com/myfork/package.git"
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+## Note: revision will depend on your repository type; git and hg have SHA1s,
+## bzr a 3-part id, svn a revision number.
+# revision = "abc123"
+
+## "required" lists a set of packages (not projects) that must be included in
+## Gopkg.lock. This has the same effect as directly importing a package, but
+## can be used to require "main" packages.
+# required = ["github.com/user/thing/cmd/thing"]
+
+## "ignored" lists a set of packages (not projects) that are ignored when
+## dep statically analyzes source code. Ignored packages can be in this project,
+## or in a dependency.
+# ignored = ["github.com/user/project/badpkg"]

--- a/cmd/dep/testdata/harness_tests/init/case3/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/case3/final/Gopkg.toml
@@ -1,27 +1,5 @@
 
-## EXAMPLES & DOCS - safe to delete!
-#
-## Dependencies define constraints on how dependent projects should be
-## incorporated into Gopkg.lock. They are respected by dep whether
-## this project is the current project, or if it's a dependency.
-# [[dependencies]]
-## Required: the root import path of the project being constrained
-# name = "github.com/user/project"
-## Optional: an alternate location (URL or import path) for the project's source
-# source = "https://github.com/myfork/package.git"
-## Optional, but recommended: the version constraint to enforce for the project.
-## Only one of "branch", "version" or "revision" can be specified.
-# version = "1.0.0"
-# branch = "master"
-## Note: revision will depend on your repository type; git and hg have SHA1s,
-## bzr a 3-part id, svn a revision number.
-# revision = "abc123"
-#
-## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
-## all [[dependencies]] declarations from all projects. Only the current project's
-## [[overrides]] are applied.
-##
-## Overrides are a sledgehammer, and should be used only as a last resort.
+## EXAMPLE (these lines may be deleted)
 #
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
@@ -29,10 +7,52 @@
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
 #
+#
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
+#
+#
+# [[dependencies]]
+## Dependencies define constraints on dependent projects. They are respected by
+## dep whether coming from the Gopkg.toml of the current project or a dependency.
+#
+## Required: the root import path of the project being constrained.
+# name = "github.com/user/project"
+#
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+# revision = "abc123"
+#
+## Optional: an alternate location (URL or import path) for the project's source.
+# source = "https://github.com/myfork/package.git"
+#
+#
+# [[overrides]]
+## Overrides have the same structure as [[dependencies]], but supercede all
+## [[dependencies]] declarations from all projects. Only the current project's
+## [[overrides]] are applied.
+##
+## Overrides are a sledgehammer. Use them only as a last resort.
+#
+## Required: the root import path of the project being constrained.
+# name = "github.com/user/project"
+#
+## Optional: specifying a version constraint override will cause all other
+## constraints on this project to be ignored; only the overriden constraint
+## need be satisfied.
+## Again, only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+# revision = "abc123"
+#
+## Optional: specifying an alternate source location as an override will
+## enforce that the alternate location is used for that project, regardless of
+## what source location any dependent projects specify.
+# source = "https://github.com/myfork/package.git"
 
 
 

--- a/cmd/dep/testdata/harness_tests/init/case3/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/case3/final/Gopkg.toml
@@ -1,15 +1,6 @@
 
-[[dependencies]]
-  branch = "master"
-  name = "github.com/sdboyer/deptest"
-
-[[dependencies]]
-  name = "github.com/sdboyer/deptestdos"
-  revision = "a0196baa11ea047dd65037287451d36b861b00ea"
-
-
 ## EXAMPLES & DOCS - safe to delete!
-
+#
 ## Dependencies define constraints on how dependent projects should be
 ## incorporated into Gopkg.lock. They are respected by dep whether
 ## this project is the current project, or if it's a dependency.
@@ -25,20 +16,30 @@
 ## Note: revision will depend on your repository type; git and hg have SHA1s,
 ## bzr a 3-part id, svn a revision number.
 # revision = "abc123"
-
+#
 ## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
 ## all [[dependencies]] declarations from all projects. Only the current project's
 ## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer, and should be used only as a last resort.
-
+#
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
 ## project. Use it when your project needs a package it doesn't explicitly import -
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
-
+#
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
+
+
+
+[[dependencies]]
+  branch = "master"
+  name = "github.com/sdboyer/deptest"
+
+[[dependencies]]
+  name = "github.com/sdboyer/deptestdos"
+  revision = "a0196baa11ea047dd65037287451d36b861b00ea"

--- a/cmd/dep/testdata/harness_tests/init/skip-hidden/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/skip-hidden/final/Gopkg.toml
@@ -1,27 +1,24 @@
 
-## EXAMPLE (these lines may be deleted)
-#
+## Gopkg.toml example (these lines may be deleted)
+
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
 ## project. Use it when your project needs a package it doesn't explicitly import -
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
-#
-#
+
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
-#
-#
-# [[dependencies]]
+
 ## Dependencies define constraints on dependent projects. They are respected by
 ## dep whether coming from the Gopkg.toml of the current project or a dependency.
-#
+# [[dependencies]]
 ## Required: the root import path of the project being constrained.
 # name = "github.com/user/project"
 #
-## Optional, but recommended: the version constraint to enforce for the project.
+## Recommended: the version constraint to enforce for the project.
 ## Only one of "branch", "version" or "revision" can be specified.
 # version = "1.0.0"
 # branch = "master"
@@ -29,15 +26,13 @@
 #
 ## Optional: an alternate location (URL or import path) for the project's source.
 # source = "https://github.com/myfork/package.git"
-#
-#
-# [[overrides]]
+
 ## Overrides have the same structure as [[dependencies]], but supercede all
 ## [[dependencies]] declarations from all projects. Only the current project's
 ## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer. Use them only as a last resort.
-#
+# [[overrides]]
 ## Required: the root import path of the project being constrained.
 # name = "github.com/user/project"
 #

--- a/cmd/dep/testdata/harness_tests/init/skip-hidden/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/skip-hidden/final/Gopkg.toml
@@ -1,27 +1,5 @@
 
-## EXAMPLES & DOCS - safe to delete!
-#
-## Dependencies define constraints on how dependent projects should be
-## incorporated into Gopkg.lock. They are respected by dep whether
-## this project is the current project, or if it's a dependency.
-# [[dependencies]]
-## Required: the root import path of the project being constrained
-# name = "github.com/user/project"
-## Optional: an alternate location (URL or import path) for the project's source
-# source = "https://github.com/myfork/package.git"
-## Optional, but recommended: the version constraint to enforce for the project.
-## Only one of "branch", "version" or "revision" can be specified.
-# version = "1.0.0"
-# branch = "master"
-## Note: revision will depend on your repository type; git and hg have SHA1s,
-## bzr a 3-part id, svn a revision number.
-# revision = "abc123"
-#
-## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
-## all [[dependencies]] declarations from all projects. Only the current project's
-## [[overrides]] are applied.
-##
-## Overrides are a sledgehammer, and should be used only as a last resort.
+## EXAMPLE (these lines may be deleted)
 #
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
@@ -29,9 +7,51 @@
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
 #
+#
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
+#
+#
+# [[dependencies]]
+## Dependencies define constraints on dependent projects. They are respected by
+## dep whether coming from the Gopkg.toml of the current project or a dependency.
+#
+## Required: the root import path of the project being constrained.
+# name = "github.com/user/project"
+#
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+# revision = "abc123"
+#
+## Optional: an alternate location (URL or import path) for the project's source.
+# source = "https://github.com/myfork/package.git"
+#
+#
+# [[overrides]]
+## Overrides have the same structure as [[dependencies]], but supercede all
+## [[dependencies]] declarations from all projects. Only the current project's
+## [[overrides]] are applied.
+##
+## Overrides are a sledgehammer. Use them only as a last resort.
+#
+## Required: the root import path of the project being constrained.
+# name = "github.com/user/project"
+#
+## Optional: specifying a version constraint override will cause all other
+## constraints on this project to be ignored; only the overriden constraint
+## need be satisfied.
+## Again, only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+# revision = "abc123"
+#
+## Optional: specifying an alternate source location as an override will
+## enforce that the alternate location is used for that project, regardless of
+## what source location any dependent projects specify.
+# source = "https://github.com/myfork/package.git"
 
 

--- a/cmd/dep/testdata/harness_tests/init/skip-hidden/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/skip-hidden/final/Gopkg.toml
@@ -1,4 +1,7 @@
 
+
+## EXAMPLES & DOCS - safe to delete!
+
 ## Dependencies define constraints on how dependent projects should be
 ## incorporated into Gopkg.lock. They are respected by dep whether
 ## this project is the current project, or if it's a dependency.
@@ -15,27 +18,16 @@
 ## bzr a 3-part id, svn a revision number.
 # revision = "abc123"
 
-## Overrides have the same structure as [[dependencies]], but supercede all
-## [[dependencies]] declarations from all projects. However, only the current
-## project's overrides will apply.
+## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
+## all [[dependencies]] declarations from all projects. Only the current project's
+## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer, and should be used only as a last resort.
-# [[overrides]]
-## Required: the root import path of the project being constrained
-# name = "github.com/user/project"
-## Optional: an alternate location (URL or import path) for the project's source
-# source = "https://github.com/myfork/package.git"
-## Optional, but recommended: the version constraint to enforce for the project.
-## Only one of "branch", "version" or "revision" can be specified.
-# version = "1.0.0"
-# branch = "master"
-## Note: revision will depend on your repository type; git and hg have SHA1s,
-## bzr a 3-part id, svn a revision number.
-# revision = "abc123"
 
 ## "required" lists a set of packages (not projects) that must be included in
-## Gopkg.lock. This has the same effect as directly importing a package, but
-## can be used to require "main" packages.
+## Gopkg.lock. This list is merged with the set of packages imported by the current
+## project. Use it when your project needs a package it doesn't explicitly import -
+## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
 
 ## "ignored" lists a set of packages (not projects) that are ignored when

--- a/cmd/dep/testdata/harness_tests/init/skip-hidden/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/skip-hidden/final/Gopkg.toml
@@ -1,9 +1,44 @@
 
-# Example:
+## Dependencies define constraints on how dependent projects should be
+## incorporated into Gopkg.lock. They are respected by dep whether
+## this project is the current project, or if it's a dependency.
 # [[dependencies]]
+## Required: the root import path of the project being constrained
+# name = "github.com/user/project"
+## Optional: an alternate location (URL or import path) for the project's source
 # source = "https://github.com/myfork/package.git"
-# branch = "master"
-# name = "github.com/vendor/package"
-# Note: revision will depend on your repository type, i.e git, svc, bzr etc...
-# revision = "abc123"
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
 # version = "1.0.0"
+# branch = "master"
+## Note: revision will depend on your repository type; git and hg have SHA1s,
+## bzr a 3-part id, svn a revision number.
+# revision = "abc123"
+
+## Overrides have the same structure as [[dependencies]], but supercede all
+## [[dependencies]] declarations from all projects. However, only the current
+## project's overrides will apply.
+##
+## Overrides are a sledgehammer, and should be used only as a last resort.
+# [[overrides]]
+## Required: the root import path of the project being constrained
+# name = "github.com/user/project"
+## Optional: an alternate location (URL or import path) for the project's source
+# source = "https://github.com/myfork/package.git"
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+## Note: revision will depend on your repository type; git and hg have SHA1s,
+## bzr a 3-part id, svn a revision number.
+# revision = "abc123"
+
+## "required" lists a set of packages (not projects) that must be included in
+## Gopkg.lock. This has the same effect as directly importing a package, but
+## can be used to require "main" packages.
+# required = ["github.com/user/thing/cmd/thing"]
+
+## "ignored" lists a set of packages (not projects) that are ignored when
+## dep statically analyzes source code. Ignored packages can be in this project,
+## or in a dependency.
+# ignored = ["github.com/user/project/badpkg"]

--- a/cmd/dep/testdata/harness_tests/init/skip-hidden/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/skip-hidden/final/Gopkg.toml
@@ -1,7 +1,6 @@
 
-
 ## EXAMPLES & DOCS - safe to delete!
-
+#
 ## Dependencies define constraints on how dependent projects should be
 ## incorporated into Gopkg.lock. They are respected by dep whether
 ## this project is the current project, or if it's a dependency.
@@ -17,20 +16,22 @@
 ## Note: revision will depend on your repository type; git and hg have SHA1s,
 ## bzr a 3-part id, svn a revision number.
 # revision = "abc123"
-
+#
 ## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
 ## all [[dependencies]] declarations from all projects. Only the current project's
 ## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer, and should be used only as a last resort.
-
+#
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
 ## project. Use it when your project needs a package it doesn't explicitly import -
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
-
+#
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
+
+

--- a/cmd/dep/testdata/harness_tests/remove/force/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/remove/force/case1/final/Gopkg.toml
@@ -1,27 +1,24 @@
 
-## EXAMPLE (these lines may be deleted)
-#
+## Gopkg.toml example (these lines may be deleted)
+
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
 ## project. Use it when your project needs a package it doesn't explicitly import -
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
-#
-#
+
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
-#
-#
-# [[dependencies]]
+
 ## Dependencies define constraints on dependent projects. They are respected by
 ## dep whether coming from the Gopkg.toml of the current project or a dependency.
-#
+# [[dependencies]]
 ## Required: the root import path of the project being constrained.
 # name = "github.com/user/project"
 #
-## Optional, but recommended: the version constraint to enforce for the project.
+## Recommended: the version constraint to enforce for the project.
 ## Only one of "branch", "version" or "revision" can be specified.
 # version = "1.0.0"
 # branch = "master"
@@ -29,15 +26,13 @@
 #
 ## Optional: an alternate location (URL or import path) for the project's source.
 # source = "https://github.com/myfork/package.git"
-#
-#
-# [[overrides]]
+
 ## Overrides have the same structure as [[dependencies]], but supercede all
 ## [[dependencies]] declarations from all projects. Only the current project's
 ## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer. Use them only as a last resort.
-#
+# [[overrides]]
 ## Required: the root import path of the project being constrained.
 # name = "github.com/user/project"
 #

--- a/cmd/dep/testdata/harness_tests/remove/force/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/remove/force/case1/final/Gopkg.toml
@@ -3,6 +3,9 @@
   name = "github.com/sdboyer/deptest"
   version = ">=0.8.0, <1.0.0"
 
+
+## EXAMPLES & DOCS - safe to delete!
+
 ## Dependencies define constraints on how dependent projects should be
 ## incorporated into Gopkg.lock. They are respected by dep whether
 ## this project is the current project, or if it's a dependency.
@@ -19,27 +22,16 @@
 ## bzr a 3-part id, svn a revision number.
 # revision = "abc123"
 
-## Overrides have the same structure as [[dependencies]], but supercede all
-## [[dependencies]] declarations from all projects. However, only the current
-## project's overrides will apply.
+## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
+## all [[dependencies]] declarations from all projects. Only the current project's
+## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer, and should be used only as a last resort.
-# [[overrides]]
-## Required: the root import path of the project being constrained
-# name = "github.com/user/project"
-## Optional: an alternate location (URL or import path) for the project's source
-# source = "https://github.com/myfork/package.git"
-## Optional, but recommended: the version constraint to enforce for the project.
-## Only one of "branch", "version" or "revision" can be specified.
-# version = "1.0.0"
-# branch = "master"
-## Note: revision will depend on your repository type; git and hg have SHA1s,
-## bzr a 3-part id, svn a revision number.
-# revision = "abc123"
 
 ## "required" lists a set of packages (not projects) that must be included in
-## Gopkg.lock. This has the same effect as directly importing a package, but
-## can be used to require "main" packages.
+## Gopkg.lock. This list is merged with the set of packages imported by the current
+## project. Use it when your project needs a package it doesn't explicitly import -
+## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
 
 ## "ignored" lists a set of packages (not projects) that are ignored when

--- a/cmd/dep/testdata/harness_tests/remove/force/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/remove/force/case1/final/Gopkg.toml
@@ -1,11 +1,6 @@
 
-[[dependencies]]
-  name = "github.com/sdboyer/deptest"
-  version = ">=0.8.0, <1.0.0"
-
-
 ## EXAMPLES & DOCS - safe to delete!
-
+#
 ## Dependencies define constraints on how dependent projects should be
 ## incorporated into Gopkg.lock. They are respected by dep whether
 ## this project is the current project, or if it's a dependency.
@@ -21,20 +16,26 @@
 ## Note: revision will depend on your repository type; git and hg have SHA1s,
 ## bzr a 3-part id, svn a revision number.
 # revision = "abc123"
-
+#
 ## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
 ## all [[dependencies]] declarations from all projects. Only the current project's
 ## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer, and should be used only as a last resort.
-
+#
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
 ## project. Use it when your project needs a package it doesn't explicitly import -
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
-
+#
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
+
+
+
+[[dependencies]]
+  name = "github.com/sdboyer/deptest"
+  version = ">=0.8.0, <1.0.0"

--- a/cmd/dep/testdata/harness_tests/remove/force/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/remove/force/case1/final/Gopkg.toml
@@ -1,27 +1,5 @@
 
-## EXAMPLES & DOCS - safe to delete!
-#
-## Dependencies define constraints on how dependent projects should be
-## incorporated into Gopkg.lock. They are respected by dep whether
-## this project is the current project, or if it's a dependency.
-# [[dependencies]]
-## Required: the root import path of the project being constrained
-# name = "github.com/user/project"
-## Optional: an alternate location (URL or import path) for the project's source
-# source = "https://github.com/myfork/package.git"
-## Optional, but recommended: the version constraint to enforce for the project.
-## Only one of "branch", "version" or "revision" can be specified.
-# version = "1.0.0"
-# branch = "master"
-## Note: revision will depend on your repository type; git and hg have SHA1s,
-## bzr a 3-part id, svn a revision number.
-# revision = "abc123"
-#
-## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
-## all [[dependencies]] declarations from all projects. Only the current project's
-## [[overrides]] are applied.
-##
-## Overrides are a sledgehammer, and should be used only as a last resort.
+## EXAMPLE (these lines may be deleted)
 #
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
@@ -29,10 +7,52 @@
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
 #
+#
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
+#
+#
+# [[dependencies]]
+## Dependencies define constraints on dependent projects. They are respected by
+## dep whether coming from the Gopkg.toml of the current project or a dependency.
+#
+## Required: the root import path of the project being constrained.
+# name = "github.com/user/project"
+#
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+# revision = "abc123"
+#
+## Optional: an alternate location (URL or import path) for the project's source.
+# source = "https://github.com/myfork/package.git"
+#
+#
+# [[overrides]]
+## Overrides have the same structure as [[dependencies]], but supercede all
+## [[dependencies]] declarations from all projects. Only the current project's
+## [[overrides]] are applied.
+##
+## Overrides are a sledgehammer. Use them only as a last resort.
+#
+## Required: the root import path of the project being constrained.
+# name = "github.com/user/project"
+#
+## Optional: specifying a version constraint override will cause all other
+## constraints on this project to be ignored; only the overriden constraint
+## need be satisfied.
+## Again, only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+# revision = "abc123"
+#
+## Optional: specifying an alternate source location as an override will
+## enforce that the alternate location is used for that project, regardless of
+## what source location any dependent projects specify.
+# source = "https://github.com/myfork/package.git"
 
 
 

--- a/cmd/dep/testdata/harness_tests/remove/force/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/remove/force/case1/final/Gopkg.toml
@@ -2,3 +2,47 @@
 [[dependencies]]
   name = "github.com/sdboyer/deptest"
   version = ">=0.8.0, <1.0.0"
+
+## Dependencies define constraints on how dependent projects should be
+## incorporated into Gopkg.lock. They are respected by dep whether
+## this project is the current project, or if it's a dependency.
+# [[dependencies]]
+## Required: the root import path of the project being constrained
+# name = "github.com/user/project"
+## Optional: an alternate location (URL or import path) for the project's source
+# source = "https://github.com/myfork/package.git"
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+## Note: revision will depend on your repository type; git and hg have SHA1s,
+## bzr a 3-part id, svn a revision number.
+# revision = "abc123"
+
+## Overrides have the same structure as [[dependencies]], but supercede all
+## [[dependencies]] declarations from all projects. However, only the current
+## project's overrides will apply.
+##
+## Overrides are a sledgehammer, and should be used only as a last resort.
+# [[overrides]]
+## Required: the root import path of the project being constrained
+# name = "github.com/user/project"
+## Optional: an alternate location (URL or import path) for the project's source
+# source = "https://github.com/myfork/package.git"
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+## Note: revision will depend on your repository type; git and hg have SHA1s,
+## bzr a 3-part id, svn a revision number.
+# revision = "abc123"
+
+## "required" lists a set of packages (not projects) that must be included in
+## Gopkg.lock. This has the same effect as directly importing a package, but
+## can be used to require "main" packages.
+# required = ["github.com/user/thing/cmd/thing"]
+
+## "ignored" lists a set of packages (not projects) that are ignored when
+## dep statically analyzes source code. Ignored packages can be in this project,
+## or in a dependency.
+# ignored = ["github.com/user/project/badpkg"]

--- a/cmd/dep/testdata/harness_tests/remove/specific/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/remove/specific/case1/final/Gopkg.toml
@@ -1,27 +1,24 @@
 
-## EXAMPLE (these lines may be deleted)
-#
+## Gopkg.toml example (these lines may be deleted)
+
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
 ## project. Use it when your project needs a package it doesn't explicitly import -
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
-#
-#
+
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
-#
-#
-# [[dependencies]]
+
 ## Dependencies define constraints on dependent projects. They are respected by
 ## dep whether coming from the Gopkg.toml of the current project or a dependency.
-#
+# [[dependencies]]
 ## Required: the root import path of the project being constrained.
 # name = "github.com/user/project"
 #
-## Optional, but recommended: the version constraint to enforce for the project.
+## Recommended: the version constraint to enforce for the project.
 ## Only one of "branch", "version" or "revision" can be specified.
 # version = "1.0.0"
 # branch = "master"
@@ -29,15 +26,13 @@
 #
 ## Optional: an alternate location (URL or import path) for the project's source.
 # source = "https://github.com/myfork/package.git"
-#
-#
-# [[overrides]]
+
 ## Overrides have the same structure as [[dependencies]], but supercede all
 ## [[dependencies]] declarations from all projects. Only the current project's
 ## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer. Use them only as a last resort.
-#
+# [[overrides]]
 ## Required: the root import path of the project being constrained.
 # name = "github.com/user/project"
 #

--- a/cmd/dep/testdata/harness_tests/remove/specific/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/remove/specific/case1/final/Gopkg.toml
@@ -7,6 +7,9 @@
   name = "github.com/sdboyer/deptestdos"
   revision = "a0196baa11ea047dd65037287451d36b861b00ea"
 
+
+## EXAMPLES & DOCS - safe to delete!
+
 ## Dependencies define constraints on how dependent projects should be
 ## incorporated into Gopkg.lock. They are respected by dep whether
 ## this project is the current project, or if it's a dependency.
@@ -23,27 +26,16 @@
 ## bzr a 3-part id, svn a revision number.
 # revision = "abc123"
 
-## Overrides have the same structure as [[dependencies]], but supercede all
-## [[dependencies]] declarations from all projects. However, only the current
-## project's overrides will apply.
+## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
+## all [[dependencies]] declarations from all projects. Only the current project's
+## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer, and should be used only as a last resort.
-# [[overrides]]
-## Required: the root import path of the project being constrained
-# name = "github.com/user/project"
-## Optional: an alternate location (URL or import path) for the project's source
-# source = "https://github.com/myfork/package.git"
-## Optional, but recommended: the version constraint to enforce for the project.
-## Only one of "branch", "version" or "revision" can be specified.
-# version = "1.0.0"
-# branch = "master"
-## Note: revision will depend on your repository type; git and hg have SHA1s,
-## bzr a 3-part id, svn a revision number.
-# revision = "abc123"
 
 ## "required" lists a set of packages (not projects) that must be included in
-## Gopkg.lock. This has the same effect as directly importing a package, but
-## can be used to require "main" packages.
+## Gopkg.lock. This list is merged with the set of packages imported by the current
+## project. Use it when your project needs a package it doesn't explicitly import -
+## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
 
 ## "ignored" lists a set of packages (not projects) that are ignored when

--- a/cmd/dep/testdata/harness_tests/remove/specific/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/remove/specific/case1/final/Gopkg.toml
@@ -6,3 +6,47 @@
 [[dependencies]]
   name = "github.com/sdboyer/deptestdos"
   revision = "a0196baa11ea047dd65037287451d36b861b00ea"
+
+## Dependencies define constraints on how dependent projects should be
+## incorporated into Gopkg.lock. They are respected by dep whether
+## this project is the current project, or if it's a dependency.
+# [[dependencies]]
+## Required: the root import path of the project being constrained
+# name = "github.com/user/project"
+## Optional: an alternate location (URL or import path) for the project's source
+# source = "https://github.com/myfork/package.git"
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+## Note: revision will depend on your repository type; git and hg have SHA1s,
+## bzr a 3-part id, svn a revision number.
+# revision = "abc123"
+
+## Overrides have the same structure as [[dependencies]], but supercede all
+## [[dependencies]] declarations from all projects. However, only the current
+## project's overrides will apply.
+##
+## Overrides are a sledgehammer, and should be used only as a last resort.
+# [[overrides]]
+## Required: the root import path of the project being constrained
+# name = "github.com/user/project"
+## Optional: an alternate location (URL or import path) for the project's source
+# source = "https://github.com/myfork/package.git"
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+## Note: revision will depend on your repository type; git and hg have SHA1s,
+## bzr a 3-part id, svn a revision number.
+# revision = "abc123"
+
+## "required" lists a set of packages (not projects) that must be included in
+## Gopkg.lock. This has the same effect as directly importing a package, but
+## can be used to require "main" packages.
+# required = ["github.com/user/thing/cmd/thing"]
+
+## "ignored" lists a set of packages (not projects) that are ignored when
+## dep statically analyzes source code. Ignored packages can be in this project,
+## or in a dependency.
+# ignored = ["github.com/user/project/badpkg"]

--- a/cmd/dep/testdata/harness_tests/remove/specific/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/remove/specific/case1/final/Gopkg.toml
@@ -1,27 +1,5 @@
 
-## EXAMPLES & DOCS - safe to delete!
-#
-## Dependencies define constraints on how dependent projects should be
-## incorporated into Gopkg.lock. They are respected by dep whether
-## this project is the current project, or if it's a dependency.
-# [[dependencies]]
-## Required: the root import path of the project being constrained
-# name = "github.com/user/project"
-## Optional: an alternate location (URL or import path) for the project's source
-# source = "https://github.com/myfork/package.git"
-## Optional, but recommended: the version constraint to enforce for the project.
-## Only one of "branch", "version" or "revision" can be specified.
-# version = "1.0.0"
-# branch = "master"
-## Note: revision will depend on your repository type; git and hg have SHA1s,
-## bzr a 3-part id, svn a revision number.
-# revision = "abc123"
-#
-## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
-## all [[dependencies]] declarations from all projects. Only the current project's
-## [[overrides]] are applied.
-##
-## Overrides are a sledgehammer, and should be used only as a last resort.
+## EXAMPLE (these lines may be deleted)
 #
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
@@ -29,10 +7,52 @@
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
 #
+#
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
+#
+#
+# [[dependencies]]
+## Dependencies define constraints on dependent projects. They are respected by
+## dep whether coming from the Gopkg.toml of the current project or a dependency.
+#
+## Required: the root import path of the project being constrained.
+# name = "github.com/user/project"
+#
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+# revision = "abc123"
+#
+## Optional: an alternate location (URL or import path) for the project's source.
+# source = "https://github.com/myfork/package.git"
+#
+#
+# [[overrides]]
+## Overrides have the same structure as [[dependencies]], but supercede all
+## [[dependencies]] declarations from all projects. Only the current project's
+## [[overrides]] are applied.
+##
+## Overrides are a sledgehammer. Use them only as a last resort.
+#
+## Required: the root import path of the project being constrained.
+# name = "github.com/user/project"
+#
+## Optional: specifying a version constraint override will cause all other
+## constraints on this project to be ignored; only the overriden constraint
+## need be satisfied.
+## Again, only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+# revision = "abc123"
+#
+## Optional: specifying an alternate source location as an override will
+## enforce that the alternate location is used for that project, regardless of
+## what source location any dependent projects specify.
+# source = "https://github.com/myfork/package.git"
 
 
 

--- a/cmd/dep/testdata/harness_tests/remove/specific/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/remove/specific/case1/final/Gopkg.toml
@@ -1,15 +1,6 @@
 
-[[dependencies]]
-  name = "github.com/sdboyer/deptest"
-  version = ">=0.8.0, <1.0.0"
-
-[[dependencies]]
-  name = "github.com/sdboyer/deptestdos"
-  revision = "a0196baa11ea047dd65037287451d36b861b00ea"
-
-
 ## EXAMPLES & DOCS - safe to delete!
-
+#
 ## Dependencies define constraints on how dependent projects should be
 ## incorporated into Gopkg.lock. They are respected by dep whether
 ## this project is the current project, or if it's a dependency.
@@ -25,20 +16,30 @@
 ## Note: revision will depend on your repository type; git and hg have SHA1s,
 ## bzr a 3-part id, svn a revision number.
 # revision = "abc123"
-
+#
 ## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
 ## all [[dependencies]] declarations from all projects. Only the current project's
 ## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer, and should be used only as a last resort.
-
+#
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
 ## project. Use it when your project needs a package it doesn't explicitly import -
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
-
+#
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
+
+
+
+[[dependencies]]
+  name = "github.com/sdboyer/deptest"
+  version = ">=0.8.0, <1.0.0"
+
+[[dependencies]]
+  name = "github.com/sdboyer/deptestdos"
+  revision = "a0196baa11ea047dd65037287451d36b861b00ea"

--- a/cmd/dep/testdata/harness_tests/remove/specific/case2/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/remove/specific/case2/final/Gopkg.toml
@@ -1,27 +1,24 @@
 
-## EXAMPLE (these lines may be deleted)
-#
+## Gopkg.toml example (these lines may be deleted)
+
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
 ## project. Use it when your project needs a package it doesn't explicitly import -
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
-#
-#
+
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
-#
-#
-# [[dependencies]]
+
 ## Dependencies define constraints on dependent projects. They are respected by
 ## dep whether coming from the Gopkg.toml of the current project or a dependency.
-#
+# [[dependencies]]
 ## Required: the root import path of the project being constrained.
 # name = "github.com/user/project"
 #
-## Optional, but recommended: the version constraint to enforce for the project.
+## Recommended: the version constraint to enforce for the project.
 ## Only one of "branch", "version" or "revision" can be specified.
 # version = "1.0.0"
 # branch = "master"
@@ -29,15 +26,13 @@
 #
 ## Optional: an alternate location (URL or import path) for the project's source.
 # source = "https://github.com/myfork/package.git"
-#
-#
-# [[overrides]]
+
 ## Overrides have the same structure as [[dependencies]], but supercede all
 ## [[dependencies]] declarations from all projects. Only the current project's
 ## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer. Use them only as a last resort.
-#
+# [[overrides]]
 ## Required: the root import path of the project being constrained.
 # name = "github.com/user/project"
 #

--- a/cmd/dep/testdata/harness_tests/remove/specific/case2/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/remove/specific/case2/final/Gopkg.toml
@@ -7,6 +7,9 @@
   name = "github.com/sdboyer/deptestdos"
   revision = "a0196baa11ea047dd65037287451d36b861b00ea"
 
+
+## EXAMPLES & DOCS - safe to delete!
+
 ## Dependencies define constraints on how dependent projects should be
 ## incorporated into Gopkg.lock. They are respected by dep whether
 ## this project is the current project, or if it's a dependency.
@@ -23,27 +26,16 @@
 ## bzr a 3-part id, svn a revision number.
 # revision = "abc123"
 
-## Overrides have the same structure as [[dependencies]], but supercede all
-## [[dependencies]] declarations from all projects. However, only the current
-## project's overrides will apply.
+## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
+## all [[dependencies]] declarations from all projects. Only the current project's
+## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer, and should be used only as a last resort.
-# [[overrides]]
-## Required: the root import path of the project being constrained
-# name = "github.com/user/project"
-## Optional: an alternate location (URL or import path) for the project's source
-# source = "https://github.com/myfork/package.git"
-## Optional, but recommended: the version constraint to enforce for the project.
-## Only one of "branch", "version" or "revision" can be specified.
-# version = "1.0.0"
-# branch = "master"
-## Note: revision will depend on your repository type; git and hg have SHA1s,
-## bzr a 3-part id, svn a revision number.
-# revision = "abc123"
 
 ## "required" lists a set of packages (not projects) that must be included in
-## Gopkg.lock. This has the same effect as directly importing a package, but
-## can be used to require "main" packages.
+## Gopkg.lock. This list is merged with the set of packages imported by the current
+## project. Use it when your project needs a package it doesn't explicitly import -
+## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
 
 ## "ignored" lists a set of packages (not projects) that are ignored when

--- a/cmd/dep/testdata/harness_tests/remove/specific/case2/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/remove/specific/case2/final/Gopkg.toml
@@ -6,3 +6,47 @@
 [[dependencies]]
   name = "github.com/sdboyer/deptestdos"
   revision = "a0196baa11ea047dd65037287451d36b861b00ea"
+
+## Dependencies define constraints on how dependent projects should be
+## incorporated into Gopkg.lock. They are respected by dep whether
+## this project is the current project, or if it's a dependency.
+# [[dependencies]]
+## Required: the root import path of the project being constrained
+# name = "github.com/user/project"
+## Optional: an alternate location (URL or import path) for the project's source
+# source = "https://github.com/myfork/package.git"
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+## Note: revision will depend on your repository type; git and hg have SHA1s,
+## bzr a 3-part id, svn a revision number.
+# revision = "abc123"
+
+## Overrides have the same structure as [[dependencies]], but supercede all
+## [[dependencies]] declarations from all projects. However, only the current
+## project's overrides will apply.
+##
+## Overrides are a sledgehammer, and should be used only as a last resort.
+# [[overrides]]
+## Required: the root import path of the project being constrained
+# name = "github.com/user/project"
+## Optional: an alternate location (URL or import path) for the project's source
+# source = "https://github.com/myfork/package.git"
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+## Note: revision will depend on your repository type; git and hg have SHA1s,
+## bzr a 3-part id, svn a revision number.
+# revision = "abc123"
+
+## "required" lists a set of packages (not projects) that must be included in
+## Gopkg.lock. This has the same effect as directly importing a package, but
+## can be used to require "main" packages.
+# required = ["github.com/user/thing/cmd/thing"]
+
+## "ignored" lists a set of packages (not projects) that are ignored when
+## dep statically analyzes source code. Ignored packages can be in this project,
+## or in a dependency.
+# ignored = ["github.com/user/project/badpkg"]

--- a/cmd/dep/testdata/harness_tests/remove/specific/case2/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/remove/specific/case2/final/Gopkg.toml
@@ -1,27 +1,5 @@
 
-## EXAMPLES & DOCS - safe to delete!
-#
-## Dependencies define constraints on how dependent projects should be
-## incorporated into Gopkg.lock. They are respected by dep whether
-## this project is the current project, or if it's a dependency.
-# [[dependencies]]
-## Required: the root import path of the project being constrained
-# name = "github.com/user/project"
-## Optional: an alternate location (URL or import path) for the project's source
-# source = "https://github.com/myfork/package.git"
-## Optional, but recommended: the version constraint to enforce for the project.
-## Only one of "branch", "version" or "revision" can be specified.
-# version = "1.0.0"
-# branch = "master"
-## Note: revision will depend on your repository type; git and hg have SHA1s,
-## bzr a 3-part id, svn a revision number.
-# revision = "abc123"
-#
-## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
-## all [[dependencies]] declarations from all projects. Only the current project's
-## [[overrides]] are applied.
-##
-## Overrides are a sledgehammer, and should be used only as a last resort.
+## EXAMPLE (these lines may be deleted)
 #
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
@@ -29,10 +7,52 @@
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
 #
+#
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
+#
+#
+# [[dependencies]]
+## Dependencies define constraints on dependent projects. They are respected by
+## dep whether coming from the Gopkg.toml of the current project or a dependency.
+#
+## Required: the root import path of the project being constrained.
+# name = "github.com/user/project"
+#
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+# revision = "abc123"
+#
+## Optional: an alternate location (URL or import path) for the project's source.
+# source = "https://github.com/myfork/package.git"
+#
+#
+# [[overrides]]
+## Overrides have the same structure as [[dependencies]], but supercede all
+## [[dependencies]] declarations from all projects. Only the current project's
+## [[overrides]] are applied.
+##
+## Overrides are a sledgehammer. Use them only as a last resort.
+#
+## Required: the root import path of the project being constrained.
+# name = "github.com/user/project"
+#
+## Optional: specifying a version constraint override will cause all other
+## constraints on this project to be ignored; only the overriden constraint
+## need be satisfied.
+## Again, only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+# revision = "abc123"
+#
+## Optional: specifying an alternate source location as an override will
+## enforce that the alternate location is used for that project, regardless of
+## what source location any dependent projects specify.
+# source = "https://github.com/myfork/package.git"
 
 
 

--- a/cmd/dep/testdata/harness_tests/remove/specific/case2/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/remove/specific/case2/final/Gopkg.toml
@@ -1,15 +1,6 @@
 
-[[dependencies]]
-  name = "github.com/sdboyer/deptest"
-  version = ">=0.8.0, <1.0.0"
-
-[[dependencies]]
-  name = "github.com/sdboyer/deptestdos"
-  revision = "a0196baa11ea047dd65037287451d36b861b00ea"
-
-
 ## EXAMPLES & DOCS - safe to delete!
-
+#
 ## Dependencies define constraints on how dependent projects should be
 ## incorporated into Gopkg.lock. They are respected by dep whether
 ## this project is the current project, or if it's a dependency.
@@ -25,20 +16,30 @@
 ## Note: revision will depend on your repository type; git and hg have SHA1s,
 ## bzr a 3-part id, svn a revision number.
 # revision = "abc123"
-
+#
 ## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
 ## all [[dependencies]] declarations from all projects. Only the current project's
 ## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer, and should be used only as a last resort.
-
+#
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
 ## project. Use it when your project needs a package it doesn't explicitly import -
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
-
+#
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
+
+
+
+[[dependencies]]
+  name = "github.com/sdboyer/deptest"
+  version = ">=0.8.0, <1.0.0"
+
+[[dependencies]]
+  name = "github.com/sdboyer/deptestdos"
+  revision = "a0196baa11ea047dd65037287451d36b861b00ea"

--- a/cmd/dep/testdata/harness_tests/remove/unused/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/remove/unused/case1/final/Gopkg.toml
@@ -1,27 +1,24 @@
 
-## EXAMPLE (these lines may be deleted)
-#
+## Gopkg.toml example (these lines may be deleted)
+
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
 ## project. Use it when your project needs a package it doesn't explicitly import -
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
-#
-#
+
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
-#
-#
-# [[dependencies]]
+
 ## Dependencies define constraints on dependent projects. They are respected by
 ## dep whether coming from the Gopkg.toml of the current project or a dependency.
-#
+# [[dependencies]]
 ## Required: the root import path of the project being constrained.
 # name = "github.com/user/project"
 #
-## Optional, but recommended: the version constraint to enforce for the project.
+## Recommended: the version constraint to enforce for the project.
 ## Only one of "branch", "version" or "revision" can be specified.
 # version = "1.0.0"
 # branch = "master"
@@ -29,15 +26,13 @@
 #
 ## Optional: an alternate location (URL or import path) for the project's source.
 # source = "https://github.com/myfork/package.git"
-#
-#
-# [[overrides]]
+
 ## Overrides have the same structure as [[dependencies]], but supercede all
 ## [[dependencies]] declarations from all projects. Only the current project's
 ## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer. Use them only as a last resort.
-#
+# [[overrides]]
 ## Required: the root import path of the project being constrained.
 # name = "github.com/user/project"
 #

--- a/cmd/dep/testdata/harness_tests/remove/unused/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/remove/unused/case1/final/Gopkg.toml
@@ -7,6 +7,9 @@
   name = "github.com/sdboyer/deptestdos"
   revision = "a0196baa11ea047dd65037287451d36b861b00ea"
 
+
+## EXAMPLES & DOCS - safe to delete!
+
 ## Dependencies define constraints on how dependent projects should be
 ## incorporated into Gopkg.lock. They are respected by dep whether
 ## this project is the current project, or if it's a dependency.
@@ -23,27 +26,16 @@
 ## bzr a 3-part id, svn a revision number.
 # revision = "abc123"
 
-## Overrides have the same structure as [[dependencies]], but supercede all
-## [[dependencies]] declarations from all projects. However, only the current
-## project's overrides will apply.
+## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
+## all [[dependencies]] declarations from all projects. Only the current project's
+## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer, and should be used only as a last resort.
-# [[overrides]]
-## Required: the root import path of the project being constrained
-# name = "github.com/user/project"
-## Optional: an alternate location (URL or import path) for the project's source
-# source = "https://github.com/myfork/package.git"
-## Optional, but recommended: the version constraint to enforce for the project.
-## Only one of "branch", "version" or "revision" can be specified.
-# version = "1.0.0"
-# branch = "master"
-## Note: revision will depend on your repository type; git and hg have SHA1s,
-## bzr a 3-part id, svn a revision number.
-# revision = "abc123"
 
 ## "required" lists a set of packages (not projects) that must be included in
-## Gopkg.lock. This has the same effect as directly importing a package, but
-## can be used to require "main" packages.
+## Gopkg.lock. This list is merged with the set of packages imported by the current
+## project. Use it when your project needs a package it doesn't explicitly import -
+## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
 
 ## "ignored" lists a set of packages (not projects) that are ignored when

--- a/cmd/dep/testdata/harness_tests/remove/unused/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/remove/unused/case1/final/Gopkg.toml
@@ -6,3 +6,47 @@
 [[dependencies]]
   name = "github.com/sdboyer/deptestdos"
   revision = "a0196baa11ea047dd65037287451d36b861b00ea"
+
+## Dependencies define constraints on how dependent projects should be
+## incorporated into Gopkg.lock. They are respected by dep whether
+## this project is the current project, or if it's a dependency.
+# [[dependencies]]
+## Required: the root import path of the project being constrained
+# name = "github.com/user/project"
+## Optional: an alternate location (URL or import path) for the project's source
+# source = "https://github.com/myfork/package.git"
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+## Note: revision will depend on your repository type; git and hg have SHA1s,
+## bzr a 3-part id, svn a revision number.
+# revision = "abc123"
+
+## Overrides have the same structure as [[dependencies]], but supercede all
+## [[dependencies]] declarations from all projects. However, only the current
+## project's overrides will apply.
+##
+## Overrides are a sledgehammer, and should be used only as a last resort.
+# [[overrides]]
+## Required: the root import path of the project being constrained
+# name = "github.com/user/project"
+## Optional: an alternate location (URL or import path) for the project's source
+# source = "https://github.com/myfork/package.git"
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+## Note: revision will depend on your repository type; git and hg have SHA1s,
+## bzr a 3-part id, svn a revision number.
+# revision = "abc123"
+
+## "required" lists a set of packages (not projects) that must be included in
+## Gopkg.lock. This has the same effect as directly importing a package, but
+## can be used to require "main" packages.
+# required = ["github.com/user/thing/cmd/thing"]
+
+## "ignored" lists a set of packages (not projects) that are ignored when
+## dep statically analyzes source code. Ignored packages can be in this project,
+## or in a dependency.
+# ignored = ["github.com/user/project/badpkg"]

--- a/cmd/dep/testdata/harness_tests/remove/unused/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/remove/unused/case1/final/Gopkg.toml
@@ -1,27 +1,5 @@
 
-## EXAMPLES & DOCS - safe to delete!
-#
-## Dependencies define constraints on how dependent projects should be
-## incorporated into Gopkg.lock. They are respected by dep whether
-## this project is the current project, or if it's a dependency.
-# [[dependencies]]
-## Required: the root import path of the project being constrained
-# name = "github.com/user/project"
-## Optional: an alternate location (URL or import path) for the project's source
-# source = "https://github.com/myfork/package.git"
-## Optional, but recommended: the version constraint to enforce for the project.
-## Only one of "branch", "version" or "revision" can be specified.
-# version = "1.0.0"
-# branch = "master"
-## Note: revision will depend on your repository type; git and hg have SHA1s,
-## bzr a 3-part id, svn a revision number.
-# revision = "abc123"
-#
-## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
-## all [[dependencies]] declarations from all projects. Only the current project's
-## [[overrides]] are applied.
-##
-## Overrides are a sledgehammer, and should be used only as a last resort.
+## EXAMPLE (these lines may be deleted)
 #
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
@@ -29,10 +7,52 @@
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
 #
+#
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
+#
+#
+# [[dependencies]]
+## Dependencies define constraints on dependent projects. They are respected by
+## dep whether coming from the Gopkg.toml of the current project or a dependency.
+#
+## Required: the root import path of the project being constrained.
+# name = "github.com/user/project"
+#
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+# revision = "abc123"
+#
+## Optional: an alternate location (URL or import path) for the project's source.
+# source = "https://github.com/myfork/package.git"
+#
+#
+# [[overrides]]
+## Overrides have the same structure as [[dependencies]], but supercede all
+## [[dependencies]] declarations from all projects. Only the current project's
+## [[overrides]] are applied.
+##
+## Overrides are a sledgehammer. Use them only as a last resort.
+#
+## Required: the root import path of the project being constrained.
+# name = "github.com/user/project"
+#
+## Optional: specifying a version constraint override will cause all other
+## constraints on this project to be ignored; only the overriden constraint
+## need be satisfied.
+## Again, only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+# revision = "abc123"
+#
+## Optional: specifying an alternate source location as an override will
+## enforce that the alternate location is used for that project, regardless of
+## what source location any dependent projects specify.
+# source = "https://github.com/myfork/package.git"
 
 
 

--- a/cmd/dep/testdata/harness_tests/remove/unused/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/remove/unused/case1/final/Gopkg.toml
@@ -1,15 +1,6 @@
 
-[[dependencies]]
-  name = "github.com/sdboyer/deptest"
-  version = ">=0.8.0, <1.0.0"
-
-[[dependencies]]
-  name = "github.com/sdboyer/deptestdos"
-  revision = "a0196baa11ea047dd65037287451d36b861b00ea"
-
-
 ## EXAMPLES & DOCS - safe to delete!
-
+#
 ## Dependencies define constraints on how dependent projects should be
 ## incorporated into Gopkg.lock. They are respected by dep whether
 ## this project is the current project, or if it's a dependency.
@@ -25,20 +16,30 @@
 ## Note: revision will depend on your repository type; git and hg have SHA1s,
 ## bzr a 3-part id, svn a revision number.
 # revision = "abc123"
-
+#
 ## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
 ## all [[dependencies]] declarations from all projects. Only the current project's
 ## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer, and should be used only as a last resort.
-
+#
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
 ## project. Use it when your project needs a package it doesn't explicitly import -
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
-
+#
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
+
+
+
+[[dependencies]]
+  name = "github.com/sdboyer/deptest"
+  version = ">=0.8.0, <1.0.0"
+
+[[dependencies]]
+  name = "github.com/sdboyer/deptestdos"
+  revision = "a0196baa11ea047dd65037287451d36b861b00ea"

--- a/cmd/dep/testdata/harness_tests/status/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/status/case1/final/Gopkg.toml
@@ -1,27 +1,24 @@
 
-## EXAMPLE (these lines may be deleted)
-#
+## Gopkg.toml example (these lines may be deleted)
+
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
 ## project. Use it when your project needs a package it doesn't explicitly import -
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
-#
-#
+
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
-#
-#
-# [[dependencies]]
+
 ## Dependencies define constraints on dependent projects. They are respected by
 ## dep whether coming from the Gopkg.toml of the current project or a dependency.
-#
+# [[dependencies]]
 ## Required: the root import path of the project being constrained.
 # name = "github.com/user/project"
 #
-## Optional, but recommended: the version constraint to enforce for the project.
+## Recommended: the version constraint to enforce for the project.
 ## Only one of "branch", "version" or "revision" can be specified.
 # version = "1.0.0"
 # branch = "master"
@@ -29,15 +26,13 @@
 #
 ## Optional: an alternate location (URL or import path) for the project's source.
 # source = "https://github.com/myfork/package.git"
-#
-#
-# [[overrides]]
+
 ## Overrides have the same structure as [[dependencies]], but supercede all
 ## [[dependencies]] declarations from all projects. Only the current project's
 ## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer. Use them only as a last resort.
-#
+# [[overrides]]
 ## Required: the root import path of the project being constrained.
 # name = "github.com/user/project"
 #

--- a/cmd/dep/testdata/harness_tests/status/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/status/case1/final/Gopkg.toml
@@ -3,6 +3,9 @@
   name = "github.com/sdboyer/deptest"
   version = ">=0.8.0, <1.0.0"
 
+
+## EXAMPLES & DOCS - safe to delete!
+
 ## Dependencies define constraints on how dependent projects should be
 ## incorporated into Gopkg.lock. They are respected by dep whether
 ## this project is the current project, or if it's a dependency.
@@ -19,27 +22,16 @@
 ## bzr a 3-part id, svn a revision number.
 # revision = "abc123"
 
-## Overrides have the same structure as [[dependencies]], but supercede all
-## [[dependencies]] declarations from all projects. However, only the current
-## project's overrides will apply.
+## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
+## all [[dependencies]] declarations from all projects. Only the current project's
+## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer, and should be used only as a last resort.
-# [[overrides]]
-## Required: the root import path of the project being constrained
-# name = "github.com/user/project"
-## Optional: an alternate location (URL or import path) for the project's source
-# source = "https://github.com/myfork/package.git"
-## Optional, but recommended: the version constraint to enforce for the project.
-## Only one of "branch", "version" or "revision" can be specified.
-# version = "1.0.0"
-# branch = "master"
-## Note: revision will depend on your repository type; git and hg have SHA1s,
-## bzr a 3-part id, svn a revision number.
-# revision = "abc123"
 
 ## "required" lists a set of packages (not projects) that must be included in
-## Gopkg.lock. This has the same effect as directly importing a package, but
-## can be used to require "main" packages.
+## Gopkg.lock. This list is merged with the set of packages imported by the current
+## project. Use it when your project needs a package it doesn't explicitly import -
+## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
 
 ## "ignored" lists a set of packages (not projects) that are ignored when

--- a/cmd/dep/testdata/harness_tests/status/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/status/case1/final/Gopkg.toml
@@ -1,11 +1,6 @@
 
-[[dependencies]]
-  name = "github.com/sdboyer/deptest"
-  version = ">=0.8.0, <1.0.0"
-
-
 ## EXAMPLES & DOCS - safe to delete!
-
+#
 ## Dependencies define constraints on how dependent projects should be
 ## incorporated into Gopkg.lock. They are respected by dep whether
 ## this project is the current project, or if it's a dependency.
@@ -21,20 +16,26 @@
 ## Note: revision will depend on your repository type; git and hg have SHA1s,
 ## bzr a 3-part id, svn a revision number.
 # revision = "abc123"
-
+#
 ## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
 ## all [[dependencies]] declarations from all projects. Only the current project's
 ## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer, and should be used only as a last resort.
-
+#
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
 ## project. Use it when your project needs a package it doesn't explicitly import -
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
-
+#
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
+
+
+
+[[dependencies]]
+  name = "github.com/sdboyer/deptest"
+  version = ">=0.8.0, <1.0.0"

--- a/cmd/dep/testdata/harness_tests/status/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/status/case1/final/Gopkg.toml
@@ -1,27 +1,5 @@
 
-## EXAMPLES & DOCS - safe to delete!
-#
-## Dependencies define constraints on how dependent projects should be
-## incorporated into Gopkg.lock. They are respected by dep whether
-## this project is the current project, or if it's a dependency.
-# [[dependencies]]
-## Required: the root import path of the project being constrained
-# name = "github.com/user/project"
-## Optional: an alternate location (URL or import path) for the project's source
-# source = "https://github.com/myfork/package.git"
-## Optional, but recommended: the version constraint to enforce for the project.
-## Only one of "branch", "version" or "revision" can be specified.
-# version = "1.0.0"
-# branch = "master"
-## Note: revision will depend on your repository type; git and hg have SHA1s,
-## bzr a 3-part id, svn a revision number.
-# revision = "abc123"
-#
-## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
-## all [[dependencies]] declarations from all projects. Only the current project's
-## [[overrides]] are applied.
-##
-## Overrides are a sledgehammer, and should be used only as a last resort.
+## EXAMPLE (these lines may be deleted)
 #
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
@@ -29,10 +7,52 @@
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
 #
+#
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
+#
+#
+# [[dependencies]]
+## Dependencies define constraints on dependent projects. They are respected by
+## dep whether coming from the Gopkg.toml of the current project or a dependency.
+#
+## Required: the root import path of the project being constrained.
+# name = "github.com/user/project"
+#
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+# revision = "abc123"
+#
+## Optional: an alternate location (URL or import path) for the project's source.
+# source = "https://github.com/myfork/package.git"
+#
+#
+# [[overrides]]
+## Overrides have the same structure as [[dependencies]], but supercede all
+## [[dependencies]] declarations from all projects. Only the current project's
+## [[overrides]] are applied.
+##
+## Overrides are a sledgehammer. Use them only as a last resort.
+#
+## Required: the root import path of the project being constrained.
+# name = "github.com/user/project"
+#
+## Optional: specifying a version constraint override will cause all other
+## constraints on this project to be ignored; only the overriden constraint
+## need be satisfied.
+## Again, only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+# revision = "abc123"
+#
+## Optional: specifying an alternate source location as an override will
+## enforce that the alternate location is used for that project, regardless of
+## what source location any dependent projects specify.
+# source = "https://github.com/myfork/package.git"
 
 
 

--- a/cmd/dep/testdata/harness_tests/status/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/status/case1/final/Gopkg.toml
@@ -2,3 +2,47 @@
 [[dependencies]]
   name = "github.com/sdboyer/deptest"
   version = ">=0.8.0, <1.0.0"
+
+## Dependencies define constraints on how dependent projects should be
+## incorporated into Gopkg.lock. They are respected by dep whether
+## this project is the current project, or if it's a dependency.
+# [[dependencies]]
+## Required: the root import path of the project being constrained
+# name = "github.com/user/project"
+## Optional: an alternate location (URL or import path) for the project's source
+# source = "https://github.com/myfork/package.git"
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+## Note: revision will depend on your repository type; git and hg have SHA1s,
+## bzr a 3-part id, svn a revision number.
+# revision = "abc123"
+
+## Overrides have the same structure as [[dependencies]], but supercede all
+## [[dependencies]] declarations from all projects. However, only the current
+## project's overrides will apply.
+##
+## Overrides are a sledgehammer, and should be used only as a last resort.
+# [[overrides]]
+## Required: the root import path of the project being constrained
+# name = "github.com/user/project"
+## Optional: an alternate location (URL or import path) for the project's source
+# source = "https://github.com/myfork/package.git"
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+## Note: revision will depend on your repository type; git and hg have SHA1s,
+## bzr a 3-part id, svn a revision number.
+# revision = "abc123"
+
+## "required" lists a set of packages (not projects) that must be included in
+## Gopkg.lock. This has the same effect as directly importing a package, but
+## can be used to require "main" packages.
+# required = ["github.com/user/thing/cmd/thing"]
+
+## "ignored" lists a set of packages (not projects) that are ignored when
+## dep statically analyzes source code. Ignored packages can be in this project,
+## or in a dependency.
+# ignored = ["github.com/user/project/badpkg"]

--- a/testdata/txn_writer/expected_manifest.toml
+++ b/testdata/txn_writer/expected_manifest.toml
@@ -1,27 +1,24 @@
 
-## EXAMPLE (these lines may be deleted)
-#
+## Gopkg.toml example (these lines may be deleted)
+
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
 ## project. Use it when your project needs a package it doesn't explicitly import -
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
-#
-#
+
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
-#
-#
-# [[dependencies]]
+
 ## Dependencies define constraints on dependent projects. They are respected by
 ## dep whether coming from the Gopkg.toml of the current project or a dependency.
-#
+# [[dependencies]]
 ## Required: the root import path of the project being constrained.
 # name = "github.com/user/project"
 #
-## Optional, but recommended: the version constraint to enforce for the project.
+## Recommended: the version constraint to enforce for the project.
 ## Only one of "branch", "version" or "revision" can be specified.
 # version = "1.0.0"
 # branch = "master"
@@ -29,15 +26,13 @@
 #
 ## Optional: an alternate location (URL or import path) for the project's source.
 # source = "https://github.com/myfork/package.git"
-#
-#
-# [[overrides]]
+
 ## Overrides have the same structure as [[dependencies]], but supercede all
 ## [[dependencies]] declarations from all projects. Only the current project's
 ## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer. Use them only as a last resort.
-#
+# [[overrides]]
 ## Required: the root import path of the project being constrained.
 # name = "github.com/user/project"
 #

--- a/testdata/txn_writer/expected_manifest.toml
+++ b/testdata/txn_writer/expected_manifest.toml
@@ -1,11 +1,6 @@
 
-[[dependencies]]
-  name = "github.com/sdboyer/dep-test"
-  version = "1.0.0"
-
-
 ## EXAMPLES & DOCS - safe to delete!
-
+#
 ## Dependencies define constraints on how dependent projects should be
 ## incorporated into Gopkg.lock. They are respected by dep whether
 ## this project is the current project, or if it's a dependency.
@@ -21,20 +16,26 @@
 ## Note: revision will depend on your repository type; git and hg have SHA1s,
 ## bzr a 3-part id, svn a revision number.
 # revision = "abc123"
-
+#
 ## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
 ## all [[dependencies]] declarations from all projects. Only the current project's
 ## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer, and should be used only as a last resort.
-
+#
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
 ## project. Use it when your project needs a package it doesn't explicitly import -
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
-
+#
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
+
+
+
+[[dependencies]]
+  name = "github.com/sdboyer/dep-test"
+  version = "1.0.0"

--- a/testdata/txn_writer/expected_manifest.toml
+++ b/testdata/txn_writer/expected_manifest.toml
@@ -3,6 +3,9 @@
   name = "github.com/sdboyer/dep-test"
   version = "1.0.0"
 
+
+## EXAMPLES & DOCS - safe to delete!
+
 ## Dependencies define constraints on how dependent projects should be
 ## incorporated into Gopkg.lock. They are respected by dep whether
 ## this project is the current project, or if it's a dependency.
@@ -19,27 +22,16 @@
 ## bzr a 3-part id, svn a revision number.
 # revision = "abc123"
 
-## Overrides have the same structure as [[dependencies]], but supercede all
-## [[dependencies]] declarations from all projects. However, only the current
-## project's overrides will apply.
+## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
+## all [[dependencies]] declarations from all projects. Only the current project's
+## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer, and should be used only as a last resort.
-# [[overrides]]
-## Required: the root import path of the project being constrained
-# name = "github.com/user/project"
-## Optional: an alternate location (URL or import path) for the project's source
-# source = "https://github.com/myfork/package.git"
-## Optional, but recommended: the version constraint to enforce for the project.
-## Only one of "branch", "version" or "revision" can be specified.
-# version = "1.0.0"
-# branch = "master"
-## Note: revision will depend on your repository type; git and hg have SHA1s,
-## bzr a 3-part id, svn a revision number.
-# revision = "abc123"
 
 ## "required" lists a set of packages (not projects) that must be included in
-## Gopkg.lock. This has the same effect as directly importing a package, but
-## can be used to require "main" packages.
+## Gopkg.lock. This list is merged with the set of packages imported by the current
+## project. Use it when your project needs a package it doesn't explicitly import -
+## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
 
 ## "ignored" lists a set of packages (not projects) that are ignored when

--- a/testdata/txn_writer/expected_manifest.toml
+++ b/testdata/txn_writer/expected_manifest.toml
@@ -1,27 +1,5 @@
 
-## EXAMPLES & DOCS - safe to delete!
-#
-## Dependencies define constraints on how dependent projects should be
-## incorporated into Gopkg.lock. They are respected by dep whether
-## this project is the current project, or if it's a dependency.
-# [[dependencies]]
-## Required: the root import path of the project being constrained
-# name = "github.com/user/project"
-## Optional: an alternate location (URL or import path) for the project's source
-# source = "https://github.com/myfork/package.git"
-## Optional, but recommended: the version constraint to enforce for the project.
-## Only one of "branch", "version" or "revision" can be specified.
-# version = "1.0.0"
-# branch = "master"
-## Note: revision will depend on your repository type; git and hg have SHA1s,
-## bzr a 3-part id, svn a revision number.
-# revision = "abc123"
-#
-## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
-## all [[dependencies]] declarations from all projects. Only the current project's
-## [[overrides]] are applied.
-##
-## Overrides are a sledgehammer, and should be used only as a last resort.
+## EXAMPLE (these lines may be deleted)
 #
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
@@ -29,10 +7,52 @@
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
 #
+#
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
+#
+#
+# [[dependencies]]
+## Dependencies define constraints on dependent projects. They are respected by
+## dep whether coming from the Gopkg.toml of the current project or a dependency.
+#
+## Required: the root import path of the project being constrained.
+# name = "github.com/user/project"
+#
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+# revision = "abc123"
+#
+## Optional: an alternate location (URL or import path) for the project's source.
+# source = "https://github.com/myfork/package.git"
+#
+#
+# [[overrides]]
+## Overrides have the same structure as [[dependencies]], but supercede all
+## [[dependencies]] declarations from all projects. Only the current project's
+## [[overrides]] are applied.
+##
+## Overrides are a sledgehammer. Use them only as a last resort.
+#
+## Required: the root import path of the project being constrained.
+# name = "github.com/user/project"
+#
+## Optional: specifying a version constraint override will cause all other
+## constraints on this project to be ignored; only the overriden constraint
+## need be satisfied.
+## Again, only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+# revision = "abc123"
+#
+## Optional: specifying an alternate source location as an override will
+## enforce that the alternate location is used for that project, regardless of
+## what source location any dependent projects specify.
+# source = "https://github.com/myfork/package.git"
 
 
 

--- a/testdata/txn_writer/expected_manifest.toml
+++ b/testdata/txn_writer/expected_manifest.toml
@@ -2,3 +2,47 @@
 [[dependencies]]
   name = "github.com/sdboyer/dep-test"
   version = "1.0.0"
+
+## Dependencies define constraints on how dependent projects should be
+## incorporated into Gopkg.lock. They are respected by dep whether
+## this project is the current project, or if it's a dependency.
+# [[dependencies]]
+## Required: the root import path of the project being constrained
+# name = "github.com/user/project"
+## Optional: an alternate location (URL or import path) for the project's source
+# source = "https://github.com/myfork/package.git"
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+## Note: revision will depend on your repository type; git and hg have SHA1s,
+## bzr a 3-part id, svn a revision number.
+# revision = "abc123"
+
+## Overrides have the same structure as [[dependencies]], but supercede all
+## [[dependencies]] declarations from all projects. However, only the current
+## project's overrides will apply.
+##
+## Overrides are a sledgehammer, and should be used only as a last resort.
+# [[overrides]]
+## Required: the root import path of the project being constrained
+# name = "github.com/user/project"
+## Optional: an alternate location (URL or import path) for the project's source
+# source = "https://github.com/myfork/package.git"
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+## Note: revision will depend on your repository type; git and hg have SHA1s,
+## bzr a 3-part id, svn a revision number.
+# revision = "abc123"
+
+## "required" lists a set of packages (not projects) that must be included in
+## Gopkg.lock. This has the same effect as directly importing a package, but
+## can be used to require "main" packages.
+# required = ["github.com/user/thing/cmd/thing"]
+
+## "ignored" lists a set of packages (not projects) that are ignored when
+## dep statically analyzes source code. Ignored packages can be in this project,
+## or in a dependency.
+# ignored = ["github.com/user/project/badpkg"]

--- a/txn_writer.go
+++ b/txn_writer.go
@@ -22,29 +22,26 @@ import (
 // if no dependencies are found in the project
 // during `dep init`
 const exampleTOML = `
-## EXAMPLE (these lines may be deleted)
-#
+## Gopkg.toml example (these lines may be deleted)
+
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
 ## project. Use it when your project needs a package it doesn't explicitly import -
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
-#
-#
+
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
-#
-#
-# [[dependencies]]
+
 ## Dependencies define constraints on dependent projects. They are respected by
 ## dep whether coming from the Gopkg.toml of the current project or a dependency.
-#
+# [[dependencies]]
 ## Required: the root import path of the project being constrained.
 # name = "github.com/user/project"
 #
-## Optional, but recommended: the version constraint to enforce for the project.
+## Recommended: the version constraint to enforce for the project.
 ## Only one of "branch", "version" or "revision" can be specified.
 # version = "1.0.0"
 # branch = "master"
@@ -52,15 +49,13 @@ const exampleTOML = `
 #
 ## Optional: an alternate location (URL or import path) for the project's source.
 # source = "https://github.com/myfork/package.git"
-#
-#
-# [[overrides]]
+
 ## Overrides have the same structure as [[dependencies]], but supercede all
 ## [[dependencies]] declarations from all projects. Only the current project's
 ## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer. Use them only as a last resort.
-#
+# [[overrides]]
 ## Required: the root import path of the project being constrained.
 # name = "github.com/user/project"
 #

--- a/txn_writer.go
+++ b/txn_writer.go
@@ -22,9 +22,8 @@ import (
 // if no dependencies are found in the project
 // during `dep init`
 const exampleTOML = `
-
 ## EXAMPLES & DOCS - safe to delete!
-
+#
 ## Dependencies define constraints on how dependent projects should be
 ## incorporated into Gopkg.lock. They are respected by dep whether
 ## this project is the current project, or if it's a dependency.
@@ -40,23 +39,25 @@ const exampleTOML = `
 ## Note: revision will depend on your repository type; git and hg have SHA1s,
 ## bzr a 3-part id, svn a revision number.
 # revision = "abc123"
-
+#
 ## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
 ## all [[dependencies]] declarations from all projects. Only the current project's
 ## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer, and should be used only as a last resort.
-
+#
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
 ## project. Use it when your project needs a package it doesn't explicitly import -
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
-
+#
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
+
+
 `
 
 // SafeWriter transactionalizes writes of manifest, lock, and vendor dir, both
@@ -299,7 +300,6 @@ func (sw *SafeWriter) Write(root string, sm gps.SourceManager) error {
 
 	if sw.Payload.HasManifest() {
 		// Always write the example text to the bottom of the TOML file.
-		examples := []byte(exampleTOML)
 		tb, err := sw.Payload.Manifest.MarshalTOML()
 		if err != nil {
 			return errors.Wrap(err, "failed to marshal manifest to TOML")
@@ -307,7 +307,7 @@ func (sw *SafeWriter) Write(root string, sm gps.SourceManager) error {
 
 		// 0666 is before umask; mirrors behavior of os.Create (used by
 		// writeFile())
-		if err = ioutil.WriteFile(filepath.Join(td, ManifestName), append(tb, examples...), 0666); err != nil {
+		if err = ioutil.WriteFile(filepath.Join(td, ManifestName), append([]byte(exampleTOML), tb...), 0666); err != nil {
 			return errors.Wrap(err, "failed to write manifest file to temp dir")
 		}
 	}

--- a/txn_writer.go
+++ b/txn_writer.go
@@ -22,29 +22,7 @@ import (
 // if no dependencies are found in the project
 // during `dep init`
 const exampleTOML = `
-## EXAMPLES & DOCS - safe to delete!
-#
-## Dependencies define constraints on how dependent projects should be
-## incorporated into Gopkg.lock. They are respected by dep whether
-## this project is the current project, or if it's a dependency.
-# [[dependencies]]
-## Required: the root import path of the project being constrained
-# name = "github.com/user/project"
-## Optional: an alternate location (URL or import path) for the project's source
-# source = "https://github.com/myfork/package.git"
-## Optional, but recommended: the version constraint to enforce for the project.
-## Only one of "branch", "version" or "revision" can be specified.
-# version = "1.0.0"
-# branch = "master"
-## Note: revision will depend on your repository type; git and hg have SHA1s,
-## bzr a 3-part id, svn a revision number.
-# revision = "abc123"
-#
-## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
-## all [[dependencies]] declarations from all projects. Only the current project's
-## [[overrides]] are applied.
-##
-## Overrides are a sledgehammer, and should be used only as a last resort.
+## EXAMPLE (these lines may be deleted)
 #
 ## "required" lists a set of packages (not projects) that must be included in
 ## Gopkg.lock. This list is merged with the set of packages imported by the current
@@ -52,10 +30,52 @@ const exampleTOML = `
 ## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
 #
+#
 ## "ignored" lists a set of packages (not projects) that are ignored when
 ## dep statically analyzes source code. Ignored packages can be in this project,
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
+#
+#
+# [[dependencies]]
+## Dependencies define constraints on dependent projects. They are respected by
+## dep whether coming from the Gopkg.toml of the current project or a dependency.
+#
+## Required: the root import path of the project being constrained.
+# name = "github.com/user/project"
+#
+## Optional, but recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+# revision = "abc123"
+#
+## Optional: an alternate location (URL or import path) for the project's source.
+# source = "https://github.com/myfork/package.git"
+#
+#
+# [[overrides]]
+## Overrides have the same structure as [[dependencies]], but supercede all
+## [[dependencies]] declarations from all projects. Only the current project's
+## [[overrides]] are applied.
+##
+## Overrides are a sledgehammer. Use them only as a last resort.
+#
+## Required: the root import path of the project being constrained.
+# name = "github.com/user/project"
+#
+## Optional: specifying a version constraint override will cause all other
+## constraints on this project to be ignored; only the overriden constraint
+## need be satisfied.
+## Again, only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+# revision = "abc123"
+#
+## Optional: specifying an alternate source location as an override will
+## enforce that the alternate location is used for that project, regardless of
+## what source location any dependent projects specify.
+# source = "https://github.com/myfork/package.git"
 
 
 `

--- a/txn_writer.go
+++ b/txn_writer.go
@@ -22,6 +22,9 @@ import (
 // if no dependencies are found in the project
 // during `dep init`
 const exampleTOML = `
+
+## EXAMPLES & DOCS - safe to delete!
+
 ## Dependencies define constraints on how dependent projects should be
 ## incorporated into Gopkg.lock. They are respected by dep whether
 ## this project is the current project, or if it's a dependency.
@@ -38,27 +41,16 @@ const exampleTOML = `
 ## bzr a 3-part id, svn a revision number.
 # revision = "abc123"
 
-## Overrides have the same structure as [[dependencies]], but supercede all
-## [[dependencies]] declarations from all projects. However, only the current
-## project's overrides will apply.
+## [[overrides]] follow the exact same structure as [[dependencies]], but supercede
+## all [[dependencies]] declarations from all projects. Only the current project's
+## [[overrides]] are applied.
 ##
 ## Overrides are a sledgehammer, and should be used only as a last resort.
-# [[overrides]]
-## Required: the root import path of the project being constrained
-# name = "github.com/user/project"
-## Optional: an alternate location (URL or import path) for the project's source
-# source = "https://github.com/myfork/package.git"
-## Optional, but recommended: the version constraint to enforce for the project.
-## Only one of "branch", "version" or "revision" can be specified.
-# version = "1.0.0"
-# branch = "master"
-## Note: revision will depend on your repository type; git and hg have SHA1s,
-## bzr a 3-part id, svn a revision number.
-# revision = "abc123"
 
 ## "required" lists a set of packages (not projects) that must be included in
-## Gopkg.lock. This has the same effect as directly importing a package, but
-## can be used to require "main" packages.
+## Gopkg.lock. This list is merged with the set of packages imported by the current
+## project. Use it when your project needs a package it doesn't explicitly import -
+## including "main" packages.
 # required = ["github.com/user/thing/cmd/thing"]
 
 ## "ignored" lists a set of packages (not projects) that are ignored when


### PR DESCRIPTION
This expands the example text we add to `Gopkg.toml` to cover all valid values for the file.

It also changes the behavior of `dep init` to write out the example data unconditionally to the bottom of Gopkg.toml, rather than doing so only if nothing was to populate the manifest.

I'm not sure this latter part is the best idea, but being that there will be precious few situations under which we'd have an empty manifest (once init changes are done, #277), it seems worth being more aggressive about writing out these examples.

We could also add a flag to init that allows the user to suppress writing out the examples.