### PR TITLE
Improve IsNonEmptyDir - use File.Readdirnames

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -42,11 +42,23 @@ func IsNonEmptyDir(name string) (bool, error) {
 		return isDir, err
 	}
 
-	files, err := ioutil.ReadDir(name)
+	// Get file descriptor
+	f, err := os.Open(name)
 	if err != nil {
 		return false, err
 	}
-	return len(files) != 0, nil
+	defer f.Close()
+
+	// Query only 1 child. EOF if no children.
+	_, err = f.Readdirnames(1)
+	switch err {
+	case io.EOF:
+		return false, nil
+	case nil:
+		return true, nil
+	default:
+		return false, err
+	}
 }
 
 func writeFile(path string, in toml.Marshaler) error {


### PR DESCRIPTION
- IsNonEmptyDir() uses ioutil.ReadDir() which collects all the files in
the directory, sorts and obtains FileInfo structs before returning.
- File.Readdirnames() fetches only the requested number of children and
returns. No extra calls.