### PR TITLE
dep init - support relative path 

### DIFF
--- a/cmd/dep/init.go
+++ b/cmd/dep/init.go
@@ -69,6 +69,12 @@ func (cmd *initCommand) Run(ctx *dep.Ctx, args []string) error {
 		root = ctx.WorkingDir
 	} else {
 		root = args[0]
+		if !filepath.IsAbs(args[0]) {
+			root = filepath.Join(ctx.WorkingDir, args[0])
+		}
+		if err := os.MkdirAll(root, os.FileMode(0777)); err != nil {
+			return errors.Errorf("unable to create directory %s , err %v", root, err)
+		}
 	}
 
 	mf := filepath.Join(root, dep.ManifestName)

--- a/cmd/dep/integration_test.go
+++ b/cmd/dep/integration_test.go
@@ -109,7 +109,7 @@ func testIntegration(name, wd string, externalProc bool, run test.RunFunc) func(
 		t.Parallel()
 
 		// Set up environment
-		testCase := test.NewTestCase(t, name, wd)
+		testCase := test.NewTestCase(t, name, "harness_tests", wd)
 		defer testCase.Cleanup()
 		testProj := test.NewTestProject(t, testCase.InitialPath(), wd, externalProc, run)
 		defer testProj.Cleanup()
@@ -158,9 +158,9 @@ func testRelativePath(name, wd string, externalProc bool, run test.RunFunc) func
 		t.Parallel()
 
 		// Set up environment
-		testCase := test.NewTestCaseRelPath(t, name, wd)
+		testCase := test.NewTestCase(t, name, "init_path_tests", wd)
 		defer testCase.Cleanup()
-		testProj := test.NewTestProjectRelPath(t, testCase.InitialPath(), testCase.InitPath, wd, externalProc, run)
+		testProj := test.NewTestProject(t, testCase.InitialPath(), wd, externalProc, run)
 		defer testProj.Cleanup()
 
 		// Create and checkout the vendor revisions
@@ -196,7 +196,6 @@ func testRelativePath(name, wd string, externalProc bool, run test.RunFunc) func
 		testCase.CompareFile(dep.ManifestName, testProj.ProjPath(dep.ManifestName))
 		testCase.CompareFile(dep.LockName, testProj.ProjPath(dep.LockName))
 
-		// Check vendor paths
 		testProj.CompareImportPaths()
 	}
 }

--- a/cmd/dep/integration_test.go
+++ b/cmd/dep/integration_test.go
@@ -43,6 +43,30 @@ func TestIntegration(t *testing.T) {
 		}
 		return nil
 	})
+
+	filepath.Walk(filepath.Join("testdata", "init_path_tests"),
+		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				t.Fatal("error walking filepath")
+			}
+
+			wd, err := os.Getwd()
+			if err != nil {
+				panic(err)
+			}
+
+			if filepath.Base(path) == "testcase.json" {
+				parse := strings.Split(path, string(filepath.Separator))
+				testName := strings.Join(parse[2:len(parse)-1], "/")
+				t.Run(testName, func(t *testing.T) {
+					t.Parallel()
+
+					t.Run("external", testRelativePath(testName, wd, true, execCmd))
+					t.Run("internal", testRelativePath(testName, wd, false, runMain))
+				})
+			}
+			return nil
+		})
 }
 
 // execCmd is a test.RunFunc which runs the program in another process.
@@ -126,5 +150,53 @@ func testIntegration(name, wd string, externalProc bool, run test.RunFunc) func(
 		// Check vendor paths
 		testProj.CompareImportPaths()
 		testCase.CompareVendorPaths(testProj.GetVendorPaths())
+	}
+}
+
+func testRelativePath(name, wd string, externalProc bool, run test.RunFunc) func(t *testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+
+		// Set up environment
+		testCase := test.NewTestCaseRelPath(t, name, wd)
+		defer testCase.Cleanup()
+		testProj := test.NewTestProjectRelPath(t, testCase.InitialPath(), testCase.InitPath, wd, externalProc, run)
+		defer testProj.Cleanup()
+
+		// Create and checkout the vendor revisions
+		for ip, rev := range testCase.VendorInitial {
+			testProj.GetVendorGit(ip)
+			testProj.RunGit(testProj.VendorPath(ip), "checkout", rev)
+		}
+
+		// Create and checkout the import revisions
+		for ip, rev := range testCase.GopathInitial {
+			testProj.RunGo("get", ip)
+			testProj.RunGit(testProj.Path("src", ip), "checkout", rev)
+		}
+
+		// Run commands
+		testProj.RecordImportPaths()
+
+		var err error
+		for i, args := range testCase.Commands {
+			err = testProj.DoRun(args)
+			if err != nil && i < len(testCase.Commands)-1 {
+				t.Fatalf("cmd %s raised an unexpected error: %s", args[0], err.Error())
+			}
+		}
+
+		// Check error raised in final command
+		testCase.CompareError(err, testProj.GetStderr())
+
+		// Check output
+		testCase.CompareOutput(testProj.GetStdout())
+
+		// Check final manifest and lock
+		testCase.CompareFile(dep.ManifestName, testProj.ProjPath(dep.ManifestName))
+		testCase.CompareFile(dep.LockName, testProj.ProjPath(dep.LockName))
+
+		// Check vendor paths
+		testProj.CompareImportPaths()
 	}
 }

