### PR TITLE
gps/solver - Remove SolveParameters.Trace

### DIFF
--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -123,7 +123,6 @@ func (cmd *ensureCommand) Run(ctx *dep.Ctx, args []string) error {
 
 	params := p.MakeParams()
 	if *verbose {
-		params.Trace = true
 		params.TraceLogger = log.New(os.Stderr, "", 0)
 	}
 	params.RootPackageTree, err = pkgtree.ListPackages(p.AbsRoot, string(p.ImportRoot))

--- a/cmd/dep/init.go
+++ b/cmd/dep/init.go
@@ -155,7 +155,6 @@ func (cmd *initCommand) Run(ctx *dep.Ctx, args []string) error {
 	}
 
 	if *verbose {
-		params.Trace = true
 		params.TraceLogger = log.New(os.Stderr, "", 0)
 	}
 	s, err := gps.Prepare(params, sm)

--- a/cmd/dep/prune.go
+++ b/cmd/dep/prune.go
@@ -63,7 +63,6 @@ func (cmd *pruneCommand) Run(ctx *dep.Ctx, args []string) error {
 	params.RootPackageTree = ptree
 
 	if *verbose {
-		params.Trace = true
 		params.TraceLogger = log.New(os.Stderr, "", 0)
 	}
 

--- a/cmd/dep/remove.go
+++ b/cmd/dep/remove.go
@@ -166,7 +166,6 @@ func (cmd *removeCommand) Run(ctx *dep.Ctx, args []string) error {
 	params.RootPackageTree = pkgT
 
 	if *verbose {
-		params.Trace = true
 		params.TraceLogger = log.New(os.Stderr, "", 0)
 	}
 	s, err := gps.Prepare(params, sm)

--- a/cmd/dep/status.go
+++ b/cmd/dep/status.go
@@ -256,7 +256,6 @@ func runStatusAll(out outputter, p *dep.Project, sm *gps.SourceMgr) error {
 		// Locks aren't a part of the input hash check, so we can omit it.
 	}
 	if *verbose {
-		params.Trace = true
 		params.TraceLogger = log.New(os.Stderr, "", 0)
 	}
 

--- a/gps/example.go
+++ b/gps/example.go
@@ -36,7 +36,6 @@ func main() {
 	// Set up params, including tracing
 	params := gps.SolveParameters{
 		RootDir:         root,
-		Trace:           true,
 		TraceLogger:     log.New(os.Stdout, "", 0),
 		ProjectAnalyzer: NaiveAnalyzer{},
 	}

--- a/gps/solve_test.go
+++ b/gps/solve_test.go
@@ -79,7 +79,6 @@ func fixSolve(params SolveParameters, sm SourceManager, t *testing.T) (Solution,
 	// Trace unconditionally; by passing the trace through t.Log(), the testing
 	// system will decide whether or not to actually show the output (based on
 	// -v, or selectively on test failure).
-	params.Trace = true
 	params.TraceLogger = log.New(testlogger{T: t}, "", 0)
 
 	s, err := Prepare(params, sm)
@@ -373,13 +372,6 @@ func TestBadSolveOpts(t *testing.T) {
 				},
 			},
 		},
-	}
-	params.Trace = true
-	_, err = Prepare(params, sm)
-	if err == nil {
-		t.Errorf("Should have errored on trace with no logger")
-	} else if !strings.Contains(err.Error(), "no logger provided") {
-		t.Error("Prepare should have given error on missing trace logger, but gave:", err)
 	}
 	params.TraceLogger = log.New(ioutil.Discard, "", 0)
 

--- a/gps/solver.go
+++ b/gps/solver.go
@@ -105,12 +105,9 @@ type SolveParameters struct {
 	// typical case.
 	Downgrade bool
 
-	// Trace controls whether the solver will generate informative trace output
-	// as it moves through the solving process.
-	Trace bool
-
-	// TraceLogger is the logger to use for generating trace output. If Trace is
-	// true but no logger is provided, solving will result in an error.
+	// TraceLogger is the logger to use for generating trace output. If set, the
+	// solver will generate informative trace output as it moves through the
+	// solving process.
 	TraceLogger *log.Logger
 }
 
@@ -122,7 +119,7 @@ type solver struct {
 	// starts moving forward again.
 	attempts int
 
-	// Logger used exclusively for trace output, if the trace option is set.
+	// Logger used exclusively for trace output, or nil to suppress.
 	tl *log.Logger
 
 	// A bridge to the standard SourceManager. The adapter does some local
@@ -280,9 +277,6 @@ func (params SolveParameters) toRootdata() (rootdata, error) {
 func Prepare(params SolveParameters, sm SourceManager) (Solver, error) {
 	if sm == nil {
 		return nil, badOptsFailure("must provide non-nil SourceManager")
-	}
-	if params.Trace && params.TraceLogger == nil {
-		return nil, badOptsFailure("trace requested, but no logger provided")
 	}
 
 	rd, err := params.toRootdata()


### PR DESCRIPTION
This change is a simplification with no effect on program behavior.
Originally discussed here: https://github.com/golang/dep/pull/525#discussion_r115111629

The `Trace` field looked like a switch to turn on trace logging, which required a nil validation check on `TraceLogger`. However, nil checking the logger is the actual mechanism that triggers logging internally, and the logger was passed along even if `Trace==false`, so `Trace` was really only a switch to turn on a nil check. All (7) usages set `TraceLogger` to the result of `log.New()` which is never nil, so the validation was not necessary, and omitting it does not otherwise change program behavior.