### PR TITLE
add codeclimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,10 @@
+engines:
+  gofmt:
+    enabled: true
+  govet:
+    enabled: true
+ratings:
+  paths:
+    - "**.go"
+exclude_paths:
+  - vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,14 @@ install:
 before_script:
   - PKGS=$(go list ./... | grep -v /vendor/)
   - go get -v honnef.co/go/tools/cmd/{gosimple,staticcheck}
+  - npm install -g codeclimate-test-reporter
 script:
   - go build -v ./cmd/dep
-  - go vet $PKGS
   - staticcheck $PKGS
   - gosimple $PKGS
-  - test -z "$(gofmt -s -l . 2>&1 | grep -v vendor/ | tee /dev/stderr)"
-  - go test -race $PKGS
+  - for pkg in $PKGS; do go test -race -coverprofile=profile.out -covermode=atomic $pkg; if [[ -f profile.out ]]; then cat profile.out >> coverage.txt; rm profile.out; fi; done
   - go build ./hack/licenseok
   - find . -path ./vendor -prune -o -type f -name "*.go" -printf '%P\n' | xargs ./licenseok
   - ./hack/validate-vendor.bash
+after_success:
+  - codeclimate-test-reporter < coverage.txt

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dep
 
-Linux: [![Build Status](https://travis-ci.org/golang/dep.svg?branch=master)](https://travis-ci.org/golang/dep) | Windows: [![Build status](https://ci.appveyor.com/api/projects/status/4pu2xnnrikol2gsf/branch/master?svg=true)](https://ci.appveyor.com/project/golang/dep/branch/master)
+Linux: [![Build Status](https://travis-ci.org/golang/dep.svg?branch=master)](https://travis-ci.org/golang/dep) | Windows: [![Build status](https://ci.appveyor.com/api/projects/status/4pu2xnnrikol2gsf/branch/master?svg=true)](https://ci.appveyor.com/project/golang/dep/branch/master) | [![Code Climate](https://codeclimate.com/github/golang/dep/badges/gpa.svg)](https://codeclimate.com/github/golang/dep)
 
 Dep is a prototype dependency management tool. It requires Go 1.7 or newer to compile.
 


### PR DESCRIPTION
So it looks like test coverage is only  Ruby, JavaScript, PHP, and Python from: https://docs.codeclimate.com/docs/setting-up-test-coverage

But we could use this for golint, gofmt, etc and then remove those from travis so it's faster and use codecov for coverage?