### PR TITLE
Fix all gofmt lint errors

### DIFF
--- a/cmd/dep/init.go
+++ b/cmd/dep/init.go
@@ -172,7 +172,7 @@ func (cmd *initCommand) Run(ctx *dep.Ctx, loggers *Loggers, args []string) error
 	l = dep.LockFromInterface(soln)
 
 	// Pick notondisk project constraints from solution and add to manifest
-	for k, _ := range pd.notondisk {
+	for k := range pd.notondisk {
 		for _, x := range l.Projects() {
 			if k == x.Ident().ProjectRoot {
 				m.Dependencies[k] = getProjectPropertiesFromVersion(x.Version())

--- a/internal/gps/deduce_test.go
+++ b/internal/gps/deduce_test.go
@@ -33,7 +33,7 @@ func mkurl(s string) (u *url.URL) {
 }
 
 var pathDeductionFixtures = map[string][]pathDeductionFixture{
-	"github": []pathDeductionFixture{
+	"github": {
 		{
 			in:   "github.com/sdboyer/gps",
 			root: "github.com/sdboyer/gps",
@@ -126,7 +126,7 @@ var pathDeductionFixtures = map[string][]pathDeductionFixture{
 			},
 		},
 	},
-	"gopkg.in": []pathDeductionFixture{
+	"gopkg.in": {
 		{
 			in:   "gopkg.in/sdboyer/gps.v0",
 			root: "gopkg.in/sdboyer/gps.v0",
@@ -193,7 +193,7 @@ var pathDeductionFixtures = map[string][]pathDeductionFixture{
 			rerr: errors.New("gopkg.in/yaml.v1.2 is not a valid import path; gopkg.in only allows major versions (\"v1\" instead of \"v1.2\")"),
 		},
 	},
-	"jazz": []pathDeductionFixture{
+	"jazz": {
 		// IBM hub devops services - fixtures borrowed from go get
 		{
 			in:   "hub.jazz.net/git/user1/pkgname",
@@ -238,7 +238,7 @@ var pathDeductionFixtures = map[string][]pathDeductionFixture{
 			rerr: errors.New("hub.jazz.net/git/USER/pkgname is not a valid path for a source on hub.jazz.net"),
 		},
 	},
-	"bitbucket": []pathDeductionFixture{
+	"bitbucket": {
 		{
 			in:   "bitbucket.org/sdboyer/reporoot",
 			root: "bitbucket.org/sdboyer/reporoot",
@@ -309,7 +309,7 @@ var pathDeductionFixtures = map[string][]pathDeductionFixture{
 			srcerr: errors.New("git is not a valid scheme for accessing an hg repository"),
 		},
 	},
-	"launchpad": []pathDeductionFixture{
+	"launchpad": {
 		// tests for launchpad, mostly bazaar
 		// TODO(sdboyer) need more tests to deal w/launchpad's oddities
 		{
@@ -337,7 +337,7 @@ var pathDeductionFixtures = map[string][]pathDeductionFixture{
 			rerr: errors.New("launchpad.net/repo root is not a valid path for a source on launchpad.net"),
 		},
 	},
-	"git.launchpad": []pathDeductionFixture{
+	"git.launchpad": {
 		{
 			in:   "git.launchpad.net/reporoot",
 			root: "git.launchpad.net/reporoot",
@@ -363,7 +363,7 @@ var pathDeductionFixtures = map[string][]pathDeductionFixture{
 			rerr: errors.New("git.launchpad.net/repo root is not a valid path for a source on launchpad.net"),
 		},
 	},
-	"apache": []pathDeductionFixture{
+	"apache": {
 		{
 			in:   "git.apache.org/package-name.git",
 			root: "git.apache.org/package-name.git",
@@ -385,7 +385,7 @@ var pathDeductionFixtures = map[string][]pathDeductionFixture{
 			},
 		},
 	},
-	"vcsext": []pathDeductionFixture{
+	"vcsext": {
 		// VCS extension-based syntax
 		{
 			in:   "foobar.com/baz.git",
@@ -464,7 +464,7 @@ var pathDeductionFixtures = map[string][]pathDeductionFixture{
 			},
 		},
 	},
-	"vanity": []pathDeductionFixture{
+	"vanity": {
 		// Vanity imports
 		{
 			in:   "golang.org/x/exp",

--- a/internal/gps/hash_test.go
+++ b/internal/gps/hash_test.go
@@ -215,7 +215,7 @@ func TestHashInputsOverrides(t *testing.T) {
 				// corresponding project properties in the dependencies from
 				// root
 				rm.ovr = map[ProjectRoot]ProjectProperties{
-					"c": ProjectProperties{
+					"c": {
 						Source: "car",
 					},
 				}

--- a/internal/gps/manager_test.go
+++ b/internal/gps/manager_test.go
@@ -526,7 +526,7 @@ func TestMultiFetchThreadsafe(t *testing.T) {
 	projects := []ProjectIdentifier{
 		mkPI("github.com/sdboyer/gps"),
 		mkPI("github.com/sdboyer/gpkt"),
-		ProjectIdentifier{
+		{
 			ProjectRoot: ProjectRoot("github.com/sdboyer/gpkt"),
 			Source:      "https://github.com/sdboyer/gpkt",
 		},

--- a/internal/gps/pkgtree/pkgtree_test.go
+++ b/internal/gps/pkgtree/pkgtree_test.go
@@ -152,7 +152,7 @@ func TestWorkmapToReach(t *testing.T) {
 				},
 			},
 			em: map[string]*ProblemImportError{
-				"A": &ProblemImportError{
+				"A": {
 					ImportPath: "A",
 					Cause:      []string{"A/foo"},
 					Err:        missingPkgErr("A/foo"),
@@ -192,12 +192,12 @@ func TestWorkmapToReach(t *testing.T) {
 				},
 			},
 			em: map[string]*ProblemImportError{
-				"A": &ProblemImportError{
+				"A": {
 					ImportPath: "A",
 					Cause:      []string{"A/foo", "A/bar"},
 					Err:        missingPkgErr("A/bar"),
 				},
-				"A/foo": &ProblemImportError{
+				"A/foo": {
 					ImportPath: "A/foo",
 					Cause:      []string{"A/bar"},
 					Err:        missingPkgErr("A/bar"),
@@ -232,12 +232,12 @@ func TestWorkmapToReach(t *testing.T) {
 				},
 			},
 			em: map[string]*ProblemImportError{
-				"A": &ProblemImportError{
+				"A": {
 					ImportPath: "A",
 					Cause:      []string{"A/foo"},
 					Err:        fmt.Errorf("err pkg"),
 				},
-				"A/foo": &ProblemImportError{
+				"A/foo": {
 					ImportPath: "A/foo",
 					Err:        fmt.Errorf("err pkg"),
 				},
@@ -279,17 +279,17 @@ func TestWorkmapToReach(t *testing.T) {
 				},
 			},
 			em: map[string]*ProblemImportError{
-				"A": &ProblemImportError{
+				"A": {
 					ImportPath: "A",
 					Cause:      []string{"A/foo", "A/bar"},
 					Err:        fmt.Errorf("err pkg"),
 				},
-				"A/foo": &ProblemImportError{
+				"A/foo": {
 					ImportPath: "A/foo",
 					Cause:      []string{"A/bar"},
 					Err:        fmt.Errorf("err pkg"),
 				},
-				"A/bar": &ProblemImportError{
+				"A/bar": {
 					ImportPath: "A/bar",
 					Err:        fmt.Errorf("err pkg"),
 				},
@@ -340,7 +340,7 @@ func TestWorkmapToReach(t *testing.T) {
 				},
 			},
 			em: map[string]*ProblemImportError{
-				"A/bar": &ProblemImportError{
+				"A/bar": {
 					ImportPath: "A/bar",
 					Err:        fmt.Errorf("err pkg"),
 				},

--- a/internal/gps/solve_bimodal_test.go
+++ b/internal/gps/solve_bimodal_test.go
@@ -473,7 +473,7 @@ var bimodalFixtures = map[string]bimodalFixture{
 					f: &checkeeHasProblemPackagesFailure{
 						goal: mkAtom("a 1.0.0"),
 						failpkg: map[string]errDeppers{
-							"a/foo": errDeppers{
+							"a/foo": {
 								err: nil, // nil indicates package is missing
 								deppers: []atom{
 									mkAtom("root"),
@@ -935,7 +935,7 @@ var bimodalFixtures = map[string]bimodalFixture{
 					f: &checkeeHasProblemPackagesFailure{
 						goal: mkAtom("baz 1.0.0"),
 						failpkg: map[string]errDeppers{
-							"baz/qux": errDeppers{
+							"baz/qux": {
 								err: nil, // nil indicates package is missing
 								deppers: []atom{
 									mkAtom("root"),
@@ -976,7 +976,7 @@ var bimodalFixtures = map[string]bimodalFixture{
 					f: &checkeeHasProblemPackagesFailure{
 						goal: mkAtom("baz 1.0.0"),
 						failpkg: map[string]errDeppers{
-							"baz/qux": errDeppers{
+							"baz/qux": {
 								err: nil, // nil indicates package is missing
 								deppers: []atom{
 									mkAtom("root"),
@@ -1017,7 +1017,7 @@ var bimodalFixtures = map[string]bimodalFixture{
 					f: &checkeeHasProblemPackagesFailure{
 						goal: mkAtom("baz 1.0.0"),
 						failpkg: map[string]errDeppers{
-							"baz/qux": errDeppers{
+							"baz/qux": {
 								err: nil, // nil indicates package is missing
 								deppers: []atom{
 									mkAtom("root"),

--- a/internal/gps/source_test.go
+++ b/internal/gps/source_test.go
@@ -140,7 +140,7 @@ func testSourceGateway(t *testing.T) {
 			wantptree := pkgtree.PackageTree{
 				ImportRoot: "github.com/sdboyer/deptest",
 				Packages: map[string]pkgtree.PackageOrErr{
-					"github.com/sdboyer/deptest": pkgtree.PackageOrErr{
+					"github.com/sdboyer/deptest": {
 						P: pkgtree.Package{
 							ImportPath: "github.com/sdboyer/deptest",
 							Name:       "deptest",

--- a/internal/gps/strip_vendor_nonwindows_test.go
+++ b/internal/gps/strip_vendor_nonwindows_test.go
@@ -12,11 +12,11 @@ func TestStripVendorSymlinks(t *testing.T) {
 	t.Run("vendor symlink", stripVendorTestCase(fsTestCase{
 		before: filesystemState{
 			dirs: []fsPath{
-				fsPath{"package"},
-				fsPath{"package", "_vendor"},
+				{"package"},
+				{"package", "_vendor"},
 			},
 			links: []fsLink{
-				fsLink{
+				{
 					path: fsPath{"package", "vendor"},
 					to:   "_vendor",
 				},
@@ -24,8 +24,8 @@ func TestStripVendorSymlinks(t *testing.T) {
 		},
 		after: filesystemState{
 			dirs: []fsPath{
-				fsPath{"package"},
-				fsPath{"package", "_vendor"},
+				{"package"},
+				{"package", "_vendor"},
 			},
 		},
 	}))
@@ -33,11 +33,11 @@ func TestStripVendorSymlinks(t *testing.T) {
 	t.Run("nonvendor symlink", stripVendorTestCase(fsTestCase{
 		before: filesystemState{
 			dirs: []fsPath{
-				fsPath{"package"},
-				fsPath{"package", "_vendor"},
+				{"package"},
+				{"package", "_vendor"},
 			},
 			links: []fsLink{
-				fsLink{
+				{
 					path: fsPath{"package", "link"},
 					to:   "_vendor",
 				},
@@ -45,11 +45,11 @@ func TestStripVendorSymlinks(t *testing.T) {
 		},
 		after: filesystemState{
 			dirs: []fsPath{
-				fsPath{"package"},
-				fsPath{"package", "_vendor"},
+				{"package"},
+				{"package", "_vendor"},
 			},
 			links: []fsLink{
-				fsLink{
+				{
 					path: fsPath{"package", "link"},
 					to:   "_vendor",
 				},
@@ -60,10 +60,10 @@ func TestStripVendorSymlinks(t *testing.T) {
 	t.Run("vendor symlink to file", stripVendorTestCase(fsTestCase{
 		before: filesystemState{
 			files: []fsPath{
-				fsPath{"file"},
+				{"file"},
 			},
 			links: []fsLink{
-				fsLink{
+				{
 					path: fsPath{"vendor"},
 					to:   "file",
 				},
@@ -71,10 +71,10 @@ func TestStripVendorSymlinks(t *testing.T) {
 		},
 		after: filesystemState{
 			files: []fsPath{
-				fsPath{"file"},
+				{"file"},
 			},
 			links: []fsLink{
-				fsLink{
+				{
 					path: fsPath{"vendor"},
 					to:   "file",
 				},
@@ -85,14 +85,14 @@ func TestStripVendorSymlinks(t *testing.T) {
 	t.Run("chained symlinks", stripVendorTestCase(fsTestCase{
 		before: filesystemState{
 			dirs: []fsPath{
-				fsPath{"_vendor"},
+				{"_vendor"},
 			},
 			links: []fsLink{
-				fsLink{
+				{
 					path: fsPath{"vendor"},
 					to:   "vendor2",
 				},
-				fsLink{
+				{
 					path: fsPath{"vendor2"},
 					to:   "_vendor",
 				},
@@ -100,10 +100,10 @@ func TestStripVendorSymlinks(t *testing.T) {
 		},
 		after: filesystemState{
 			dirs: []fsPath{
-				fsPath{"_vendor"},
+				{"_vendor"},
 			},
 			links: []fsLink{
-				fsLink{
+				{
 					path: fsPath{"vendor2"},
 					to:   "_vendor",
 				},
@@ -114,14 +114,14 @@ func TestStripVendorSymlinks(t *testing.T) {
 	t.Run("circular symlinks", stripVendorTestCase(fsTestCase{
 		before: filesystemState{
 			dirs: []fsPath{
-				fsPath{"package"},
+				{"package"},
 			},
 			links: []fsLink{
-				fsLink{
+				{
 					path: fsPath{"package", "link1"},
 					to:   "link2",
 				},
-				fsLink{
+				{
 					path: fsPath{"package", "link2"},
 					to:   "link1",
 				},
@@ -129,14 +129,14 @@ func TestStripVendorSymlinks(t *testing.T) {
 		},
 		after: filesystemState{
 			dirs: []fsPath{
-				fsPath{"package"},
+				{"package"},
 			},
 			links: []fsLink{
-				fsLink{
+				{
 					path: fsPath{"package", "link1"},
 					to:   "link2",
 				},
-				fsLink{
+				{
 					path: fsPath{"package", "link2"},
 					to:   "link1",
 				},

--- a/internal/gps/strip_vendor_test.go
+++ b/internal/gps/strip_vendor_test.go
@@ -39,13 +39,13 @@ func TestStripVendorDirectory(t *testing.T) {
 	t.Run("vendor directory", stripVendorTestCase(fsTestCase{
 		before: filesystemState{
 			dirs: []fsPath{
-				fsPath{"package"},
-				fsPath{"package", "vendor"},
+				{"package"},
+				{"package", "vendor"},
 			},
 		},
 		after: filesystemState{
 			dirs: []fsPath{
-				fsPath{"package"},
+				{"package"},
 			},
 		},
 	}))
@@ -53,18 +53,18 @@ func TestStripVendorDirectory(t *testing.T) {
 	t.Run("vendor file", stripVendorTestCase(fsTestCase{
 		before: filesystemState{
 			dirs: []fsPath{
-				fsPath{"package"},
+				{"package"},
 			},
 			files: []fsPath{
-				fsPath{"package", "vendor"},
+				{"package", "vendor"},
 			},
 		},
 		after: filesystemState{
 			dirs: []fsPath{
-				fsPath{"package"},
+				{"package"},
 			},
 			files: []fsPath{
-				fsPath{"package", "vendor"},
+				{"package", "vendor"},
 			},
 		},
 	}))

--- a/internal/gps/strip_vendor_windows_test.go
+++ b/internal/gps/strip_vendor_windows_test.go
@@ -14,11 +14,11 @@ func TestStripVendorSymlinks(t *testing.T) {
 	t.Run("vendor symlink", stripVendorTestCase(fsTestCase{
 		before: filesystemState{
 			dirs: []fsPath{
-				fsPath{"package"},
-				fsPath{"package", "_vendor"},
+				{"package"},
+				{"package", "_vendor"},
 			},
 			links: []fsLink{
-				fsLink{
+				{
 					path: fsPath{"package", "vendor"},
 					to:   "_vendor",
 				},
@@ -26,11 +26,11 @@ func TestStripVendorSymlinks(t *testing.T) {
 		},
 		after: filesystemState{
 			dirs: []fsPath{
-				fsPath{"package"},
-				fsPath{"package", "_vendor"},
+				{"package"},
+				{"package", "_vendor"},
 			},
 			links: []fsLink{
-				fsLink{
+				{
 					path: fsPath{"package", "vendor"},
 					to:   "_vendor",
 				},
@@ -41,11 +41,11 @@ func TestStripVendorSymlinks(t *testing.T) {
 	t.Run("nonvendor symlink", stripVendorTestCase(fsTestCase{
 		before: filesystemState{
 			dirs: []fsPath{
-				fsPath{"package"},
-				fsPath{"package", "_vendor"},
+				{"package"},
+				{"package", "_vendor"},
 			},
 			links: []fsLink{
-				fsLink{
+				{
 					path: fsPath{"package", "link"},
 					to:   "_vendor",
 				},
@@ -53,11 +53,11 @@ func TestStripVendorSymlinks(t *testing.T) {
 		},
 		after: filesystemState{
 			dirs: []fsPath{
-				fsPath{"package"},
-				fsPath{"package", "_vendor"},
+				{"package"},
+				{"package", "_vendor"},
 			},
 			links: []fsLink{
-				fsLink{
+				{
 					path: fsPath{"package", "link"},
 					to:   "_vendor",
 				},
@@ -68,10 +68,10 @@ func TestStripVendorSymlinks(t *testing.T) {
 	t.Run("vendor symlink to file", stripVendorTestCase(fsTestCase{
 		before: filesystemState{
 			files: []fsPath{
-				fsPath{"file"},
+				{"file"},
 			},
 			links: []fsLink{
-				fsLink{
+				{
 					path: fsPath{"vendor"},
 					to:   "file",
 				},
@@ -79,10 +79,10 @@ func TestStripVendorSymlinks(t *testing.T) {
 		},
 		after: filesystemState{
 			files: []fsPath{
-				fsPath{"file"},
+				{"file"},
 			},
 			links: []fsLink{
-				fsLink{
+				{
 					path: fsPath{"vendor"},
 					to:   "file",
 				},
@@ -97,14 +97,14 @@ func TestStripVendorSymlinks(t *testing.T) {
 		// directory.
 		before: filesystemState{
 			dirs: []fsPath{
-				fsPath{"_vendor"},
+				{"_vendor"},
 			},
 			links: []fsLink{
-				fsLink{
+				{
 					path: fsPath{"vendor"},
 					to:   "vendor2",
 				},
-				fsLink{
+				{
 					path: fsPath{"vendor2"},
 					to:   "_vendor",
 				},
@@ -112,10 +112,10 @@ func TestStripVendorSymlinks(t *testing.T) {
 		},
 		after: filesystemState{
 			dirs: []fsPath{
-				fsPath{"_vendor"},
+				{"_vendor"},
 			},
 			links: []fsLink{
-				fsLink{
+				{
 					path: fsPath{"vendor2"},
 					to:   "_vendor",
 				},
@@ -126,14 +126,14 @@ func TestStripVendorSymlinks(t *testing.T) {
 	t.Run("circular symlinks", stripVendorTestCase(fsTestCase{
 		before: filesystemState{
 			dirs: []fsPath{
-				fsPath{"package"},
+				{"package"},
 			},
 			links: []fsLink{
-				fsLink{
+				{
 					path: fsPath{"package", "link1"},
 					to:   "link2",
 				},
-				fsLink{
+				{
 					path: fsPath{"package", "link2"},
 					to:   "link1",
 				},
@@ -141,14 +141,14 @@ func TestStripVendorSymlinks(t *testing.T) {
 		},
 		after: filesystemState{
 			dirs: []fsPath{
-				fsPath{"package"},
+				{"package"},
 			},
 			links: []fsLink{
-				fsLink{
+				{
 					path: fsPath{"package", "link1"},
 					to:   "link2",
 				},
-				fsLink{
+				{
 					path: fsPath{"package", "link2"},
 					to:   "link1",
 				},

--- a/vendor/github.com/Masterminds/semver/constraints_test.go
+++ b/vendor/github.com/Masterminds/semver/constraints_test.go
@@ -520,22 +520,22 @@ func TestUnionErr(t *testing.T) {
 
 func TestIsSuperset(t *testing.T) {
 	rc := []rangeConstraint{
-		rangeConstraint{
+		{
 			min:        newV(1, 2, 0),
 			max:        newV(2, 0, 0),
 			includeMin: true,
 		},
-		rangeConstraint{
+		{
 			min: newV(1, 2, 0),
 			max: newV(2, 1, 0),
 		},
-		rangeConstraint{
+		{
 			max: newV(1, 10, 0),
 		},
-		rangeConstraint{
+		{
 			min: newV(2, 0, 0),
 		},
-		rangeConstraint{
+		{
 			min:        newV(1, 2, 0),
 			max:        newV(2, 0, 0),
 			includeMax: true,

--- a/vendor/github.com/Masterminds/vcs/git.go
+++ b/vendor/github.com/Masterminds/vcs/git.go
@@ -366,7 +366,7 @@ func (s *GitRepo) Ping() bool {
 
 // EscapePathSeparator escapes the path separator by replacing it with several.
 // Note: this is harmless on Unix, and needed on Windows.
-func EscapePathSeparator(path string) (string) {
+func EscapePathSeparator(path string) string {
 	switch runtime.GOOS {
 	case `windows`:
 		// On Windows, triple all path separators.
@@ -379,7 +379,7 @@ func EscapePathSeparator(path string) (string) {
 		// used with --prefix, like this: --prefix=C:\foo\bar\ -> --prefix=C:\\\foo\\\bar\\\
 		return strings.Replace(path,
 			string(os.PathSeparator),
-			string(os.PathSeparator) + string(os.PathSeparator) + string(os.PathSeparator),
+			string(os.PathSeparator)+string(os.PathSeparator)+string(os.PathSeparator),
 			-1)
 	default:
 		return path
@@ -404,7 +404,7 @@ func (s *GitRepo) ExportDir(dir string) error {
 		return NewLocalError("Unable to create directory", err, "")
 	}
 
-	path = EscapePathSeparator( dir )
+	path = EscapePathSeparator(dir)
 	out, err := s.RunFromDir("git", "checkout-index", "-f", "-a", "--prefix="+path)
 	s.log(out)
 	if err != nil {
@@ -412,7 +412,7 @@ func (s *GitRepo) ExportDir(dir string) error {
 	}
 
 	// and now, the horror of submodules
-	path = EscapePathSeparator( dir + "$path" + string(os.PathSeparator) )
+	path = EscapePathSeparator(dir + "$path" + string(os.PathSeparator))
 	out, err = s.RunFromDir("git", "submodule", "foreach", "--recursive", "git checkout-index -f -a --prefix="+path)
 	s.log(out)
 	if err != nil {

--- a/vendor/github.com/Masterminds/vcs/git_test.go
+++ b/vendor/github.com/Masterminds/vcs/git_test.go
@@ -559,7 +559,6 @@ func TestGitSubmoduleHandling2(t *testing.T) {
 		t.Errorf("Current failed to detect Git on tip of master. Got version: %s", v)
 	}
 
-
 	tempDir2, err := ioutil.TempDir("", "go-vcs-git-tests-export")
 	if err != nil {
 		t.Fatalf("Error creating temp directory: %s", err)
@@ -583,7 +582,7 @@ func TestGitSubmoduleHandling2(t *testing.T) {
 		t.Errorf("Error checking exported file in Git: %s", err)
 	}
 
-	_, err = os.Stat(filepath.Join( filepath.Join(exportDir, "definitions"), "README.md"))
+	_, err = os.Stat(filepath.Join(filepath.Join(exportDir, "definitions"), "README.md"))
 	if err != nil {
 		t.Errorf("Error checking exported file in Git: %s", err)
 	}

--- a/vendor/github.com/pelletier/go-toml/marshal_test.go
+++ b/vendor/github.com/pelletier/go-toml/marshal_test.go
@@ -145,8 +145,8 @@ var docData = testDoc{
 		Second: &subdoc,
 	},
 	SubDocList: []testSubDoc{
-		testSubDoc{"List.First", 0},
-		testSubDoc{"List.Second", 0},
+		{"List.First", 0},
+		{"List.Second", 0},
 	},
 	SubDocPtrs: []*testSubDoc{&subdoc},
 }
@@ -504,7 +504,7 @@ var strPtr = []*string{&str1, &str2}
 var strPtr2 = []*[]*string{&strPtr}
 
 var nestedTestData = nestedMarshalTestStruct{
-	String:    [][]string{[]string{"Five", "Six"}, []string{"One", "Two"}},
+	String:    [][]string{{"Five", "Six"}, {"One", "Two"}},
 	StringPtr: &strPtr2,
 }
 

--- a/vendor/github.com/pelletier/go-toml/tomltree_create_test.go
+++ b/vendor/github.com/pelletier/go-toml/tomltree_create_test.go
@@ -1,9 +1,9 @@
 package toml
 
 import (
+	"strconv"
 	"testing"
 	"time"
-	"strconv"
 )
 
 type customString string
@@ -60,7 +60,7 @@ func TestTomlTreeCreateToTree(t *testing.T) {
 		},
 		"array":                 []string{"a", "b", "c"},
 		"array_uint":            []uint{uint(1), uint(2)},
-		"array_table":           []map[string]interface{}{map[string]interface{}{"sub_map": 52}},
+		"array_table":           []map[string]interface{}{{"sub_map": 52}},
 		"array_times":           []time.Time{time.Now(), time.Now()},
 		"map_times":             map[string]time.Time{"now": time.Now()},
 		"custom_string_map_key": map[customString]interface{}{customString("custom"): "custom"},
@@ -97,7 +97,7 @@ func TestTomlTreeCreateToTreeInvalidArrayMemberType(t *testing.T) {
 }
 
 func TestTomlTreeCreateToTreeInvalidTableGroupType(t *testing.T) {
-	_, err := TreeFromMap(map[string]interface{}{"foo": []map[string]interface{}{map[string]interface{}{"hello": t}}})
+	_, err := TreeFromMap(map[string]interface{}{"foo": []map[string]interface{}{{"hello": t}}})
 	expected := "cannot convert type *testing.T to TomlTree"
 	if err.Error() != expected {
 		t.Fatalf("expected error %s, got %s", expected, err.Error())

--- a/vendor/github.com/pelletier/go-toml/tomltree_write.go
+++ b/vendor/github.com/pelletier/go-toml/tomltree_write.go
@@ -4,11 +4,11 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
-	"reflect"
 )
 
 // encodes a string to a TOML-compliant string value


### PR DESCRIPTION
We're not enforcing them in CI yet.

See @sdboyer's comment on

https://github.com/golang/dep/pull/555#issuecomment-300765542

NOTE: This was all done with `gofmt`, I just typed:

```bash
gofmt -w -s -l $(go list ./... | grep -v /vendor/)
```