### PR TITLE
Implement new spec for init

### DIFF
--- a/cmd/dep/init.go
+++ b/cmd/dep/init.go
@@ -139,25 +139,28 @@ func (cmd *initCommand) Run(ctx *dep.Ctx, args []string) error {
 		)
 	}
 
+	// Run solver with project versions found on disk
 	internal.Vlogf("Solving...")
-	params := gps.SolveParameters{
-		RootDir:         root,
-		RootPackageTree: pkgT,
-		Manifest:        m,
-		Lock:            l,
-		ProjectAnalyzer: dep.Analyzer{},
-	}
-
-	if *verbose {
-		params.Trace = true
-		params.TraceLogger = log.New(os.Stderr, "", 0)
-	}
-	s, err := gps.Prepare(params, sm)
+	soln, err := getSolverSolution(root, pkgT, m, l, sm)
 	if err != nil {
-		return errors.Wrap(err, "prepare solver")
+		handleAllTheFailuresOfTheWorld(err)
+		return err
+	}
+	l = dep.LockFromInterface(soln)
+
+	// Pick notondisk project constraints from solution and add to manifest
+	for k, _ := range pd.notondisk {
+		for _, x := range l.Projects() {
+			if k == x.Ident().ProjectRoot {
+				m.Dependencies[k] = getProjectPropertiesFromVersion(x.Version())
+				break
+			}
+		}
 	}
 