--- a/cmd/dep/remove_test.go
+++ b/cmd/dep/remove_test.go
@@ -27,7 +27,7 @@ func TestRemoveErrors(t *testing.T) {
 
 func removeErrors(name, wd string, externalProc bool, run test.RunFunc) func(*testing.T) {
 	return func(t *testing.T) {
-		testCase := test.NewTestCase(t, name, wd)
+		testCase := test.NewTestCase(t, name, "harness_tests", wd)
 		testProj := test.NewTestProject(t, testCase.InitialPath(), wd, externalProc, run)
 		defer testProj.Cleanup()
 

--- a/cmd/dep/testdata/init_path_tests/relative_path/final/project_dir/Gopkg.lock
+++ b/cmd/dep/testdata/init_path_tests/relative_path/final/project_dir/Gopkg.lock
@@ -1,0 +1,12 @@
+memo = "af9a783a5430dabcaaf44683c09e2b729e1c0d61f13bfdf6677c4fd0b41387ca"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/sdboyer/deptest"
+  packages = ["."]
+  revision = "3f4c3bea144e112a69bbe5d8d01c1b09a544253f"
+
+[[projects]]
+  name = "github.com/sdboyer/deptestdos"
+  packages = ["."]
+  revision = "a0196baa11ea047dd65037287451d36b861b00ea"

--- a/cmd/dep/testdata/init_path_tests/relative_path/final/project_dir/Gopkg.toml
+++ b/cmd/dep/testdata/init_path_tests/relative_path/final/project_dir/Gopkg.toml
@@ -1,0 +1,7 @@
+
+[[dependencies]]
+  branch = "master"
+  name = "github.com/sdboyer/deptest"
+
+[[dependencies]]
+  name = "github.com/sdboyer/deptestdos"

--- a/cmd/dep/testdata/init_path_tests/relative_path/initial/project_dir/foo/bar.go
+++ b/cmd/dep/testdata/init_path_tests/relative_path/initial/project_dir/foo/bar.go
@@ -1,0 +1,13 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package foo
+
+import "github.com/sdboyer/deptest"
+
+func Foo() deptest.Foo {
+	var y deptest.Foo
+
+	return y
+}

--- a/cmd/dep/testdata/init_path_tests/relative_path/initial/project_dir/main.go
+++ b/cmd/dep/testdata/init_path_tests/relative_path/initial/project_dir/main.go
@@ -1,0 +1,18 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/sdboyer/deptestdos"
+)
+
+func main() {
+	var x deptestdos.Bar
+	y := foo.FooFunc()
+
+	fmt.Println(x, y)
+}

--- a/cmd/dep/testdata/init_path_tests/relative_path/testcase.json
+++ b/cmd/dep/testdata/init_path_tests/relative_path/testcase.json
@@ -1,0 +1,7 @@
+{
+  "commands": [
+    ["init", "project_dir"]
+  ],
+  "init-path": "project_dir"
+
+}

--- a/internal/test/integration_testcase.go
+++ b/internal/test/integration_testcase.go
@@ -36,28 +36,8 @@ type IntegrationTestCase struct {
 	InitPath      string            `json:"init-path"`
 }
 
-func NewTestCase(t *testing.T, name, wd string) *IntegrationTestCase {
-	rootPath := filepath.FromSlash(filepath.Join(wd, "testdata", "harness_tests", name))
-	n := &IntegrationTestCase{
-		t:           t,
-		name:        name,
-		rootPath:    rootPath,
-		initialPath: filepath.Join(rootPath, "initial"),
-		finalPath:   filepath.Join(rootPath, "final"),
-	}
-	j, err := ioutil.ReadFile(filepath.Join(rootPath, "testcase.json"))
-	if err != nil {
-		panic(err)
-	}
-	err = json.Unmarshal(j, n)
-	if err != nil {
-		panic(err)
-	}
-	return n
-}
-
-func NewTestCaseRelPath(t *testing.T, name, wd string) *IntegrationTestCase {
-	rootPath := filepath.FromSlash(filepath.Join(wd, "testdata", "init_path_tests", name))
+func NewTestCase(t *testing.T, name, test_dir, wd string) *IntegrationTestCase {
+	rootPath := filepath.FromSlash(filepath.Join(wd, "testdata", test_dir, name))
 	n := &IntegrationTestCase{
 		t:           t,
 		name:        name,

--- a/internal/test/integration_testcase.go
+++ b/internal/test/integration_testcase.go
@@ -33,10 +33,31 @@ type IntegrationTestCase struct {
 	GopathInitial map[string]string `json:"gopath-initial"`
 	VendorInitial map[string]string `json:"vendor-initial"`
 	VendorFinal   []string          `json:"vendor-final"`
+	InitPath      string            `json:"init-path"`
 }
 
 func NewTestCase(t *testing.T, name, wd string) *IntegrationTestCase {
 	rootPath := filepath.FromSlash(filepath.Join(wd, "testdata", "harness_tests", name))
+	n := &IntegrationTestCase{
+		t:           t,
+		name:        name,
+		rootPath:    rootPath,
+		initialPath: filepath.Join(rootPath, "initial"),
+		finalPath:   filepath.Join(rootPath, "final"),
+	}
+	j, err := ioutil.ReadFile(filepath.Join(rootPath, "testcase.json"))
+	if err != nil {
+		panic(err)
+	}
+	err = json.Unmarshal(j, n)
+	if err != nil {
+		panic(err)
+	}
+	return n
+}
+
+func NewTestCaseRelPath(t *testing.T, name, wd string) *IntegrationTestCase {
+	rootPath := filepath.FromSlash(filepath.Join(wd, "testdata", "init_path_tests", name))
 	n := &IntegrationTestCase{
 		t:           t,
 		name:        name,

--- a/internal/test/integration_testproj.go
+++ b/internal/test/integration_testproj.go
@@ -64,31 +64,6 @@ func NewTestProject(t *testing.T, initPath, wd string, externalProc bool, run Ru
 	return new
 }
 
-func NewTestProjectRelPath(t *testing.T, initPath, wd, relativePath string, externalProc bool, run RunFunc) *IntegrationTestProject {
-	new := &IntegrationTestProject{
-		t:      t,
-		origWd: wd,
-		env:    os.Environ(),
-		run:    run,
-	}
-	new.makeRootTempDir()
-	new.TempDir(ProjectRoot, "vendor")
-	new.CopyTree(initPath)
-
-	// Note that the Travis darwin platform, directories with certain roots such
-	// as /var are actually links to a dirtree under /private.  Without the patch
-	// below the wd, and therefore the GOPATH, is recorded as "/var/..." but the
-	// actual process runs in "/private/var/..." and dies due to not being in the
-	// GOPATH because the roots don't line up.
-	if externalProc && runtime.GOOS == "darwin" && needsPrivateLeader(new.tempdir) {
-		new.Setenv("GOPATH", filepath.Join("/private", new.tempdir))
-	} else {
-		new.Setenv("GOPATH", new.tempdir)
-	}
-
-	return new
-}
-
 func (p *IntegrationTestProject) Cleanup() {
 	os.RemoveAll(p.tempdir)
 }

--- a/internal/test/integration_testproj.go
+++ b/internal/test/integration_testproj.go
@@ -64,6 +64,31 @@ func NewTestProject(t *testing.T, initPath, wd string, externalProc bool, run Ru
 	return new
 }
 
+func NewTestProjectRelPath(t *testing.T, initPath, wd, relativePath string, externalProc bool, run RunFunc) *IntegrationTestProject {
+	new := &IntegrationTestProject{
+		t:      t,
+		origWd: wd,
+		env:    os.Environ(),
+		run:    run,
+	}
+	new.makeRootTempDir()
+	new.TempDir(ProjectRoot, "vendor")
+	new.CopyTree(initPath)
+
+	// Note that the Travis darwin platform, directories with certain roots such
+	// as /var are actually links to a dirtree under /private.  Without the patch
+	// below the wd, and therefore the GOPATH, is recorded as "/var/..." but the
+	// actual process runs in "/private/var/..." and dies due to not being in the
+	// GOPATH because the roots don't line up.
+	if externalProc && runtime.GOOS == "darwin" && needsPrivateLeader(new.tempdir) {
+		new.Setenv("GOPATH", filepath.Join("/private", new.tempdir))
+	} else {
+		new.Setenv("GOPATH", new.tempdir)
+	}
+
+	return new
+}
+
 func (p *IntegrationTestProject) Cleanup() {
 	os.RemoveAll(p.tempdir)
 }


### PR DESCRIPTION
Fixes https://github.com/golang/dep/issues/537

Need some help on test cases. The current approach is giving issues as adding tests to `harness_tests/init` cannot find vendor paths. Let me know if there is a better approach to test this feature. 