### PR TITLE
Add metadata to manifest & warn on unknown fields

### DIFF
--- a/manifest_test.go
+++ b/manifest_test.go
@@ -129,7 +129,15 @@ func TestValidateManifest(t *testing.T) {
 		{
 			tomlString: `
 			[[dependencies]]
-        name = "github.com/foo/bar"
+			  name = "github.com/foo/bar"
+			`,
+			want: []error{},
+		},
+		{
+			tomlString: `
+			[[metadata]]
+			  authors = "foo"
+			  version = "1.0.0"
 			`,
 			want: []error{},
 		},
@@ -158,7 +166,33 @@ func TestValidateManifest(t *testing.T) {
 			[[dependencies]]
 			  name = "github.com/foo/bar"
 			`,
-			want: []error{errors.New("metadata should consist of key-value pairs")},
+			want: []error{errors.New("metadata should be a TOML array of tables")},
+		},
+		{
+			tomlString: `
+			dependencies = "foo"
+			overrides = "bar"
+			`,
+			want: []error{
+				errors.New("dependencies should be a TOML array of tables"),
+				errors.New("overrides should be a TOML array of tables"),
+			},
+		},
+		{
+			tomlString: `
+			[[dependencies]]
+			  name = "github.com/foo/bar"
+			  location = "some-value"
+			  link = "some-other-value"
+
+			[[overrides]]
+			  nick = "foo"
+			`,
+			want: []error{
+				errors.New("Invalid key \"location\" in \"dependencies\""),
+				errors.New("Invalid key \"link\" in \"dependencies\""),
+				errors.New("Invalid key \"nick\" in \"overrides\""),
+			},
 		},
 	}
 

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -135,7 +135,7 @@ func TestValidateManifest(t *testing.T) {
 		},
 		{
 			tomlString: `
-			[[metadata]]
+			[metadata]
 			  authors = "foo"
 			  version = "1.0.0"
 			`,
@@ -166,7 +166,7 @@ func TestValidateManifest(t *testing.T) {
 			[[dependencies]]
 			  name = "github.com/foo/bar"
 			`,
-			want: []error{errors.New("metadata should be a TOML array of tables")},
+			want: []error{errors.New("metadata should be a TOML table")},
 		},
 		{
 			tomlString: `
@@ -184,6 +184,7 @@ func TestValidateManifest(t *testing.T) {
 			  name = "github.com/foo/bar"
 			  location = "some-value"
 			  link = "some-other-value"
+			  metadata = "foo"
 
 			[[overrides]]
 			  nick = "foo"
@@ -192,7 +193,18 @@ func TestValidateManifest(t *testing.T) {
 				errors.New("Invalid key \"location\" in \"dependencies\""),
 				errors.New("Invalid key \"link\" in \"dependencies\""),
 				errors.New("Invalid key \"nick\" in \"overrides\""),
+				errors.New("metadata in \"dependencies\" should be a TOML table"),
 			},
+		},
+		{
+			tomlString: `
+			[[dependencies]]
+			  name = "github.com/foo/bar"
+
+			  [dependencies.metadata]
+			    color = "blue"
+			`,
+			want: []error{},
 		},
 	}
 


### PR DESCRIPTION
- Use manifest buffer to create a map of TomlTree and find all the
unknown fields in the tree. Raise warnings for unknown fields.
- For "metadata" field, ensure it's of map type, else raise warning.

Fixes #506 