### PR TITLE
Store version map in cache on success (instead of failure) to retrieve it.

### DIFF
--- a/gps/source.go
+++ b/gps/source.go
@@ -464,7 +464,7 @@ func (sg *sourceGateway) require(ctx context.Context, wanted sourceState) (errSt
 					return err
 				})
 
-				if err != nil {
+				if err == nil {
 					sg.cache.storeVersionMap(pvl, true)
 				}
 			case sourceHasLatestLocally:


### PR DESCRIPTION
Fixes #144.

I'm not sure how to add a test for this since the tests for `sourceGateway` assume git.