### PR TITLE
Show a clear error message when trying to 'dep init' in $GOPATH/src

### DIFF
--- a/context.go
+++ b/context.go
@@ -182,7 +182,7 @@ func (c *Ctx) SplitAbsoluteProjectRoot(path string) (string, error) {
 	srcprefix := filepath.Join(c.GOPATH, "src") + string(filepath.Separator)
 	if internal.HasFilepathPrefix(path, srcprefix) {
 		if len(path) <= len(srcprefix) {
-			return "", errors.New("projects directly within $GOPATH/src are not supported currently")
+			return "", errors.New("dep does not currently support using $GOPATH/src as the project root.")
 		}
 
 		// filepath.ToSlash because we're dealing with an import path now,

--- a/context.go
+++ b/context.go
@@ -182,7 +182,6 @@ func (c *Ctx) SplitAbsoluteProjectRoot(path string) (string, error) {
 	srcprefix := filepath.Join(c.GOPATH, "src") + string(filepath.Separator)
 	if internal.HasFilepathPrefix(path, srcprefix) {
 		if len(path) <= len(srcprefix) {
-			// the project is directly within $GOPATH/src
 			return "", errors.New("projects directly within $GOPATH/src are not supported currently")
 		}
 

--- a/context.go
+++ b/context.go
@@ -179,6 +179,10 @@ func (c *Ctx) resolveProjectRoot(path string) (string, error) {
 //
 // The second returned string indicates which GOPATH value was used.
 func (c *Ctx) SplitAbsoluteProjectRoot(path string) (string, error) {
+	if path == filepath.Join(c.GOPATH, "src") {
+		return "", errors.Errorf("Initializing a project in $GOPATH/src directly is not supported currently")
+	}
+
 	srcprefix := filepath.Join(c.GOPATH, "src") + string(filepath.Separator)
 	if internal.HasFilepathPrefix(path, srcprefix) {
 		// filepath.ToSlash because we're dealing with an import path now,

--- a/context.go
+++ b/context.go
@@ -181,8 +181,8 @@ func (c *Ctx) resolveProjectRoot(path string) (string, error) {
 func (c *Ctx) SplitAbsoluteProjectRoot(path string) (string, error) {
 	srcprefix := filepath.Join(c.GOPATH, "src") + string(filepath.Separator)
 	if internal.HasFilepathPrefix(path, srcprefix) {
-		// if path length is shorter than srcprefix then the project is directly within $GOPATH/src
-		if len(path) < len(srcprefix) {
+		if len(path) <= len(srcprefix) {
+			// the project is directly within $GOPATH/src
 			return "", errors.New("projects directly within $GOPATH/src are not supported currently")
 		}
 

--- a/context.go
+++ b/context.go
@@ -179,12 +179,13 @@ func (c *Ctx) resolveProjectRoot(path string) (string, error) {
 //
 // The second returned string indicates which GOPATH value was used.
 func (c *Ctx) SplitAbsoluteProjectRoot(path string) (string, error) {
-	if path == filepath.Join(c.GOPATH, "src") {
-		return "", errors.Errorf("Initializing a project in $GOPATH/src directly is not supported currently")
-	}
-
 	srcprefix := filepath.Join(c.GOPATH, "src") + string(filepath.Separator)
 	if internal.HasFilepathPrefix(path, srcprefix) {
+		// if path length is shorter than srcprefix then the project is directly within $GOPATH/src
+		if len(path) < len(srcprefix) {
+			return "", errors.New("projects directly within $GOPATH/src are not supported currently")
+		}
+
 		// filepath.ToSlash because we're dealing with an import path now,
 		// not an fs path
 		return filepath.ToSlash(path[len(srcprefix):]), nil

--- a/context_test.go
+++ b/context_test.go
@@ -58,10 +58,16 @@ func TestSplitAbsoluteProjectRoot(t *testing.T) {
 		}
 	}
 
-	// test where it should return error
-	got, err := depCtx.SplitAbsoluteProjectRoot("tra/la/la/la")
+	// test where it should return an error when directly within $GOPATH/src
+	got, err := depCtx.SplitAbsoluteProjectRoot(filepath.Join(depCtx.GOPATH, "src"))
 	if err == nil {
-		t.Fatalf("should have gotten error but did not for tra/la/la/la: %s", got)
+		t.Fatalf("should have gotten an error but did not for %s", got)
+	}
+
+	// test where it should return an error
+	got, err = depCtx.SplitAbsoluteProjectRoot("tra/la/la/la")
+	if err == nil {
+		t.Fatalf("should have gotten an error but did not for tra/la/la/la: %s", got)
 	}
 }
 

--- a/context_test.go
+++ b/context_test.go
@@ -60,8 +60,8 @@ func TestSplitAbsoluteProjectRoot(t *testing.T) {
 
 	// test where it should return an error when directly within $GOPATH/src
 	got, err := depCtx.SplitAbsoluteProjectRoot(filepath.Join(depCtx.GOPATH, "src"))
-	if err == nil {
-		t.Fatalf("should have gotten an error but did not for %s", got)
+	if err == nil || !strings.Contains(err.Error(), "$GOPATH/src") {
+		t.Fatalf("should have gotten an error for use directly in $GOPATH/src, but got %s", got)
 	}
 
 	// test where it should return an error


### PR DESCRIPTION
This should solve #471.

The panic was caused by line 186 trying to get a slice starting at larger index than the path string length:
```go
return filepath.ToSlash(path[len(srcprefix):]), nil
```
But `len(srcprefix)` will be larger than the length of `path` since it will include an additional `filepath.Separator`

I don't like the message honestly, but it's the best I could come up with currently. 😞 