### PR TITLE
Restore warning logging

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -27,7 +27,7 @@ func (a Analyzer) DeriveManifestAndLock(path string, n gps.ProjectRoot) (gps.Man
 	}
 	defer f.Close()
 
-	m, err := readManifest(f)
+	m, err := readManifest(f, &Loggers{})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -101,7 +101,7 @@ type ensureCommand struct {
 	overrides stringSlice
 }
 
-func (cmd *ensureCommand) Run(ctx *dep.Ctx, loggers *Loggers, args []string) error {
+func (cmd *ensureCommand) Run(ctx *dep.Ctx, loggers *dep.Loggers, args []string) error {
 	if cmd.examples {
 		loggers.Err.Println(strings.TrimSpace(ensureExamples))
 		return nil

--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -101,9 +101,9 @@ type ensureCommand struct {
 	overrides stringSlice
 }
 
-func (cmd *ensureCommand) Run(ctx *dep.Ctx, loggers *dep.Loggers, args []string) error {
+func (cmd *ensureCommand) Run(ctx *dep.Ctx, args []string) error {
 	if cmd.examples {
-		loggers.Err.Println(strings.TrimSpace(ensureExamples))
+		ctx.Loggers.Err.Println(strings.TrimSpace(ensureExamples))
 		return nil
 	}
 
@@ -120,8 +120,8 @@ func (cmd *ensureCommand) Run(ctx *dep.Ctx, loggers *dep.Loggers, args []string)
 	defer sm.Release()
 
 	params := p.MakeParams()
-	if loggers.Verbose {
-		params.TraceLogger = loggers.Err
+	if ctx.Loggers.Verbose {
+		params.TraceLogger = ctx.Loggers.Err
 	}
 	params.RootPackageTree, err = pkgtree.ListPackages(p.AbsRoot, string(p.ImportRoot))
 	if err != nil {
@@ -135,7 +135,7 @@ func (cmd *ensureCommand) Run(ctx *dep.Ctx, loggers *dep.Loggers, args []string)
 	if cmd.update {
 		applyUpdateArgs(args, &params)
 	} else {
-		err := applyEnsureArgs(loggers.Err, args, cmd.overrides, p, sm, &params)
+		err := applyEnsureArgs(ctx.Loggers.Err, args, cmd.overrides, p, sm, &params)
 		if err != nil {
 			return err
 		}
@@ -168,7 +168,7 @@ func (cmd *ensureCommand) Run(ctx *dep.Ctx, loggers *dep.Loggers, args []string)
 		return err
 	}
 	if cmd.dryRun {
-		return sw.PrintPreparedActions(loggers.Out)
+		return sw.PrintPreparedActions(ctx.Loggers.Out)
 	}
 
 	return errors.Wrap(sw.Write(p.AbsRoot, sm, true), "grouped write of manifest, lock and vendor")

--- a/cmd/dep/hash_in.go
+++ b/cmd/dep/hash_in.go
@@ -23,7 +23,7 @@ func (cmd *hashinCommand) Register(fs *flag.FlagSet) {}
 
 type hashinCommand struct{}
 
-func (hashinCommand) Run(ctx *dep.Ctx, loggers *Loggers, args []string) error {
+func (hashinCommand) Run(ctx *dep.Ctx, loggers *dep.Loggers, args []string) error {
 	p, err := ctx.LoadProject("")
 	if err != nil {
 		return err

--- a/cmd/dep/hash_in.go
+++ b/cmd/dep/hash_in.go
@@ -23,7 +23,7 @@ func (cmd *hashinCommand) Register(fs *flag.FlagSet) {}
 
 type hashinCommand struct{}
 
-func (hashinCommand) Run(ctx *dep.Ctx, loggers *dep.Loggers, args []string) error {
+func (hashinCommand) Run(ctx *dep.Ctx, args []string) error {
 	p, err := ctx.LoadProject("")
 	if err != nil {
 		return err
@@ -51,6 +51,6 @@ func (hashinCommand) Run(ctx *dep.Ctx, loggers *dep.Loggers, args []string) erro
 	if err != nil {
 		return errors.Wrap(err, "prepare solver")
 	}
-	loggers.Out.Println(gps.HashingInputsAsString(s))
+	ctx.Loggers.Out.Println(gps.HashingInputsAsString(s))
 	return nil
 }

--- a/cmd/dep/init.go
+++ b/cmd/dep/init.go
@@ -58,7 +58,7 @@ func trimPathPrefix(p1, p2 string) string {
 	return p1
 }
 
-func (cmd *initCommand) Run(ctx *dep.Ctx, loggers *Loggers, args []string) error {
+func (cmd *initCommand) Run(ctx *dep.Ctx, loggers *dep.Loggers, args []string) error {
 	if len(args) > 1 {
 		return errors.Errorf("too many args (%d)", len(args))
 	}
@@ -277,7 +277,7 @@ type projectData struct {
 	ondisk       map[gps.ProjectRoot]gps.Version // projects that were found on disk
 }
 
-func getProjectData(ctx *dep.Ctx, loggers *Loggers, pkgT pkgtree.PackageTree, cpr string, sm gps.SourceManager) (projectData, error) {
+func getProjectData(ctx *dep.Ctx, loggers *dep.Loggers, pkgT pkgtree.PackageTree, cpr string, sm gps.SourceManager) (projectData, error) {
 	constraints := make(gps.ProjectConstraints)
 	dependencies := make(map[gps.ProjectRoot][]string)
 	packages := make(map[string]bool)

--- a/cmd/dep/main.go
+++ b/cmd/dep/main.go
@@ -25,7 +25,7 @@ type command interface {
 	LongHelp() string       // "Foo the first bar meeting the following conditions..."
 	Register(*flag.FlagSet) // command-specific flags
 	Hidden() bool           // indicates whether the command should be hidden from help output
-	Run(*dep.Ctx, *Loggers, []string) error
+	Run(*dep.Ctx, *dep.Loggers, []string) error
 }
 
 func main() {
@@ -141,7 +141,7 @@ func (c *Config) Run() (exitCode int) {
 				return
 			}
 
-			loggers := &Loggers{
+			loggers := &dep.Loggers{
 				Out:     log.New(c.Stdout, "", 0),
 				Err:     errLogger,
 				Verbose: *verbose,

--- a/cmd/dep/main.go
+++ b/cmd/dep/main.go
@@ -25,7 +25,7 @@ type command interface {
 	LongHelp() string       // "Foo the first bar meeting the following conditions..."
 	Register(*flag.FlagSet) // command-specific flags
 	Hidden() bool           // indicates whether the command should be hidden from help output
-	Run(*dep.Ctx, *dep.Loggers, []string) error
+	Run(*dep.Ctx, []string) error
 }
 
 func main() {
@@ -148,7 +148,7 @@ func (c *Config) Run() (exitCode int) {
 			}
 
 			// Set up the dep context.
-			ctx, err := dep.NewContext(c.WorkingDir, c.Env)
+			ctx, err := dep.NewContext(c.WorkingDir, c.Env, loggers)
 			if err != nil {
 				loggers.Err.Println(err)
 				exitCode = 1
@@ -156,7 +156,7 @@ func (c *Config) Run() (exitCode int) {
 			}
 
 			// Run the command with the post-flag-processing args.
-			if err := cmd.Run(ctx, loggers, fs.Args()); err != nil {
+			if err := cmd.Run(ctx, fs.Args()); err != nil {
 				errLogger.Printf("%v\n", err)
 				exitCode = 1
 				return

--- a/cmd/dep/prune.go
+++ b/cmd/dep/prune.go
@@ -36,7 +36,7 @@ func (cmd *pruneCommand) Hidden() bool      { return false }
 func (cmd *pruneCommand) Register(fs *flag.FlagSet) {
 }
 
-func (cmd *pruneCommand) Run(ctx *dep.Ctx, loggers *dep.Loggers, args []string) error {
+func (cmd *pruneCommand) Run(ctx *dep.Ctx, args []string) error {
 	p, err := ctx.LoadProject("")
 	if err != nil {
 		return err
@@ -60,8 +60,8 @@ func (cmd *pruneCommand) Run(ctx *dep.Ctx, loggers *dep.Loggers, args []string) 
 	params := p.MakeParams()
 	params.RootPackageTree = ptree
 
-	if loggers.Verbose {
-		params.TraceLogger = loggers.Err
+	if ctx.Loggers.Verbose {
+		params.TraceLogger = ctx.Loggers.Err
 	}
 
 	s, err := gps.Prepare(params, sm)

--- a/cmd/dep/prune.go
+++ b/cmd/dep/prune.go
@@ -36,7 +36,7 @@ func (cmd *pruneCommand) Hidden() bool      { return false }
 func (cmd *pruneCommand) Register(fs *flag.FlagSet) {
 }
 
-func (cmd *pruneCommand) Run(ctx *dep.Ctx, loggers *Loggers, args []string) error {
+func (cmd *pruneCommand) Run(ctx *dep.Ctx, loggers *dep.Loggers, args []string) error {
 	p, err := ctx.LoadProject("")
 	if err != nil {
 		return err

--- a/cmd/dep/remove.go
+++ b/cmd/dep/remove.go
@@ -41,7 +41,7 @@ type removeCommand struct {
 	keepSource bool
 }
 
-func (cmd *removeCommand) Run(ctx *dep.Ctx, loggers *Loggers, args []string) error {
+func (cmd *removeCommand) Run(ctx *dep.Ctx, loggers *dep.Loggers, args []string) error {
 	p, err := ctx.LoadProject("")
 	if err != nil {
 		return err

--- a/cmd/dep/remove.go
+++ b/cmd/dep/remove.go
@@ -41,7 +41,7 @@ type removeCommand struct {
 	keepSource bool
 }
 
-func (cmd *removeCommand) Run(ctx *dep.Ctx, loggers *dep.Loggers, args []string) error {
+func (cmd *removeCommand) Run(ctx *dep.Ctx, args []string) error {
 	p, err := ctx.LoadProject("")
 	if err != nil {
 		return err
@@ -89,7 +89,7 @@ func (cmd *removeCommand) Run(ctx *dep.Ctx, loggers *dep.Loggers, args []string)
 				// not being able to detect the root for an import path that's
 				// actually in the import list is a deeper problem. However,
 				// it's not our direct concern here, so we just warn.
-				loggers.Err.Printf("dep: could not infer root for %q\n", pr)
+				ctx.Loggers.Err.Printf("dep: could not infer root for %q\n", pr)
 				continue
 			}
 			otherroots[pr] = true
@@ -104,7 +104,7 @@ func (cmd *removeCommand) Run(ctx *dep.Ctx, loggers *dep.Loggers, args []string)
 		}
 
 		if len(rm) == 0 {
-			loggers.Err.Println("dep: nothing to do")
+			ctx.Loggers.Err.Println("dep: nothing to do")
 			return nil
 		}
 	} else {
@@ -162,8 +162,8 @@ func (cmd *removeCommand) Run(ctx *dep.Ctx, loggers *dep.Loggers, args []string)
 	params := p.MakeParams()
 	params.RootPackageTree = pkgT
 
-	if loggers.Verbose {
-		params.TraceLogger = loggers.Err
+	if ctx.Loggers.Verbose {
+		params.TraceLogger = ctx.Loggers.Err
 	}
 	s, err := gps.Prepare(params, sm)
 	if err != nil {

--- a/cmd/dep/status.go
+++ b/cmd/dep/status.go
@@ -181,7 +181,7 @@ func (out *dotOutput) MissingHeader()                {}
 func (out *dotOutput) MissingLine(ms *MissingStatus) {}
 func (out *dotOutput) MissingFooter()                {}
 
-func (cmd *statusCommand) Run(ctx *dep.Ctx, loggers *Loggers, args []string) error {
+func (cmd *statusCommand) Run(ctx *dep.Ctx, loggers *dep.Loggers, args []string) error {
 	p, err := ctx.LoadProject("")
 	if err != nil {
 		return err
@@ -248,7 +248,7 @@ type MissingStatus struct {
 	MissingPackages []string
 }
 
-func runStatusAll(loggers *Loggers, out outputter, p *dep.Project, sm gps.SourceManager) error {
+func runStatusAll(loggers *dep.Loggers, out outputter, p *dep.Project, sm gps.SourceManager) error {
 	if p.Lock == nil {
 		// TODO if we have no lock file, do...other stuff
 		return nil

--- a/cmd/dep/status.go
+++ b/cmd/dep/status.go
@@ -181,7 +181,7 @@ func (out *dotOutput) MissingHeader()                {}
 func (out *dotOutput) MissingLine(ms *MissingStatus) {}
 func (out *dotOutput) MissingFooter()                {}
 
-func (cmd *statusCommand) Run(ctx *dep.Ctx, loggers *dep.Loggers, args []string) error {
+func (cmd *statusCommand) Run(ctx *dep.Ctx, args []string) error {
 	p, err := ctx.LoadProject("")
 	if err != nil {
 		return err
@@ -200,20 +200,20 @@ func (cmd *statusCommand) Run(ctx *dep.Ctx, loggers *dep.Loggers, args []string)
 		return errors.Errorf("not implemented")
 	case cmd.json:
 		out = &jsonOutput{
-			w: &logWriter{Logger: loggers.Out},
+			w: &logWriter{Logger: ctx.Loggers.Out},
 		}
 	case cmd.dot:
 		out = &dotOutput{
 			p: p,
 			o: cmd.output,
-			w: &logWriter{Logger: loggers.Out},
+			w: &logWriter{Logger: ctx.Loggers.Out},
 		}
 	default:
 		out = &tableOutput{
-			w: tabwriter.NewWriter(&logWriter{Logger: loggers.Out}, 0, 4, 2, ' ', 0),
+			w: tabwriter.NewWriter(&logWriter{Logger: ctx.Loggers.Out}, 0, 4, 2, ' ', 0),
 		}
 	}
-	return runStatusAll(loggers, out, p, sm)
+	return runStatusAll(ctx.Loggers, out, p, sm)
 }
 
 // A logWriter adapts a log.Logger to the io.Writer interface.

--- a/context.go
+++ b/context.go
@@ -145,7 +145,7 @@ func (c *Ctx) LoadProject(path string) (*Project, error) {
 	}
 	defer mf.Close()
 
-	p.Manifest, err = readManifest(mf)
+	p.Manifest, err = readManifest(mf, c.Loggers)
 	if err != nil {
 		return nil, errors.Errorf("error while parsing %s: %s", mp, err)
 	}

--- a/context.go
+++ b/context.go
@@ -21,12 +21,13 @@ type Ctx struct {
 	GOPATH     string   // Selected Go path
 	GOPATHS    []string // Other Go paths
 	WorkingDir string
+	Loggers    *Loggers
 }
 
 // NewContext creates a struct with the project's GOPATH. It assumes
 // that of your "GOPATH"'s we want the one we are currently in.
-func NewContext(wd string, env []string) (*Ctx, error) {
-	ctx := &Ctx{WorkingDir: wd}
+func NewContext(wd string, env []string, loggers *Loggers) (*Ctx, error) {
+	ctx := &Ctx{WorkingDir: wd, Loggers: loggers}
 
 	GOPATH := getEnv(env, "GOPATH")
 	if GOPATH == "" {

--- a/context_test.go
+++ b/context_test.go
@@ -28,7 +28,7 @@ func TestNewContextNoGOPATH(t *testing.T) {
 		t.Fatal("failed to get work directory:", err)
 	}
 
-	c, err := NewContext(wd, os.Environ())
+	c, err := NewContext(wd, os.Environ(), &Loggers{})
 	if err == nil {
 		t.Fatal("error should not have been nil")
 	}

--- a/loggers.go
+++ b/loggers.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package main
+package dep
 
 import "log"
 

--- a/manifest.go
+++ b/manifest.go
@@ -92,7 +92,7 @@ func validateManifest(s string) ([]error, error) {
 	return errs, nil
 }
 
-func readManifest(r io.Reader) (*Manifest, error) {
+func readManifest(r io.Reader, loggers *Loggers) (*Manifest, error) {
 	buf := &bytes.Buffer{}
 	_, err := buf.ReadFrom(r)
 	if err != nil {
@@ -100,14 +100,13 @@ func readManifest(r io.Reader) (*Manifest, error) {
 	}
 
 	// Validate manifest and log warnings
-	_, err = validateManifest(buf.String())
+	errs, err := validateManifest(buf.String())
 	if err != nil {
 		return nil, errors.Wrap(err, "Manifest validation failed")
 	}
-	//for _, e := range errs {
-	// FIXME(sdboyer) need to adapt this to use an injected *Loggers
-	//internal.Logf("WARNING: %v", e)
-	//}
+	for _, e := range errs {
+		loggers.Err.Printf("dep: WARNING: %v", e)
+	}
 
 	raw := rawManifest{}
 	err = toml.Unmarshal(buf.Bytes(), &raw)

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -20,7 +20,7 @@ func TestReadManifest(t *testing.T) {
 
 	mf := h.GetTestFile("manifest/golden.toml")
 	defer mf.Close()
-	got, err := readManifest(mf)
+	got, err := readManifest(mf, &Loggers{})
 	if err != nil {
 		t.Fatalf("Should have read Manifest correctly, but got err %q", err)
 	}
@@ -112,7 +112,7 @@ func TestReadManifestErrors(t *testing.T) {
 	for _, tst := range tests {
 		mf := h.GetTestFile(tst.file)
 		defer mf.Close()
-		_, err = readManifest(mf)
+		_, err = readManifest(mf, &Loggers{})
 		if err == nil {
 			t.Errorf("Reading manifest with %s should have caused error, but did not", tst.name)
 		} else if !strings.Contains(err.Error(), tst.name) {

--- a/project_test.go
+++ b/project_test.go
@@ -90,15 +90,16 @@ func TestSlashedGOPATH(t *testing.T) {
 		t.Fatal("failed to get work directory:", err)
 	}
 	env := os.Environ()
+	loggers := &Loggers{}
 
 	h.Setenv("GOPATH", filepath.ToSlash(h.Path(".")))
-	_, err = NewContext(wd, env)
+	_, err = NewContext(wd, env, loggers)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	h.Setenv("GOPATH", filepath.FromSlash(h.Path(".")))
-	_, err = NewContext(wd, env)
+	_, err = NewContext(wd, env, loggers)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test_project_context_test.go
+++ b/test_project_context_test.go
@@ -61,7 +61,7 @@ func (pc *TestProjectContext) Load() {
 	if pc.h.Exist(mp) {
 		mf := pc.h.GetFile(mp)
 		defer mf.Close()
-		m, err = readManifest(mf)
+		m, err = readManifest(mf, &Loggers{})
 		pc.h.Must(errors.Wrapf(err, "Unable to read manifest at %s", mp))
 	}
 	var l *Lock


### PR DESCRIPTION
- Move `loggers.go` out of cmd/dep to `dep` package.
- Remove injected `Loggers` from all the functions and use Loggers from `Ctx`
- Pass `Loggers` to `readManifest()` for warning logging.

Fixes #531 