### PR TITLE
Integration Test Benchmarks

### DIFF
--- a/cmd/dep/integration_test.go
+++ b/cmd/dep/integration_test.go
@@ -21,25 +21,37 @@ func TestIntegration(t *testing.T) {
 	test.NeedsExternalNetwork(t)
 	test.NeedsGit(t)
 
-	filepath.Walk(filepath.Join("testdata", "harness_tests"), func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			t.Fatal("error walking filepath")
-		}
+	err := forEachTestCase(func(wd, testName string) {
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
 
-		wd, err := os.Getwd()
+			t.Run("external", testIntegration(testName, wd, true, execCmd))
+			t.Run("internal", testIntegration(testName, wd, false, runMain))
+		})
+	})
+	if err != nil {
+		t.Fatal("error walking filepath:", err)
+	}
+}
+
+// forEachTestCase executes testCaseFunc with the current working directory and path to
+// a `testcase.json` file, for each `testdata/harness_tests` test case.
+func forEachTestCase(testCaseFunc func(wd, path string)) error {
+	wd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+
+	return filepath.Walk(filepath.Join("testdata", "harness_tests"), func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			panic(err)
+			return err
 		}
 
 		if filepath.Base(path) == "testcase.json" {
 			parse := strings.Split(path, string(filepath.Separator))
 			testName := strings.Join(parse[2:len(parse)-1], "/")
-			t.Run(testName, func(t *testing.T) {
-				t.Parallel()
 
-				t.Run("external", testIntegration(testName, wd, true, execCmd))
-				t.Run("internal", testIntegration(testName, wd, false, runMain))
-			})
+			testCaseFunc(wd, testName)
 		}
 		return nil
 	})
