### PR TITLE
Dot import handling, improved trace errors

### DIFF
--- a/gps/pkgtree/pkgtree.go
+++ b/gps/pkgtree/pkgtree.go
@@ -465,7 +465,7 @@ func (t PackageTree) ToReachMap(main, tests, backprop bool, ignore map[string]bo
 		// For each import, decide whether it should be ignored, or if it
 		// belongs in the external or internal imports list.
 		for _, imp := range imps {
-			if ignore[imp] {
+			if ignore[imp] || imp == "." {
 				continue
 			}
 

--- a/gps/pkgtree/pkgtree_test.go
+++ b/gps/pkgtree/pkgtree_test.go
@@ -1895,6 +1895,25 @@ func TestToReachMapCycle(t *testing.T) {
 	}
 }
 
+func TestToReachMapFilterDot(t *testing.T) {
+	ptree, err := ListPackages(filepath.Join(getTestdataRootDir(t), "src", "relimport"), "relimport")
+	if err != nil {
+		t.Fatalf("ListPackages failed on relimport test case: %s", err)
+	}
+
+	rm, _ := ptree.ToReachMap(true, true, false, nil)
+	if _, has := rm["relimport/dot"]; !has {
+		t.Fatal("relimport/dot should not have had errors")
+	}
+
+	imports := dedupeStrings(rm["relimport/dot"].External, rm["relimport/dot"].Internal)
+	for _, imp := range imports {
+		if imp == "." {
+			t.Fatal("dot import should have been filtered by ToReachMap")
+		}
+	}
+}
+
 func getTestdataRootDir(t *testing.T) string {
 	cwd, err := os.Getwd()
 	if err != nil {


### PR DESCRIPTION
Fixes #399 - there was both an underlying bug (`"."` imports weren't discarded appropriately by `PackageTree.ToReachMap()`) and a logging error (certain errors coming back from `*solver.check()` weren't included in trace output).