### PR TITLE
Log stderr for unexpected integration test error

### DIFF
--- a/test/integration_testcase.go
+++ b/test/integration_testcase.go
@@ -138,7 +138,7 @@ func (tc *IntegrationTestCase) CompareError(err error, stderr string) {
 			tc.t.Errorf("expected error containing %s, got error %s", want, got)
 		}
 	} else if !wantExists && gotExists {
-		tc.t.Fatal("error raised where none was expected")
+		tc.t.Fatalf("error raised where none was expected: \n%v", stderr)
 	} else if wantExists && !gotExists {
 		tc.t.Error("error not raised where one was expected")
 	}


### PR DESCRIPTION
Logging unexpected errors would help in better failure visibility.