### PR TITLE
Update Masterminds/semver to latest 2.x

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -4,7 +4,7 @@ memo = "932b7b1663f6eecccb1fada1d3670ae24cd8aa7c8b61e3b224edfefebe25954e"
   branch = "2.x"
   name = "github.com/Masterminds/semver"
   packages = ["."]
-  revision = "94ad6eaf8457cf85a68c9b53fa42e9b1b8683783"
+  revision = "139cc0982c53f1367af5636b12b7643cd03757fc"
 
 [[projects]]
   name = "github.com/Masterminds/vcs"

--- a/internal/gps/constraints.go
+++ b/internal/gps/constraints.go
@@ -58,7 +58,7 @@ func NewSemverConstraint(body string) (Constraint, error) {
 	}
 	// If we got a simple semver.Version, simplify by returning our
 	// corresponding type
-	if sv, ok := c.(*semver.Version); ok {
+	if sv, ok := c.(semver.Version); ok {
 		return semVersion{sv: sv}, nil
 	}
 	return semverConstraint{c: c}, nil

--- a/internal/gps/manager_test.go
+++ b/internal/gps/manager_test.go
@@ -35,7 +35,7 @@ func (a naiveAnalyzer) Info() (name string, version int) {
 	return "naive-analyzer", 1
 }
 
-func sv(s string) *semver.Version {
+func sv(s string) semver.Version {
 	sv, err := semver.NewVersion(s)
 	if err != nil {
 		panic(fmt.Sprintf("Error creating semver from %q: %s", s, err))

--- a/internal/gps/vcs_source.go
+++ b/internal/gps/vcs_source.go
@@ -291,7 +291,7 @@ func (s *gopkginSource) listVersions(ctx context.Context) ([]PairedVersion, erro
 	vlist := make([]PairedVersion, len(ovlist))
 	k := 0
 	var dbranch int // index of branch to be marked default
-	var bsv *semver.Version
+	var bsv semver.Version
 	for _, v := range ovlist {
 		// all git versions will always be paired
 		pv := v.(versionPair)
@@ -318,7 +318,7 @@ func (s *gopkginSource) listVersions(ctx context.Context) ([]PairedVersion, erro
 			// which one to mark as default until we've seen them all
 			tv.isDefault = false
 			// Figure out if this is the current leader for default branch
-			if bsv == nil || bsv.LessThan(sv) {
+			if bsv == (semver.Version{}) || bsv.LessThan(sv) {
 				bsv = sv
 				dbranch = k
 			}
@@ -331,7 +331,7 @@ func (s *gopkginSource) listVersions(ctx context.Context) ([]PairedVersion, erro
 	}
 
 	vlist = vlist[:k]
-	if bsv != nil {
+	if bsv != (semver.Version{}) {
 		dbv := vlist[dbranch].(versionPair)
 		vlist[dbranch] = branchVersion{
 			name:      dbv.v.(branchVersion).name,

--- a/internal/gps/version.go
+++ b/internal/gps/version.go
@@ -344,7 +344,7 @@ func (v plainVersion) Is(r Revision) PairedVersion {
 }
 
 type semVersion struct {
-	sv *semver.Version
+	sv semver.Version
 }
 
 func (v semVersion) String() string {

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -25,7 +25,7 @@ func TestReadManifest(t *testing.T) {
 		t.Fatalf("Should have read Manifest correctly, but got err %q", err)
 	}
 
-	c, _ := gps.NewSemverConstraint(">=0.12.0, <1.0.0")
+	c, _ := gps.NewSemverConstraint("^0.12.0")
 	want := Manifest{
 		Dependencies: map[gps.ProjectRoot]gps.ProjectProperties{
 			gps.ProjectRoot("github.com/golang/dep/internal/gps"): {

--- a/testdata/manifest/golden.toml
+++ b/testdata/manifest/golden.toml
@@ -6,7 +6,7 @@ ignored = ["github.com/foo/bar"]
 
 [[dependencies]]
   name = "github.com/golang/dep/internal/gps"
-  version = ">=0.12.0, <1.0.0"
+  version = "^0.12.0"
 
 [[overrides]]
   branch = "master"

--- a/vendor/github.com/Masterminds/semver/.travis.yml
+++ b/vendor/github.com/Masterminds/semver/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 
 go:
-  - 1.5
   - 1.6
   - 1.7
   - tip
@@ -13,8 +12,8 @@ go:
 sudo: false
 
 script:
-  - GO15VENDOREXPERIMENT=1 make setup
-  - GO15VENDOREXPERIMENT=1 make test
+  - make setup
+  - make test
 
 notifications:
   webhooks:

--- a/vendor/github.com/Masterminds/semver/collection.go
+++ b/vendor/github.com/Masterminds/semver/collection.go
@@ -3,7 +3,7 @@ package semver
 // Collection is a collection of Version instances and implements the sort
 // interface. See the sort package for more details.
 // https://golang.org/pkg/sort/
-type Collection []*Version
+type Collection []Version
 
 // Len returns the length of a collection. The number of Version instances
 // on the slice.

--- a/vendor/github.com/Masterminds/semver/collection_test.go
+++ b/vendor/github.com/Masterminds/semver/collection_test.go
@@ -15,7 +15,7 @@ func TestCollection(t *testing.T) {
 		"0.4.2",
 	}
 
-	vs := make([]*Version, len(raw))
+	vs := make([]Version, len(raw))
 	for i, r := range raw {
 		v, err := NewVersion(r)
 		if err != nil {

--- a/vendor/github.com/Masterminds/semver/error.go
+++ b/vendor/github.com/Masterminds/semver/error.go
@@ -11,6 +11,7 @@ var rangeErrs = [...]string{
 	"%s is greater than the maximum of %s",
 	"%s is greater than or equal to the maximum of %s",
 	"%s is specifically disallowed in %s",
+	"%s has prerelease data, so is omitted by the range %s",
 }
 
 const (
@@ -19,15 +20,21 @@ const (
 	rerrGT
 	rerrGTE
 	rerrNE
+	rerrPre
 )
 
+// MatchFailure is an interface for failures to find a Constraint match.
 type MatchFailure interface {
 	error
-	Pair() (v *Version, c Constraint)
+
+	// Pair returns the version and constraint that did not match prompting
+	// the error.
+	Pair() (v Version, c Constraint)
 }
 
+// RangeMatchFailure occurs when a version is not within a constraint range.
 type RangeMatchFailure struct {
-	v   *Version
+	v   Version
 	rc  rangeConstraint
 	typ int8
 }
@@ -36,22 +43,29 @@ func (rce RangeMatchFailure) Error() string {
 	return fmt.Sprintf(rangeErrs[rce.typ], rce.v, rce.rc)
 }
 
-func (rce RangeMatchFailure) Pair() (v *Version, r Constraint) {
+// Pair returns the version and constraint that did not match. Part of the
+// MatchFailure interface.
+func (rce RangeMatchFailure) Pair() (v Version, r Constraint) {
 	return rce.v, rce.rc
 }
 
+// VersionMatchFailure occurs when two versions do not match each other.
 type VersionMatchFailure struct {
-	v, other *Version
+	v, other Version
 }
 
 func (vce VersionMatchFailure) Error() string {
 	return fmt.Sprintf("%s is not equal to %s", vce.v, vce.other)
 }
 
-func (vce VersionMatchFailure) Pair() (v *Version, r Constraint) {
+// Pair returns the two versions that did not match. Part of the
+// MatchFailure interface.
+func (vce VersionMatchFailure) Pair() (v Version, r Constraint) {
 	return vce.v, vce.other
 }
 
+// MultiMatchFailure errors occur when there are multiple constraints a version
+// is being checked against and there are failures.
 type MultiMatchFailure []MatchFailure
 
 func (mmf MultiMatchFailure) Error() string {

--- a/vendor/github.com/Masterminds/semver/magic.go
+++ b/vendor/github.com/Masterminds/semver/magic.go
@@ -2,7 +2,7 @@ package semver
 
 import "errors"
 
-var noneErr = errors.New("The 'None' constraint admits no versions.")
+var errNone = errors.New("The 'None' constraint admits no versions.")
 
 // Any is a constraint that is satisfied by any valid semantic version.
 type any struct{}
@@ -16,9 +16,13 @@ func (any) String() string {
 	return "*"
 }
 
+func (any) ImpliedCaretString() string {
+	return "*"
+}
+
 // Matches checks that a version satisfies the constraint. As all versions
 // satisfy Any, this always returns nil.
-func (any) Matches(v *Version) error {
+func (any) Matches(v Version) error {
 	return nil
 }
 
@@ -59,10 +63,14 @@ func (none) String() string {
 	return ""
 }
 
+func (none) ImpliedCaretString() string {
+	return ""
+}
+
 // Matches checks that a version satisfies the constraint. As no version can
 // satisfy None, this always fails (returns an error).
-func (none) Matches(v *Version) error {
-	return noneErr
+func (none) Matches(v Version) error {
+	return errNone
 }
 
 // Intersect computes the intersection between two constraints.

--- a/vendor/github.com/Masterminds/semver/set_ops_test.go
+++ b/vendor/github.com/Masterminds/semver/set_ops_test.go
@@ -14,7 +14,7 @@ func TestIntersection(t *testing.T) {
 	}
 
 	if actual = Intersection(rc1); !constraintEq(actual, rc1) {
-		t.Errorf("Intersection of one item should always return that item; got %q")
+		t.Errorf("Intersection of one item should always return that item; got %q", actual)
 	}
 
 	if actual = Intersection(rc1, None()); !IsNone(actual) {
@@ -83,7 +83,7 @@ func TestRangeIntersection(t *testing.T) {
 	}
 
 	// now exclude just that version
-	rc1.excl = []*Version{v1}
+	rc1.excl = []Version{v1}
 	if actual = rc1.Intersect(v1); !IsNone(actual) {
 		t.Errorf("Intersection of version with range having specific exclude for that version should produce None; got %q", actual)
 	}
@@ -133,8 +133,10 @@ func TestRangeIntersection(t *testing.T) {
 	// Overlaps with nils
 	rc1 = rangeConstraint{
 		min: newV(1, 0, 0),
+		max: Version{special: infiniteVersion},
 	}
 	rc2 = rangeConstraint{
+		min: Version{special: zeroVersion},
 		max: newV(2, 2, 0),
 	}
 	result = rangeConstraint{
@@ -257,7 +259,7 @@ func TestRangeIntersection(t *testing.T) {
 	rc1 = rangeConstraint{
 		min: newV(1, 5, 0),
 		max: newV(2, 0, 0),
-		excl: []*Version{
+		excl: []Version{
 			newV(1, 6, 0),
 		},
 	}
@@ -281,7 +283,7 @@ func TestRangeIntersection(t *testing.T) {
 	rc2 = rangeConstraint{
 		min: newV(1, 0, 0),
 		max: newV(3, 0, 0),
-		excl: []*Version{
+		excl: []Version{
 			newV(1, 1, 0),
 		},
 	}
@@ -296,9 +298,11 @@ func TestRangeIntersection(t *testing.T) {
 	// Test min, and greater min
 	rc1 = rangeConstraint{
 		min: newV(1, 0, 0),
+		max: Version{special: infiniteVersion},
 	}
 	rc2 = rangeConstraint{
 		min:        newV(1, 5, 0),
+		max:        Version{special: infiniteVersion},
 		includeMin: true,
 	}
 
@@ -329,13 +333,17 @@ func TestRangeIntersection(t *testing.T) {
 
 	// Ensure pure excludes come through as they should
 	rc1 = rangeConstraint{
-		excl: []*Version{
+		min: Version{special: zeroVersion},
+		max: Version{special: infiniteVersion},
+		excl: []Version{
 			newV(1, 6, 0),
 		},
 	}
 
 	rc2 = rangeConstraint{
-		excl: []*Version{
+		min: Version{special: zeroVersion},
+		max: Version{special: infiniteVersion},
+		excl: []Version{
 			newV(1, 6, 0),
 			newV(1, 7, 0),
 		},
@@ -379,7 +387,7 @@ func TestRangeUnion(t *testing.T) {
 
 	// now exclude just that version
 	rc2 := rc1.dup()
-	rc2.excl = []*Version{v1}
+	rc2.excl = []Version{v1}
 	if actual = rc2.Union(v1); !constraintEq(actual, rc1) {
 		t.Errorf("Union of version with range having specific exclude for that version should produce the range without that exclude; got %q", actual)
 	}
@@ -454,8 +462,10 @@ func TestRangeUnion(t *testing.T) {
 	// Overlaps with nils
 	rc1 = rangeConstraint{
 		min: newV(1, 0, 0),
+		max: Version{special: infiniteVersion},
 	}
 	rc2 = rangeConstraint{
+		min: Version{special: zeroVersion},
 		max: newV(2, 2, 0),
 	}
 
@@ -469,6 +479,7 @@ func TestRangeUnion(t *testing.T) {
 	// Just one nil in overlap
 	rc1.max = newV(2, 0, 0)
 	result = rangeConstraint{
+		min: Version{special: zeroVersion},
 		max: newV(2, 2, 0),
 	}
 
@@ -479,10 +490,11 @@ func TestRangeUnion(t *testing.T) {
 		t.Errorf("Got constraint %q, but expected %q", actual, result)
 	}
 
-	rc1.max = nil
+	rc1.max = Version{special: infiniteVersion}
 	rc2.min = newV(1, 5, 0)
 	result = rangeConstraint{
 		min: newV(1, 0, 0),
+		max: Version{special: infiniteVersion},
 	}
 
 	if actual = rc1.Union(rc2); !constraintEq(actual, result) {
@@ -582,7 +594,7 @@ func TestRangeUnion(t *testing.T) {
 	rc1 = rangeConstraint{
 		min: newV(1, 5, 0),
 		max: newV(2, 0, 0),
-		excl: []*Version{
+		excl: []Version{
 			newV(1, 6, 0),
 		},
 	}
@@ -606,7 +618,7 @@ func TestRangeUnion(t *testing.T) {
 	rc2 = rangeConstraint{
 		min: newV(1, 0, 0),
 		max: newV(3, 0, 0),
-		excl: []*Version{
+		excl: []Version{
 			newV(1, 1, 0),
 		},
 	}
@@ -620,13 +632,17 @@ func TestRangeUnion(t *testing.T) {
 
 	// Ensure pure excludes come through as they should
 	rc1 = rangeConstraint{
-		excl: []*Version{
+		min: Version{special: zeroVersion},
+		max: Version{special: infiniteVersion},
+		excl: []Version{
 			newV(1, 6, 0),
 		},
 	}
 
 	rc2 = rangeConstraint{
-		excl: []*Version{
+		min: Version{special: zeroVersion},
+		max: Version{special: infiniteVersion},
+		excl: []Version{
 			newV(1, 6, 0),
 			newV(1, 7, 0),
 		},
@@ -640,7 +656,9 @@ func TestRangeUnion(t *testing.T) {
 	}
 
 	rc1 = rangeConstraint{
-		excl: []*Version{
+		min: Version{special: zeroVersion},
+		max: Version{special: infiniteVersion},
+		excl: []Version{
 			newV(1, 5, 0),
 		},
 	}
@@ -738,7 +756,7 @@ func TestUnionIntersection(t *testing.T) {
 	}
 
 	// Ensure excludes carry as they should
-	rc1.excl = []*Version{newV(1, 5, 5)}
+	rc1.excl = []Version{newV(1, 5, 5)}
 	u1 = unionConstraint{rc1, rc2}
 	ur = unionConstraint{rc1, rc4}
 

--- a/vendor/github.com/Masterminds/semver/version_test.go
+++ b/vendor/github.com/Masterminds/semver/version_test.go
@@ -180,6 +180,33 @@ func TestCompare(t *testing.T) {
 			)
 		}
 	}
+
+	// One-off tests for special version comparisons
+	zero := Version{special: zeroVersion}
+	inf := Version{special: infiniteVersion}
+
+	if zero.Compare(inf) != -1 {
+		t.Error("Zero version should always be less than infinite version")
+	}
+	if zero.Compare(zero) != 0 {
+		t.Error("Zero version should equal itself")
+	}
+	if inf.Compare(zero) != 1 {
+		t.Error("Infinite version should always be greater than zero version")
+	}
+	if inf.Compare(inf) != 0 {
+		t.Error("Infinite version should equal itself")
+	}
+
+	// Need to work vs. a normal version, too.
+	v := Version{}
+
+	if zero.Compare(v) != -1 {
+		t.Error("Zero version should always be less than any normal version")
+	}
+	if inf.Compare(v) != 1 {
+		t.Error("Infinite version should always be greater than any normal version")
+	}
 }
 
 func TestLessThan(t *testing.T) {

--- a/vendor/github.com/Masterminds/vcs/git.go
+++ b/vendor/github.com/Masterminds/vcs/git.go
@@ -366,7 +366,7 @@ func (s *GitRepo) Ping() bool {
 
 // EscapePathSeparator escapes the path separator by replacing it with several.
 // Note: this is harmless on Unix, and needed on Windows.
-func EscapePathSeparator(path string) string {
+func EscapePathSeparator(path string) (string) {
 	switch runtime.GOOS {
 	case `windows`:
 		// On Windows, triple all path separators.
@@ -379,7 +379,7 @@ func EscapePathSeparator(path string) string {
 		// used with --prefix, like this: --prefix=C:\foo\bar\ -> --prefix=C:\\\foo\\\bar\\\
 		return strings.Replace(path,
 			string(os.PathSeparator),
-			string(os.PathSeparator)+string(os.PathSeparator)+string(os.PathSeparator),
+			string(os.PathSeparator) + string(os.PathSeparator) + string(os.PathSeparator),
 			-1)
 	default:
 		return path
@@ -404,7 +404,7 @@ func (s *GitRepo) ExportDir(dir string) error {
 		return NewLocalError("Unable to create directory", err, "")
 	}
 
-	path = EscapePathSeparator(dir)
+	path = EscapePathSeparator( dir )
 	out, err := s.RunFromDir("git", "checkout-index", "-f", "-a", "--prefix="+path)
 	s.log(out)
 	if err != nil {
@@ -412,7 +412,7 @@ func (s *GitRepo) ExportDir(dir string) error {
 	}
 
 	// and now, the horror of submodules
-	path = EscapePathSeparator(dir + "$path" + string(os.PathSeparator))
+	path = EscapePathSeparator( dir + "$path" + string(os.PathSeparator) )
 	out, err = s.RunFromDir("git", "submodule", "foreach", "--recursive", "git checkout-index -f -a --prefix="+path)
 	s.log(out)
 	if err != nil {

--- a/vendor/github.com/Masterminds/vcs/git_test.go
+++ b/vendor/github.com/Masterminds/vcs/git_test.go
@@ -559,6 +559,7 @@ func TestGitSubmoduleHandling2(t *testing.T) {
 		t.Errorf("Current failed to detect Git on tip of master. Got version: %s", v)
 	}
 
+
 	tempDir2, err := ioutil.TempDir("", "go-vcs-git-tests-export")
 	if err != nil {
 		t.Fatalf("Error creating temp directory: %s", err)
@@ -582,7 +583,7 @@ func TestGitSubmoduleHandling2(t *testing.T) {
 		t.Errorf("Error checking exported file in Git: %s", err)
 	}
 
-	_, err = os.Stat(filepath.Join(filepath.Join(exportDir, "definitions"), "README.md"))
+	_, err = os.Stat(filepath.Join( filepath.Join(exportDir, "definitions"), "README.md"))
 	if err != nil {
 		t.Errorf("Error checking exported file in Git: %s", err)
 	}

--- a/vendor/github.com/pelletier/go-toml/marshal_test.go
+++ b/vendor/github.com/pelletier/go-toml/marshal_test.go
@@ -145,8 +145,8 @@ var docData = testDoc{
 		Second: &subdoc,
 	},
 	SubDocList: []testSubDoc{
-		{"List.First", 0},
-		{"List.Second", 0},
+		testSubDoc{"List.First", 0},
+		testSubDoc{"List.Second", 0},
 	},
 	SubDocPtrs: []*testSubDoc{&subdoc},
 }
@@ -504,7 +504,7 @@ var strPtr = []*string{&str1, &str2}
 var strPtr2 = []*[]*string{&strPtr}
 
 var nestedTestData = nestedMarshalTestStruct{
-	String:    [][]string{{"Five", "Six"}, {"One", "Two"}},
+	String:    [][]string{[]string{"Five", "Six"}, []string{"One", "Two"}},
 	StringPtr: &strPtr2,
 }
 

--- a/vendor/github.com/pelletier/go-toml/tomltree_create_test.go
+++ b/vendor/github.com/pelletier/go-toml/tomltree_create_test.go
@@ -1,9 +1,9 @@
 package toml
 
 import (
-	"strconv"
 	"testing"
 	"time"
+	"strconv"
 )
 
 type customString string
@@ -60,7 +60,7 @@ func TestTomlTreeCreateToTree(t *testing.T) {
 		},
 		"array":                 []string{"a", "b", "c"},
 		"array_uint":            []uint{uint(1), uint(2)},
-		"array_table":           []map[string]interface{}{{"sub_map": 52}},
+		"array_table":           []map[string]interface{}{map[string]interface{}{"sub_map": 52}},
 		"array_times":           []time.Time{time.Now(), time.Now()},
 		"map_times":             map[string]time.Time{"now": time.Now()},
 		"custom_string_map_key": map[customString]interface{}{customString("custom"): "custom"},
@@ -97,7 +97,7 @@ func TestTomlTreeCreateToTreeInvalidArrayMemberType(t *testing.T) {
 }
 
 func TestTomlTreeCreateToTreeInvalidTableGroupType(t *testing.T) {
-	_, err := TreeFromMap(map[string]interface{}{"foo": []map[string]interface{}{{"hello": t}}})
+	_, err := TreeFromMap(map[string]interface{}{"foo": []map[string]interface{}{map[string]interface{}{"hello": t}}})
 	expected := "cannot convert type *testing.T to TomlTree"
 	if err.Error() != expected {
 		t.Fatalf("expected error %s, got %s", expected, err.Error())

--- a/vendor/github.com/pelletier/go-toml/tomltree_write.go
+++ b/vendor/github.com/pelletier/go-toml/tomltree_write.go
@@ -4,11 +4,11 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"reflect"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
+	"reflect"
 )
 
 // encodes a string to a TOML-compliant string value


### PR DESCRIPTION
1. Ran `dep ensure -update`
2. Fixed build errors related to semver types in gps, including a return type in gps/manager_test.go
3. The following tests are failing:

---

--- FAIL: TestVersionInWorkspace (1.36s)
	context_test.go:169: expected "v0.8.0", got "v0.8.0"
--- FAIL: TestWriteManifest (0.00s)
	manifest_test.go:94: Valid manifest did not marshal to TOML as expected:
			(GOT): ignored = ["github.com/foo/bar"]
		
		[[dependencies]]
		  name = "github.com/babble/brook"
		  revision = "d05d5aca9f895d19e9265839bffeadd74a2d2ecb"
		
		[[dependencies]]
		  name = "github.com/golang/dep/internal/gps"
		  version = "^0.12.0"
		
		[[overrides]]
		  branch = "master"
		  name = "github.com/golang/dep/internal/gps"
		  source = "https://github.com/golang/dep/internal/gps"
		
			(WNT): ignored = ["github.com/foo/bar"]
		
		[[dependencies]]
		  name = "github.com/babble/brook"
		  revision = "d05d5aca9f895d19e9265839bffeadd74a2d2ecb"
		
		[[dependencies]]
		  name = "github.com/golang/dep/internal/gps"
		  version = ">=0.12.0, <1.0.0"
		
		[[overrides]]
		  branch = "master"
		  name = "github.com/golang/dep/internal/gps"
		  source = "https://github.com/golang/dep/internal/gps"
FAIL
exit status 1
FAIL	github.com/golang/dep	10.427s

---

I believe this gets "[almost] the whole way there." 

Going to look over this again later, but some guidance would be helpful.

Referencing #562