-	soln, err := s.Solve()
+	// Run solver again with appropriate constraint solutions from previous run
+	// to generate the final lock.
+	soln, err = getSolverSolution(root, pkgT, m, l, sm)
 	if err != nil {
 		handleAllTheFailuresOfTheWorld(err)
 		return err
@@ -211,6 +214,43 @@ func hasImportPathPrefix(s, prefix string) bool {
 	return strings.HasPrefix(s, prefix+"/")
 }
 
+// getProjectPropertiesFromVersion takes a gps.Version and returns a proper
+// gps.ProjectProperties with Constraint value based on the version type.
+func getProjectPropertiesFromVersion(v gps.Version) gps.ProjectProperties {
+	pp := gps.ProjectProperties{}
+	switch v.Type() {
+	case gps.IsBranch, gps.IsVersion, gps.IsRevision:
+		pp.Constraint = v
+	case gps.IsSemver:
+		c, _ := gps.NewSemverConstraint("^" + v.String())
+		pp.Constraint = c
+	}
+
+	return pp
+}
+
+// getSolverSolution runs gps solver and returns a solution.
+func getSolverSolution(root string, pkgT pkgtree.PackageTree, m *dep.Manifest, l *dep.Lock, sm *gps.SourceMgr) (gps.Solution, error) {
+	params := gps.SolveParameters{
+		RootDir:         root,
+		RootPackageTree: pkgT,
+		Manifest:        m,
+		Lock:            l,
+		ProjectAnalyzer: dep.Analyzer{},
+	}
+
+	if *verbose {
+		params.Trace = true
+		params.TraceLogger = log.New(os.Stderr, "", 0)
+	}
+	s, err := gps.Prepare(params, sm)
+	if err != nil {
+		return nil, errors.Wrap(err, "prepare solver")
+	}
+
+	return s.Solve()
+}
+
 type projectData struct {
 	constraints  gps.ProjectConstraints          // constraints that could be found
 	dependencies map[gps.ProjectRoot][]string    // all dependencies (imports) found by project root
@@ -260,21 +300,12 @@ func getProjectData(ctx *dep.Ctx, pkgT pkgtree.PackageTree, cpr string, sm *gps.
 		v, err := ctx.VersionInWorkspace(pr)
 		if err != nil {
 			notondisk[pr] = true
-			internal.Vlogf("Could not determine version for %q, assuming version to be master", pr)
-			v = gps.Revision("master")
+			internal.Vlogf("Could not determine version for %q, omitting from generated manifest", pr)
+			continue
 		}
 
 		ondisk[pr] = v
-		pp := gps.ProjectProperties{}
-		switch v.Type() {
-		case gps.IsBranch, gps.IsVersion, gps.IsRevision:
-			pp.Constraint = v
-		case gps.IsSemver:
-			c, _ := gps.NewSemverConstraint("^" + v.String())
-			pp.Constraint = c
-		}
-
-		constraints[pr] = pp
+		constraints[pr] = getProjectPropertiesFromVersion(v)
 	}
 
 	internal.Vlogf("Analyzing transitive imports...")

--- a/cmd/dep/init.go
+++ b/cmd/dep/init.go
@@ -21,16 +21,14 @@ import (
 
 const initShortHelp = `Initialize a new project with manifest and lock files`
 const initLongHelp = `
-Initialize the project at filepath root by parsing its dependencies and writing
-manifest and lock files. If root isn't specified, use the current directory.
+Initialize the project at filepath root by parsing its dependencies, writing
+manifest and lock files, and vendoring the dependencies. If root isn't
+specified, use the current directory.
 
 The version of each dependency will reflect the current state of the GOPATH. If
-a dependency doesn't exist in the GOPATH, it won't be written to the manifest,
-but it will be solved-for, and will appear in the lock.
-
-Note: init may use the network to solve the dependency graph.
-
-Note: init does NOT vendor dependencies at the moment. See dep ensure.
+a dependency doesn't exist in the GOPATH, the network would be used to
+solve-for, and the solution will appear in manifest and lock. Solved
+dependencies will be vendored in vendor/ dir relative to project root.
 `
 
 func (cmd *initCommand) Name() string      { return "init" }

--- a/cmd/dep/init.go
+++ b/cmd/dep/init.go
@@ -139,32 +139,30 @@ func (cmd *initCommand) Run(ctx *dep.Ctx, args []string) error {
 		)
 	}
 
-	if len(pd.notondisk) > 0 {
-		internal.Vlogf("Solving...")
-		params := gps.SolveParameters{
-			RootDir:         root,
-			RootPackageTree: pkgT,
-			Manifest:        m,
-			Lock:            l,
-			ProjectAnalyzer: dep.Analyzer{},
-		}
-
-		if *verbose {
-			params.Trace = true
-			params.TraceLogger = log.New(os.Stderr, "", 0)
-		}
-		s, err := gps.Prepare(params, sm)
-		if err != nil {
-			return errors.Wrap(err, "prepare solver")
-		}
-
-		soln, err := s.Solve()
-		if err != nil {
-			handleAllTheFailuresOfTheWorld(err)
-			return err
-		}
-		l = dep.LockFromInterface(soln)
+	internal.Vlogf("Solving...")
+	params := gps.SolveParameters{
+		RootDir:         root,
+		RootPackageTree: pkgT,
+		Manifest:        m,
+		Lock:            l,
+		ProjectAnalyzer: dep.Analyzer{},
 	}
+
+	if *verbose {
+		params.Trace = true
+		params.TraceLogger = log.New(os.Stderr, "", 0)
+	}
+	s, err := gps.Prepare(params, sm)
+	if err != nil {
+		return errors.Wrap(err, "prepare solver")
+	}
+
+	soln, err := s.Solve()
+	if err != nil {
+		handleAllTheFailuresOfTheWorld(err)
+		return err
+	}
+	l = dep.LockFromInterface(soln)
 
 	internal.Vlogf("Writing manifest and lock files.")
 
@@ -262,8 +260,8 @@ func getProjectData(ctx *dep.Ctx, pkgT pkgtree.PackageTree, cpr string, sm *gps.
 		v, err := ctx.VersionInWorkspace(pr)
 		if err != nil {
 			notondisk[pr] = true
-			internal.Vlogf("Could not determine version for %q, omitting from generated manifest", pr)
-			continue
+			internal.Vlogf("Could not determine version for %q, assuming version to be master", pr)
+			v = gps.Revision("master")
 		}
 
 		ondisk[pr] = v

--- a/cmd/dep/init_test.go
+++ b/cmd/dep/init_test.go
@@ -40,41 +40,43 @@ func TestIsStdLib(t *testing.T) {
 
 func TestGetProjectPropertiesFromVersion(t *testing.T) {
 	cases := []struct {
-		version  gps.Version
-		expected gps.Version
+		version gps.Version
+		want    gps.Version
 	}{
 		{
-			version:  gps.NewBranch("foo-branch").Is("some-revision"),
-			expected: gps.NewBranch("foo-branch"),
+			version: gps.NewBranch("foo-branch"),
+			want:    gps.NewBranch("foo-branch"),
 		},
 		{
-			version:  gps.NewVersion("foo-version").Is("some-revision"),
-			expected: gps.NewVersion("foo-version"),
+			version: gps.NewVersion("foo-version"),
+			want:    gps.NewVersion("foo-version"),
 		},
 		{
-			version:  gps.Revision("alsjd934"),
-			expected: nil,
+			version: gps.NewBranch("foo-branch").Is("some-revision"),
+			want:    gps.NewBranch("foo-branch"),
 		},
-		// This fails. Hence, testing separately below.
-		// {
-		// 	version: gps.NewVersion("v1.0.0"),
-		// 	expected: gps.NewVersion("^1.0.0"),
-		// },
+		{
+			version: gps.NewVersion("foo-version").Is("some-revision"),
+			want:    gps.NewVersion("foo-version"),
+		},
+		{
+			version: gps.Revision("some-revision"),
+			want:    nil,
+		},
 	}
 
 	for _, c := range cases {
 		actualProp := getProjectPropertiesFromVersion(c.version)
-		if c.expected != actualProp.Constraint {
-			t.Fatalf("Expected %q to be equal to %q", actualProp.Constraint, c.expected)
+		if c.want != actualProp.Constraint {
+			t.Fatalf("Expected project property to be %v, got %v", actualProp.Constraint, c.want)
 		}
 	}
 
+	// Test to have caret in semver version
 	outsemver := getProjectPropertiesFromVersion(gps.NewVersion("v1.0.0"))
-	expectedSemver, _ := gps.NewSemverConstraint("^1.0.0")
-	// Comparing outsemver.Constraint and expectedSemver fails with error
-	// "comparing uncomparable type semver.rangeConstraint", although they have
-	// same value and same type "gps.semverConstraint" as per "reflect".
-	if outsemver.Constraint.String() != expectedSemver.String() {
-		t.Fatalf("Expected %q to be equal to %q", outsemver, expectedSemver)
+	wantSemver, _ := gps.NewSemverConstraint("^1.0.0")
+
+	if outsemver.Constraint.String() != wantSemver.String() {
+		t.Fatalf("Expected semver to be %v, got %v", outsemver.Constraint, wantSemver)
 	}
 }

--- a/cmd/dep/testdata/harness_tests/ensure/empty/case1/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/ensure/empty/case1/final/Gopkg.lock
@@ -1,4 +1,4 @@
-memo = "4b36ae008ef4be09dee7e2ae00606d44fd75f4310fd0d0ef6e744690290569de"
+memo = "14b07b05e0f01051b03887ab2bf80b516bc5510ea92f75f76c894b1745d8850c"
 
 [[projects]]
   name = "github.com/sdboyer/deptest"

--- a/cmd/dep/testdata/harness_tests/ensure/empty/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/ensure/empty/case1/final/Gopkg.toml
@@ -50,3 +50,7 @@
 # source = "https://github.com/myfork/package.git"
 
 
+
+[[dependencies]]
+  name = "github.com/sdboyer/deptest"
+  version = "^1.0.0"

--- a/cmd/dep/testdata/harness_tests/ensure/override/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/ensure/override/case1/final/Gopkg.toml
@@ -50,3 +50,7 @@
 # source = "https://github.com/myfork/package.git"
 
 
+
+[[dependencies]]
+  name = "github.com/sdboyer/deptest"
+  version = "^1.0.0"

--- a/cmd/dep/testdata/harness_tests/ensure/pkg-errors/case1/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/ensure/pkg-errors/case1/final/Gopkg.lock
@@ -1,1 +1,1 @@
-memo = ""
+memo = "ab4fef131ee828e96ba67d31a7d690bd5f2f42040c6766b1b12fe856f87e0ff7"

--- a/cmd/dep/testdata/harness_tests/init/case1/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/init/case1/final/Gopkg.lock
@@ -1,4 +1,4 @@
-memo = ""
+memo = "88d2718cda70cce45158f953d2c6ead79c1db38e67e9704aff72be8fddb096e7"
 
 [[projects]]
   name = "github.com/sdboyer/deptest"

--- a/cmd/dep/testdata/harness_tests/init/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/case1/final/Gopkg.toml
@@ -5,4 +5,3 @@
 
 [[dependencies]]
   name = "github.com/sdboyer/deptestdos"
-  revision = "a0196baa11ea047dd65037287451d36b861b00ea"

--- a/cmd/dep/testdata/harness_tests/init/case2/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/init/case2/final/Gopkg.lock
@@ -1,4 +1,4 @@
-memo = "88d2718cda70cce45158f953d2c6ead79c1db38e67e9704aff72be8fddb096e7"
+memo = "b4fe6e8bceac924197838b6ea47989abbdd3a8d31035d20ee0a1dabc0994c368"
 
 [[projects]]
   name = "github.com/sdboyer/deptest"

--- a/cmd/dep/testdata/harness_tests/init/case2/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/case2/final/Gopkg.toml
@@ -2,3 +2,7 @@
 [[dependencies]]
   name = "github.com/sdboyer/deptest"
   version = ">=0.8.0, <1.0.0"
+
+[[dependencies]]
+  name = "github.com/sdboyer/deptestdos"
+  version = "^2.0.0"

--- a/cmd/dep/testdata/harness_tests/init/case3/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/init/case3/final/Gopkg.lock
@@ -1,4 +1,4 @@
-memo = ""
+memo = "af9a783a5430dabcaaf44683c09e2b729e1c0d61f13bfdf6677c4fd0b41387ca"
 
 [[projects]]
   branch = "master"

--- a/cmd/dep/testdata/harness_tests/init/case3/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/case3/final/Gopkg.toml
@@ -5,4 +5,3 @@
 
 [[dependencies]]
   name = "github.com/sdboyer/deptestdos"
-  revision = "a0196baa11ea047dd65037287451d36b861b00ea"

--- a/cmd/dep/testdata/harness_tests/init/skip-hidden/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/init/skip-hidden/final/Gopkg.lock
@@ -1,4 +1,4 @@
-memo = "4b36ae008ef4be09dee7e2ae00606d44fd75f4310fd0d0ef6e744690290569de"
+memo = "14b07b05e0f01051b03887ab2bf80b516bc5510ea92f75f76c894b1745d8850c"
 
 [[projects]]
   name = "github.com/sdboyer/deptest"

--- a/cmd/dep/testdata/harness_tests/init/skip-hidden/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/skip-hidden/final/Gopkg.toml
@@ -1,0 +1,4 @@
+
+[[dependencies]]
+  name = "github.com/sdboyer/deptest"
+  version = "^1.0.0"


### PR DESCRIPTION
- Adds assuming project revision to be master when VersionInWorkspace
fails for not on disk projects. Failed projects were being skipped from
manifest before this change.
- Adds running solver once at init. This ensures creating an initial
lock with memo hash in lock file.

Fixes #356 and #149 