### PR TITLE
Update cached source before listing packages

### DIFF
--- a/gps/source.go
+++ b/gps/source.go
@@ -308,7 +308,7 @@ func (sg *sourceGateway) listPackages(ctx context.Context, pr ProjectRoot, v Ver
 		return ptree, nil
 	}
 
-	_, err = sg.require(ctx, sourceIsSetUp|sourceExistsLocally)
+	_, err = sg.require(ctx, sourceIsSetUp|sourceExistsLocally|sourceHasLatestLocally)
 	if err != nil {
 		return pkgtree.PackageTree{}, err
 	}


### PR DESCRIPTION
This addresses #484. It does fix the simple case that I was testing against, which I'm able to reliably repeat locally, though wasn't sure how to make this into an integration test because it relies on git shenanigans.

1. Create go package with a release and push it to github.

    ```golang
    package main
    
    import "fmt"

    func main() {
        fmt.Println("I'm a dependency!")
    }
    ```

2. Create a go package that imports this dependency and then run `dep init`. This populates the cache with the dependency.

    ```golang
    package main

    import _ "github.com/carolynvs/tmp1"

    func main () {}
    ```

    ```toml
    [[dependencies]]
    name = "github.com/carolynvs/tmp1"
    version = "2.0.2"
    ```

    ```toml
    [[projects]]
      name = "github.com/carolynvs/tmp1"
      packages = ["."]
      revision = "b3739bbc9944d9f4c82676e6b90ed161f0981351"
      version = "2.0.2"
    ```

3. Create another release of the dependency and push to github.
4. Edit the lock and manifest to update to the newest release. Note that this commit hash and tag are not in the local cache.

    ```toml
    [[dependencies]]
    name = "github.com/carolynvs/tmp1"
    version = "2.0.4"
    ```

    ```toml
    [[projects]]
      name = "github.com/carolynvs/tmp1"
      packages = ["."]
      revision = "5a5948420cfa7f3bdc2c54a9b0d31bfd19e0dede"
      version = "2.0.4"
    ```

4. Run `dep ensure -v -n` to reproduce the following error (with some debugging thrown in):
    ```
    $ dep ensure -n -v
    Root project is "foo"
     1 transitively valid internal packages
     1 external packages imported from 1 projects
    (0)   ✓ select (root)
    (1)	? attempt github.com/carolynvs/tmp1 with 1 pkgs; at least 1 versions to try
    (1)	    try github.com/carolynvs/tmp1@2.0.4
    === DEBUG: checkRequiredPackagesExist===
    === DEBUG: src.listpackages.sg.convertToRevision ===
    === DEBUG: sg.cache.toRevision -> 5a5948420cfa7f3bdc2c54a9b0d31bfd19e0dede ===
    (1)	✗   Unable to update checked out version: fatal: reference is not a tree: 5a5948420cfa7f3bdc2c54a9b0d31bfd19e0dede
    ```

What makes me pause is that I don't understand _why_ this isn't a more common bug considering my repo steps. If you can help me figure out why dep is working fine for most people without this, I'd really appreciate it!

If I understand correctly what dep is doing, getting a list of packages included in a dependency at a particular revision, and then having the latest source code seems like the correct fix. But again, I don't get why this isn't a problem for more people then? 😀 