### PR TITLE
Warn on use of abbreviated sha1 commit hash

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -73,8 +73,8 @@ func validateManifest(s string) ([]error, error) {
 						case "revision":
 							if valueStr, ok := value.(string); ok {
 								// Check if sha1 hash is abbreviated
-								validGit := regexp.MustCompile("[a-f0-9]{40}").MatchString(valueStr)
-								if !validGit {
+								validHash := regexp.MustCompile("[a-f0-9]{40}").MatchString(valueStr)
+								if !validHash {
 									// Check for valid bzr revision-id
 									validBzr := regexp.MustCompile(".*-[0-9]{14}(-[a-zA-Z0-9]+)?").MatchString(valueStr)
 									if !validBzr {

--- a/manifest.go
+++ b/manifest.go
@@ -67,8 +67,13 @@ func validateManifest(s string) ([]error, error) {
 					for key, value := range v.(map[string]interface{}) {
 						// Check if the key is valid
 						switch key {
-						case "name", "branch", "revision", "version", "source":
+						case "name", "branch", "version", "source":
 							// valid key
+						case "revision":
+							// Check if sha1 hash is abbreviated
+							if valueStr, ok := value.(string); ok && len(valueStr) < 40 {
+								errs = append(errs, fmt.Errorf("sha1 hash %q should not be in abbreviated form", valueStr))
+							}
 						case "metadata":
 							// Check if metadata is of Map type
 							if reflect.TypeOf(value).Kind() != reflect.Map {

--- a/manifest.go
+++ b/manifest.go
@@ -52,7 +52,7 @@ func validateManifest(s string) ([]error, error) {
 	// Convert tree to a map
 	manifest := tree.ToMap()
 
-	bzrRevID := regexp.MustCompile(".*-\\d{14}-[a-z0-9]{16}")
+	bzrRevID := regexp.MustCompile(`.*-\d{14}-[a-z0-9]{16}`)
 	// Look for unknown fields and collect errors
 	for prop, val := range manifest {
 		switch prop {

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -212,7 +212,23 @@ func TestValidateManifest(t *testing.T) {
 			  name = "github.com/foo/bar"
 			  revision = "b86ad16"
 			`,
-			want: []error{errors.New("sha1 hash \"b86ad16\" should not be in abbreviated form")},
+			want: []error{errors.New("revision \"b86ad16\" should not be in abbreviated form")},
+		},
+		{
+			tomlString: `
+                        [[dependencies]]
+			  name = "bazaar.foobar.com/~bzr/trunk"
+			  revision = "foo@bar.com-12345-wiuilyamo9ian0m7"
+			`,
+			want: []error{errors.New("revision \"foo@bar.com-12345-wiuilyamo9ian0m7\" should not be in abbreviated form")},
+		},
+		{
+			tomlString: `
+			[[dependencies]]
+			  name = "bazaar.foobar.com/~bzr/trunk"
+			  revision = "foo@bar.com-20161116211307-wiuilyamo9ian0m7"
+			`,
+			want: []error{},
 		},
 	}
 

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -206,6 +206,14 @@ func TestValidateManifest(t *testing.T) {
 			`,
 			want: []error{},
 		},
+		{
+			tomlString: `
+			[[dependencies]]
+			  name = "github.com/foo/bar"
+			  revision = "b86ad16"
+			`,
+			want: []error{errors.New("sha1 hash \"b86ad16\" should not be in abbreviated form")},
+		},
 	}
 
 	// constains for error

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -216,6 +216,14 @@ func TestValidateManifest(t *testing.T) {
 		},
 		{
 			tomlString: `
+			[[dependencies]]
+			  name = "github.com/foo/bar"
+			  revision = "867f832e"
+			`,
+			want: []error{errors.New("revision \"867f832e\" should not be in abbreviated form")},
+		},
+		{
+			tomlString: `
                         [[dependencies]]
 			  name = "bazaar.foobar.com/~bzr/trunk"
 			  revision = "foo@bar.com-12345-wiuilyamo9ian0m7"

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -232,7 +232,7 @@ func TestValidateManifest(t *testing.T) {
 		},
 	}
 
-	// constains for error
+	// contains for error
 	contains := func(s []error, e error) bool {
 		for _, a := range s {
 			if a.Error() == e.Error() {


### PR DESCRIPTION
Update manifest validation to warn when an abbreviated version of a
sha1 commit hash is used.

Add test for warn.

Fixes #567 