@@ -87,7 +99,7 @@ func testIntegration(name, wd string, externalProc bool, run test.RunFunc) func(
 		// Set up environment
 		testCase := test.NewTestCase(t, name, wd)
 		defer testCase.Cleanup()
-		testProj := test.NewTestProject(t, testCase.InitialPath(), wd, externalProc, run)
+		testProj := test.NewTestProject(t, testCase.InitialPath(), wd, externalProc)
 		defer testProj.Cleanup()
 
 		// Create and checkout the vendor revisions
@@ -107,9 +119,76 @@ func testIntegration(name, wd string, externalProc bool, run test.RunFunc) func(
 
 		var err error
 		for i, args := range testCase.Commands {
-			err = testProj.DoRun(args)
+			err = testProj.DoRun(args, run)
 			if err != nil && i < len(testCase.Commands)-1 {
 				t.Fatalf("cmd %s raised an unexpected error: %s", args[0], err.Error())
+			}
+		}
+
+		// Check error raised in final command
+		testCase.CompareError(err, testProj.GetStderr())
+
+		// Check output
+		testCase.CompareOutput(testProj.GetStdout())
+
+		// Check final manifest and lock
+		testCase.CompareFile(dep.ManifestName, testProj.ProjPath(dep.ManifestName))
+		testCase.CompareFile(dep.LockName, testProj.ProjPath(dep.LockName))
+
+		// Check vendor paths
+		testProj.CompareImportPaths()
+		testCase.CompareVendorPaths(testProj.GetVendorPaths())
+	}
+}
+
+func BenchmarkIntegration(b *testing.B) {
+	err := forEachTestCase(func(wd, testName string) {
+		b.Run(testName, benchmarkIntegration(wd, testName))
+	})
+	if err != nil {
+		b.Fatal("error walking filepath:", err)
+	}
+}
+
+func benchmarkIntegration(wd, testName string) func(b *testing.B) {
+	return func(b *testing.B) {
+		// Set up environment
+		testCase := test.NewTestCase(b, testName, wd)
+		defer testCase.Cleanup()
+
+		testProj := test.NewTestProject(b, testCase.InitialPath(), wd, false)
+		defer testProj.Cleanup()
+
+		// Create and checkout the vendor revisions
+		for ip, rev := range testCase.VendorInitial {
+			testProj.GetVendorGit(ip)
+			testProj.RunGit(testProj.VendorPath(ip), "checkout", rev)
+		}
+
+		// Create and checkout the import revisions
+		for ip, rev := range testCase.GopathInitial {
+			testProj.RunGo("get", ip)
+			testProj.RunGit(testProj.Path("src", ip), "checkout", rev)
+		}
+
+		// Run commands
+		testProj.RecordImportPaths()
+
+		// Only measure the timing of calls to runMain.
+		b.StopTimer()
+		b.ResetTimer()
+		var err error
+		for i, args := range testCase.Commands {
+			// Execute DoRun, but measure only runMain.
+			err = testProj.DoRun(args, func(prog string, newargs []string, outW, errW io.Writer, dir string, env []string) error {
+				b.StartTimer()
+				err := runMain(prog, newargs, outW, errW, dir, env)
+				b.StopTimer()
+				return err
+
+			})
+			if err != nil && i < len(testCase.Commands)-1 {
+				b.Fatalf("cmd %s raised an unexpected error: %s", args[0], err.Error())
 			}
 		}
 

--- a/cmd/dep/remove_test.go
+++ b/cmd/dep/remove_test.go
@@ -28,7 +28,7 @@ func TestRemoveErrors(t *testing.T) {
 func removeErrors(name, wd string, externalProc bool, run test.RunFunc) func(*testing.T) {
 	return func(t *testing.T) {
 		testCase := test.NewTestCase(t, name, wd)
-		testProj := test.NewTestProject(t, testCase.InitialPath(), wd, externalProc, run)
+		testProj := test.NewTestProject(t, testCase.InitialPath(), wd, externalProc)
 		defer testProj.Cleanup()
 
 		// Create and checkout the vendor revisions
@@ -43,19 +43,19 @@ func removeErrors(name, wd string, externalProc bool, run test.RunFunc) func(*te
 			testProj.RunGit(testProj.Path("src", ip), "checkout", rev)
 		}
 
-		if err := testProj.DoRun([]string{"remove", "-unused", "github.com/not/used"}); err == nil {
+		if err := testProj.DoRun([]string{"remove", "-unused", "github.com/not/used"}, run); err == nil {
 			t.Fatal("rm with both -unused and arg should have failed")
 		}
 
-		if err := testProj.DoRun([]string{"remove", "github.com/not/present"}); err == nil {
+		if err := testProj.DoRun([]string{"remove", "github.com/not/present"}, run); err == nil {
 			t.Fatal("rm with arg not in manifest should have failed")
 		}
 
-		if err := testProj.DoRun([]string{"remove", "github.com/not/used", "github.com/not/present"}); err == nil {
+		if err := testProj.DoRun([]string{"remove", "github.com/not/used", "github.com/not/present"}, run); err == nil {
 			t.Fatal("rm with one arg not in manifest should have failed")
 		}
 
-		if err := testProj.DoRun([]string{"remove", "github.com/sdboyer/deptest"}); err == nil {
+		if err := testProj.DoRun([]string{"remove", "github.com/sdboyer/deptest"}, run); err == nil {
 			t.Fatal("rm of arg in manifest and imports should have failed without -force")
 		}
 	}


### PR DESCRIPTION
This change adds benchmarks for the in-process integration test cases. Here is an example execution:

```
BenchmarkIntegration/ensure/empty/case1-4         	       1	2270968333 ns/op
BenchmarkIntegration/ensure/empty/case2-4         	       1	1059966456 ns/op
BenchmarkIntegration/ensure/empty/case3-4         	       1	1092412167 ns/op
BenchmarkIntegration/ensure/override/case1-4      	       1	1669498530 ns/op
BenchmarkIntegration/ensure/pkg-errors/case1-4    	2000000000	         0.00 ns/op
BenchmarkIntegration/ensure/update/case1-4        	       1	2178060316 ns/op
BenchmarkIntegration/ensure/update/case2-4        	       1	2308889406 ns/op
BenchmarkIntegration/init/case1-4                 	       1	1550706487 ns/op
BenchmarkIntegration/init/case2-4                 	       1	1210377305 ns/op
BenchmarkIntegration/init/case3-4                 	       1	1249999250 ns/op
BenchmarkIntegration/init/manifest-exists-4       	2000000000	         0.00 ns/op
BenchmarkIntegration/init/skip-hidden-4           	       1	1073756377 ns/op
BenchmarkIntegration/remove/force/case1-4         	       1	1374232234 ns/op
BenchmarkIntegration/remove/specific/case1-4      	       1	1288340159 ns/op
BenchmarkIntegration/remove/specific/case2-4      	       1	1100542801 ns/op
BenchmarkIntegration/remove/unused/case1-4        	       1	1238545492 ns/op
BenchmarkIntegration/status/case1/dot-4           	       1	3104462186 ns/op
BenchmarkIntegration/status/case1/json-4          	       1	3085201266 ns/op
BenchmarkIntegration/status/case1/table-4         	       1	3166151319 ns/op
PASS
ok  	github.com/golang/dep/cmd/dep	36.556s
```

Using built-in benchmarking at this high of a level seems a bit silly, but it was simple to adapt the existing integration testing structure with the `testing.TB` interface. I'm happy to evolve this into something more customized if that makes sense.