### PR TITLE
gps, gps/pkgtree: remove DEPTESTBYPASS501 environment variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ matrix:
       go: tip
     - os: osx
       go: 1.8.x
-env:
-  # Flip bit to bypass tests - see dep#501 for more information
-  - DEPTESTBYPASS501=1
 install:
   - echo "This is an override of the default install deps step in travis."
 before_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,6 @@ clone_folder: c:\gopath\src\github.com\golang\dep
 
 environment:
   GOPATH: c:\gopath
-  DEPTESTBYPASS501: 1
   matrix:
     - environment:
       GOVERSION: 1.7.5

--- a/internal/gps/manager_test.go
+++ b/internal/gps/manager_test.go
@@ -846,12 +846,7 @@ func TestSupervisor(t *testing.T) {
 		t.Fatal("running call not recorded in map")
 	}
 
-	// TODO (kris-nova) We need to disable this bypass here, and in the .travis.yml
-	// as soon as dep#501 is fixed
-	bypass := os.Getenv("DEPTESTBYPASS501")
-	if bypass != "" {
-		t.Log("bypassing tc.count check for running ci")
-	} else if tc.count != 2 {
+	if tc.count != 2 {
 		t.Fatalf("wrong count of running ci: wanted 2 got %v", tc.count)
 	}
 	superv.mu.Unlock()

--- a/internal/gps/pkgtree/pkgtree_test.go
+++ b/internal/gps/pkgtree/pkgtree_test.go
@@ -1312,32 +1312,27 @@ func TestListPackages(t *testing.T) {
 					if !reflect.DeepEqual(out, fix.out) {
 						// TODO (kris-nova) We need to disable this bypass here, and in the .travis.yml
 						// as soon as dep#501 is fixed
-						bypass := os.Getenv("DEPTESTBYPASS501")
-						if bypass != "" {
-							t.Log("bypassing fix.out.Packages check < 2")
+						if len(fix.out.Packages) < 2 {
+							t.Errorf("Did not get expected PackageOrErrs:\n\t(GOT): %#v\n\t(WNT): %#v", out, fix.out)
 						} else {
-							if len(fix.out.Packages) < 2 {
-								t.Errorf("Did not get expected PackageOrErrs:\n\t(GOT): %#v\n\t(WNT): %#v", out, fix.out)
-							} else {
-								seen := make(map[string]bool)
-								for path, perr := range fix.out.Packages {
-									seen[path] = true
-									if operr, exists := out.Packages[path]; !exists {
-										t.Errorf("Expected PackageOrErr for path %s was missing from output:\n\t%s", path, perr)
-									} else {
-										if !reflect.DeepEqual(perr, operr) {
-											t.Errorf("PkgOrErr for path %s was not as expected:\n\t(GOT): %#v\n\t(WNT): %#v", path, operr, perr)
-										}
+							seen := make(map[string]bool)
+							for path, perr := range fix.out.Packages {
+								seen[path] = true
+								if operr, exists := out.Packages[path]; !exists {
+									t.Errorf("Expected PackageOrErr for path %s was missing from output:\n\t%s", path, perr)
+								} else {
+									if !reflect.DeepEqual(perr, operr) {
+										t.Errorf("PkgOrErr for path %s was not as expected:\n\t(GOT): %#v\n\t(WNT): %#v", path, operr, perr)
 									}
 								}
+							}
 
-								for path, operr := range out.Packages {
-									if seen[path] {
-										continue
-									}
-
-									t.Errorf("Got PackageOrErr for path %s, but none was expected:\n\t%s", path, operr)
+							for path, operr := range out.Packages {
+								if seen[path] {
+									continue
 								}
+
+								t.Errorf("Got PackageOrErr for path %s, but none was expected:\n\t%s", path, operr)
 							}
 						}
 					}


### PR DESCRIPTION
Fixes #501
Fixes #504

The underlying cause of the issue requiring the DEPTESTBYPASS501
workaround has been addressed. Remove DEPTESTBYPASS501 from test code
and CI config files.