### PR TITLE
Split input components out in Gopkg.lock

### DIFF
--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -162,7 +162,7 @@ func (cmd *ensureCommand) Run(ctx *dep.Ctx, args []string) error {
 		writeV = dep.VendorAlways
 	}
 
-	newLock := dep.LockFromInterface(solution)
+	newLock := dep.LockFromSolution(solution)
 	sw, err := dep.NewSafeWriter(nil, p.Lock, newLock, writeV)
 	if err != nil {
 		return err

--- a/cmd/dep/init.go
+++ b/cmd/dep/init.go
@@ -178,7 +178,7 @@ func (cmd *initCommand) Run(ctx *dep.Ctx, args []string) error {
 		handleAllTheFailuresOfTheWorld(err)
 		return err
 	}
-	l = dep.LockFromInterface(soln)
+	l = dep.LockFromSolution(soln)
 
 	// Iterate through the new projects in solved lock and add them to manifest
 	// if direct deps and log feedback for all the new projects.

--- a/cmd/dep/init.go
+++ b/cmd/dep/init.go
@@ -211,7 +211,7 @@ func (cmd *initCommand) Run(ctx *dep.Ctx, args []string) error {
 		return errors.Wrap(err, "prepare solver")
 	}
 
-	l.Inputs.Memo = s.HashInputs()
+	l.SolveMeta.Memo = s.HashInputs()
 
 	// Pass timestamp (yyyyMMddHHmmss format) as suffix to backup name.
 	vendorbak, err := dep.BackupVendor(vpath, time.Now().Format("20060102150405"))

--- a/cmd/dep/init.go
+++ b/cmd/dep/init.go
@@ -211,7 +211,7 @@ func (cmd *initCommand) Run(ctx *dep.Ctx, args []string) error {
 		return errors.Wrap(err, "prepare solver")
 	}
 
-	l.Memo = s.HashInputs()
+	l.Inputs.Memo = s.HashInputs()
 
 	// Pass timestamp (yyyyMMddHHmmss format) as suffix to backup name.
 	vendorbak, err := dep.BackupVendor(vpath, time.Now().Format("20060102150405"))

--- a/cmd/dep/prune.go
+++ b/cmd/dep/prune.go
@@ -68,7 +68,7 @@ func (cmd *pruneCommand) Run(ctx *dep.Ctx, args []string) error {
 		return errors.Wrap(err, "could not set up solver for input hashing")
 	}
 
-	if !bytes.Equal(s.HashInputs(), p.Lock.Memo) {
+	if !bytes.Equal(s.HashInputs(), p.Lock.Inputs.Memo) {
 		return fmt.Errorf("lock hash doesn't match")
 	}
 

--- a/cmd/dep/prune.go
+++ b/cmd/dep/prune.go
@@ -68,7 +68,7 @@ func (cmd *pruneCommand) Run(ctx *dep.Ctx, args []string) error {
 		return errors.Wrap(err, "could not set up solver for input hashing")
 	}
 
-	if !bytes.Equal(s.HashInputs(), p.Lock.Inputs.Memo) {
+	if !bytes.Equal(s.HashInputs(), p.Lock.SolveMeta.Memo) {
 		return fmt.Errorf("lock hash doesn't match")
 	}
 

--- a/cmd/dep/remove.go
+++ b/cmd/dep/remove.go
@@ -176,7 +176,7 @@ func (cmd *removeCommand) Run(ctx *dep.Ctx, args []string) error {
 		return err
 	}
 
-	newLock := dep.LockFromInterface(soln)
+	newLock := dep.LockFromSolution(soln)
 
 	sw, err := dep.NewSafeWriter(nil, p.Lock, newLock, dep.VendorOnChanged)
 	if err != nil {

--- a/cmd/dep/status.go
+++ b/cmd/dep/status.go
@@ -277,7 +277,7 @@ func runStatusAll(loggers *dep.Loggers, out outputter, p *dep.Project, sm gps.So
 	slp := p.Lock.Projects()
 	sort.Sort(dep.SortedLockedProjects(slp))
 
-	if bytes.Equal(s.HashInputs(), p.Lock.Memo) {
+	if bytes.Equal(s.HashInputs(), p.Lock.Inputs.Memo) {
 		// If these are equal, we're guaranteed that the lock is a transitively
 		// complete picture of all deps. That eliminates the need for at least
 		// some checks.

--- a/cmd/dep/status.go
+++ b/cmd/dep/status.go
@@ -277,7 +277,7 @@ func runStatusAll(loggers *dep.Loggers, out outputter, p *dep.Project, sm gps.So
 	slp := p.Lock.Projects()
 	sort.Sort(dep.SortedLockedProjects(slp))
 
-	if bytes.Equal(s.HashInputs(), p.Lock.Inputs.Memo) {
+	if bytes.Equal(s.HashInputs(), p.Lock.SolveMeta.Memo) {
 		// If these are equal, we're guaranteed that the lock is a transitively
 		// complete picture of all deps. That eliminates the need for at least
 		// some checks.

--- a/cmd/dep/testdata/harness_tests/ensure/empty/case1/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/ensure/empty/case1/final/Gopkg.lock
@@ -8,6 +8,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-hash = "14b07b05e0f01051b03887ab2bf80b516bc5510ea92f75f76c894b1745d8850c"
+  inputs-digest = "14b07b05e0f01051b03887ab2bf80b516bc5510ea92f75f76c894b1745d8850c"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/dep/testdata/harness_tests/ensure/empty/case1/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/ensure/empty/case1/final/Gopkg.lock
@@ -1,11 +1,13 @@
 
-[inputs]
-  analyzerName = "dep"
-  analyzerVersion = 1
-  memo = "14b07b05e0f01051b03887ab2bf80b516bc5510ea92f75f76c894b1745d8850c"
-
 [[projects]]
   name = "github.com/sdboyer/deptest"
   packages = ["."]
   revision = "ff2948a2ac8f538c4ecd55962e919d1e13e74baf"
   version = "v1.0.0"
+
+[solve-meta]
+  analyzer-name = "dep"
+  analyzer-version = 1
+  inputs-hash = "14b07b05e0f01051b03887ab2bf80b516bc5510ea92f75f76c894b1745d8850c"
+  solver-name = "gps-cdcl"
+  solver-version = 1

--- a/cmd/dep/testdata/harness_tests/ensure/empty/case1/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/ensure/empty/case1/final/Gopkg.lock
@@ -1,4 +1,8 @@
-memo = "14b07b05e0f01051b03887ab2bf80b516bc5510ea92f75f76c894b1745d8850c"
+
+[inputs]
+  analyzerName = "dep"
+  analyzerVersion = 1
+  memo = "14b07b05e0f01051b03887ab2bf80b516bc5510ea92f75f76c894b1745d8850c"
 
 [[projects]]
   name = "github.com/sdboyer/deptest"

--- a/cmd/dep/testdata/harness_tests/ensure/empty/case1/testcase.json
+++ b/cmd/dep/testdata/harness_tests/ensure/empty/case1/testcase.json
@@ -3,6 +3,7 @@
     ["init"],
     ["ensure", "-update"]
   ],
+  "error-expected": "",
   "vendor-final": [
     "github.com/sdboyer/deptest"
   ]

--- a/cmd/dep/testdata/harness_tests/ensure/empty/case2/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/ensure/empty/case2/final/Gopkg.lock
@@ -1,11 +1,13 @@
 
-[inputs]
-  analyzerName = "dep"
-  analyzerVersion = 1
-  memo = "e7725ea56516a42a641aaaf5d48754258d9f3c59949cb8a0e8a21b1ab6e07179"
-
 [[projects]]
   name = "github.com/sdboyer/deptest"
   packages = ["."]
   revision = "ff2948a2ac8f538c4ecd55962e919d1e13e74baf"
   version = "v1.0.0"
+
+[solve-meta]
+  analyzer-name = "dep"
+  analyzer-version = 1
+  inputs-hash = "e7725ea56516a42a641aaaf5d48754258d9f3c59949cb8a0e8a21b1ab6e07179"
+  solver-name = "gps-cdcl"
+  solver-version = 1

--- a/cmd/dep/testdata/harness_tests/ensure/empty/case2/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/ensure/empty/case2/final/Gopkg.lock
@@ -8,6 +8,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-hash = "e7725ea56516a42a641aaaf5d48754258d9f3c59949cb8a0e8a21b1ab6e07179"
+  inputs-digest = "e7725ea56516a42a641aaaf5d48754258d9f3c59949cb8a0e8a21b1ab6e07179"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/dep/testdata/harness_tests/ensure/empty/case2/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/ensure/empty/case2/final/Gopkg.lock
@@ -1,4 +1,8 @@
-memo = "e7725ea56516a42a641aaaf5d48754258d9f3c59949cb8a0e8a21b1ab6e07179"
+
+[inputs]
+  analyzerName = "dep"
+  analyzerVersion = 1
+  memo = "e7725ea56516a42a641aaaf5d48754258d9f3c59949cb8a0e8a21b1ab6e07179"
 
 [[projects]]
   name = "github.com/sdboyer/deptest"

--- a/cmd/dep/testdata/harness_tests/ensure/empty/case2/testcase.json
+++ b/cmd/dep/testdata/harness_tests/ensure/empty/case2/testcase.json
@@ -2,6 +2,7 @@
   "commands": [
     ["ensure"]
   ],
+  "error-expected": "",
   "vendor-final": [
     "github.com/sdboyer/deptest"
   ]

--- a/cmd/dep/testdata/harness_tests/ensure/empty/case3/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/ensure/empty/case3/final/Gopkg.lock
@@ -1,4 +1,8 @@
-memo = "e5c16e09ed6f0a1a2b3cf472c34b7fd50861dd070e81d5e623f72e8173f0c065"
+
+[inputs]
+  analyzerName = "dep"
+  analyzerVersion = 1
+  memo = "e5c16e09ed6f0a1a2b3cf472c34b7fd50861dd070e81d5e623f72e8173f0c065"
 
 [[projects]]
   branch = "master"

--- a/cmd/dep/testdata/harness_tests/ensure/empty/case3/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/ensure/empty/case3/final/Gopkg.lock
@@ -1,11 +1,13 @@
 
-[inputs]
-  analyzerName = "dep"
-  analyzerVersion = 1
-  memo = "e5c16e09ed6f0a1a2b3cf472c34b7fd50861dd070e81d5e623f72e8173f0c065"
-
 [[projects]]
   branch = "master"
   name = "github.com/sdboyer/deptest"
   packages = ["."]
   revision = "3f4c3bea144e112a69bbe5d8d01c1b09a544253f"
+
+[solve-meta]
+  analyzer-name = "dep"
+  analyzer-version = 1
+  inputs-hash = "e5c16e09ed6f0a1a2b3cf472c34b7fd50861dd070e81d5e623f72e8173f0c065"
+  solver-name = "gps-cdcl"
+  solver-version = 1

--- a/cmd/dep/testdata/harness_tests/ensure/empty/case3/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/ensure/empty/case3/final/Gopkg.lock
@@ -8,6 +8,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-hash = "e5c16e09ed6f0a1a2b3cf472c34b7fd50861dd070e81d5e623f72e8173f0c065"
+  inputs-digest = "e5c16e09ed6f0a1a2b3cf472c34b7fd50861dd070e81d5e623f72e8173f0c065"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/dep/testdata/harness_tests/ensure/empty/case3/testcase.json
+++ b/cmd/dep/testdata/harness_tests/ensure/empty/case3/testcase.json
@@ -2,6 +2,7 @@
   "commands": [
     ["ensure"]
   ],
+  "error-expected": "",
   "vendor-final": [
     "github.com/sdboyer/deptest"
   ]

--- a/cmd/dep/testdata/harness_tests/ensure/override/case1/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/ensure/override/case1/final/Gopkg.lock
@@ -8,6 +8,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-hash = "8bca9526e654e56e05d9075d1f33fa5b649bf6d58aa7d71ca39e7fbea8468e07"
+  inputs-digest = "8bca9526e654e56e05d9075d1f33fa5b649bf6d58aa7d71ca39e7fbea8468e07"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/dep/testdata/harness_tests/ensure/override/case1/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/ensure/override/case1/final/Gopkg.lock
@@ -1,11 +1,13 @@
 
-[inputs]
-  analyzerName = "dep"
-  analyzerVersion = 1
-  memo = "8bca9526e654e56e05d9075d1f33fa5b649bf6d58aa7d71ca39e7fbea8468e07"
-
 [[projects]]
   name = "github.com/sdboyer/deptest"
   packages = ["."]
   revision = "ff2948a2ac8f538c4ecd55962e919d1e13e74baf"
   version = "v1.0.0"
+
+[solve-meta]
+  analyzer-name = "dep"
+  analyzer-version = 1
+  inputs-hash = "8bca9526e654e56e05d9075d1f33fa5b649bf6d58aa7d71ca39e7fbea8468e07"
+  solver-name = "gps-cdcl"
+  solver-version = 1

--- a/cmd/dep/testdata/harness_tests/ensure/override/case1/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/ensure/override/case1/final/Gopkg.lock
@@ -1,4 +1,8 @@
-memo = "8bca9526e654e56e05d9075d1f33fa5b649bf6d58aa7d71ca39e7fbea8468e07"
+
+[inputs]
+  analyzerName = "dep"
+  analyzerVersion = 1
+  memo = "8bca9526e654e56e05d9075d1f33fa5b649bf6d58aa7d71ca39e7fbea8468e07"
 
 [[projects]]
   name = "github.com/sdboyer/deptest"

--- a/cmd/dep/testdata/harness_tests/ensure/override/case1/testcase.json
+++ b/cmd/dep/testdata/harness_tests/ensure/override/case1/testcase.json
@@ -3,6 +3,7 @@
     ["init"],
     ["ensure", "-override", "github.com/sdboyer/deptest@1.0.0"]
   ],
+  "error-expected": "",
   "vendor-final": [
     "github.com/sdboyer/deptest"
   ]

--- a/cmd/dep/testdata/harness_tests/ensure/pkg-errors/case1/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/ensure/pkg-errors/case1/final/Gopkg.lock
@@ -1,1 +1,5 @@
-memo = "ab4fef131ee828e96ba67d31a7d690bd5f2f42040c6766b1b12fe856f87e0ff7"
+
+[inputs]
+  analyzerName = "dep"
+  analyzerVersion = 1
+  memo = "ab4fef131ee828e96ba67d31a7d690bd5f2f42040c6766b1b12fe856f87e0ff7"

--- a/cmd/dep/testdata/harness_tests/ensure/pkg-errors/case1/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/ensure/pkg-errors/case1/final/Gopkg.lock
@@ -1,5 +1,7 @@
 
-[inputs]
-  analyzerName = "dep"
-  analyzerVersion = 1
-  memo = "ab4fef131ee828e96ba67d31a7d690bd5f2f42040c6766b1b12fe856f87e0ff7"
+[solve-meta]
+  analyzer-name = "dep"
+  analyzer-version = 1
+  inputs-hash = "ab4fef131ee828e96ba67d31a7d690bd5f2f42040c6766b1b12fe856f87e0ff7"
+  solver-name = "gps-cdcl"
+  solver-version = 1

--- a/cmd/dep/testdata/harness_tests/ensure/pkg-errors/case1/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/ensure/pkg-errors/case1/final/Gopkg.lock
@@ -2,6 +2,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-hash = "ab4fef131ee828e96ba67d31a7d690bd5f2f42040c6766b1b12fe856f87e0ff7"
+  inputs-digest = "ab4fef131ee828e96ba67d31a7d690bd5f2f42040c6766b1b12fe856f87e0ff7"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/dep/testdata/harness_tests/ensure/pkg-errors/case1/testcase.json
+++ b/cmd/dep/testdata/harness_tests/ensure/pkg-errors/case1/testcase.json
@@ -1,7 +1,8 @@
 {
-   "commands": [
-     ["init", "-no-examples"],
-     ["ensure", "-update"]
-   ],
-   "error-expected" : "all dirs lacked any go code"
- } 
+  "commands": [
+    ["init", "-no-examples"],
+    ["ensure", "-update"]
+  ],
+  "error-expected": "all dirs lacked any go code",
+  "vendor-final": []
+}

--- a/cmd/dep/testdata/harness_tests/ensure/update/case1/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/ensure/update/case1/final/Gopkg.lock
@@ -14,6 +14,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-hash = "1b381263a360eafafe3ef7f9be626672668d17250a3c9a8debd169d1b5e2eebb"
+  inputs-digest = "1b381263a360eafafe3ef7f9be626672668d17250a3c9a8debd169d1b5e2eebb"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/dep/testdata/harness_tests/ensure/update/case1/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/ensure/update/case1/final/Gopkg.lock
@@ -1,4 +1,8 @@
-memo = "1b381263a360eafafe3ef7f9be626672668d17250a3c9a8debd169d1b5e2eebb"
+
+[inputs]
+  analyzerName = "dep"
+  analyzerVersion = 1
+  memo = "1b381263a360eafafe3ef7f9be626672668d17250a3c9a8debd169d1b5e2eebb"
 
 [[projects]]
   name = "github.com/sdboyer/deptest"

--- a/cmd/dep/testdata/harness_tests/ensure/update/case1/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/ensure/update/case1/final/Gopkg.lock
@@ -1,9 +1,4 @@
 
-[inputs]
-  analyzerName = "dep"
-  analyzerVersion = 1
-  memo = "1b381263a360eafafe3ef7f9be626672668d17250a3c9a8debd169d1b5e2eebb"
-
 [[projects]]
   name = "github.com/sdboyer/deptest"
   packages = ["."]
@@ -15,3 +10,10 @@
   packages = ["."]
   revision = "5c607206be5decd28e6263ffffdcee067266015e"
   version = "v2.0.0"
+
+[solve-meta]
+  analyzer-name = "dep"
+  analyzer-version = 1
+  inputs-hash = "1b381263a360eafafe3ef7f9be626672668d17250a3c9a8debd169d1b5e2eebb"
+  solver-name = "gps-cdcl"
+  solver-version = 1

--- a/cmd/dep/testdata/harness_tests/ensure/update/case1/testcase.json
+++ b/cmd/dep/testdata/harness_tests/ensure/update/case1/testcase.json
@@ -2,6 +2,7 @@
   "commands": [
     ["ensure", "-update", "github.com/sdboyer/deptest"]
   ],
+  "error-expected": "",
   "vendor-final": [
     "github.com/sdboyer/deptest",
     "github.com/sdboyer/deptestdos"

--- a/cmd/dep/testdata/harness_tests/ensure/update/case2/testcase.json
+++ b/cmd/dep/testdata/harness_tests/ensure/update/case2/testcase.json
@@ -2,5 +2,6 @@
   "commands": [
     ["ensure", "-n", "-update", "github.com/sdboyer/deptest"]
   ],
+  "error-expected": "",
   "vendor-final": []
 }

--- a/cmd/dep/testdata/harness_tests/init/case1/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/init/case1/final/Gopkg.lock
@@ -1,4 +1,8 @@
-memo = "88d2718cda70cce45158f953d2c6ead79c1db38e67e9704aff72be8fddb096e7"
+
+[inputs]
+  analyzerName = "dep"
+  analyzerVersion = 1
+  memo = "88d2718cda70cce45158f953d2c6ead79c1db38e67e9704aff72be8fddb096e7"
 
 [[projects]]
   name = "github.com/sdboyer/deptest"

--- a/cmd/dep/testdata/harness_tests/init/case1/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/init/case1/final/Gopkg.lock
@@ -13,6 +13,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-hash = "88d2718cda70cce45158f953d2c6ead79c1db38e67e9704aff72be8fddb096e7"
+  inputs-digest = "88d2718cda70cce45158f953d2c6ead79c1db38e67e9704aff72be8fddb096e7"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/dep/testdata/harness_tests/init/case1/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/init/case1/final/Gopkg.lock
@@ -1,9 +1,4 @@
 
-[inputs]
-  analyzerName = "dep"
-  analyzerVersion = 1
-  memo = "88d2718cda70cce45158f953d2c6ead79c1db38e67e9704aff72be8fddb096e7"
-
 [[projects]]
   name = "github.com/sdboyer/deptest"
   packages = ["."]
@@ -14,3 +9,10 @@
   name = "github.com/sdboyer/deptestdos"
   packages = ["."]
   revision = "a0196baa11ea047dd65037287451d36b861b00ea"
+
+[solve-meta]
+  analyzer-name = "dep"
+  analyzer-version = 1
+  inputs-hash = "88d2718cda70cce45158f953d2c6ead79c1db38e67e9704aff72be8fddb096e7"
+  solver-name = "gps-cdcl"
+  solver-version = 1

--- a/cmd/dep/testdata/harness_tests/init/case1/testcase.json
+++ b/cmd/dep/testdata/harness_tests/init/case1/testcase.json
@@ -2,6 +2,7 @@
   "commands": [
     ["init", "-no-examples"]
   ],
+  "error-expected": "",
   "gopath-initial": {
     "github.com/sdboyer/deptest": "v0.8.0",
     "github.com/sdboyer/deptestdos": "a0196baa11ea047dd65037287451d36b861b00ea"

--- a/cmd/dep/testdata/harness_tests/init/case2/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/init/case2/final/Gopkg.lock
@@ -1,9 +1,4 @@
 
-[inputs]
-  analyzerName = "dep"
-  analyzerVersion = 1
-  memo = "b4fe6e8bceac924197838b6ea47989abbdd3a8d31035d20ee0a1dabc0994c368"
-
 [[projects]]
   name = "github.com/sdboyer/deptest"
   packages = ["."]
@@ -15,3 +10,10 @@
   packages = ["."]
   revision = "5c607206be5decd28e6263ffffdcee067266015e"
   version = "v2.0.0"
+
+[solve-meta]
+  analyzer-name = "dep"
+  analyzer-version = 1
+  inputs-hash = "b4fe6e8bceac924197838b6ea47989abbdd3a8d31035d20ee0a1dabc0994c368"
+  solver-name = "gps-cdcl"
+  solver-version = 1

--- a/cmd/dep/testdata/harness_tests/init/case2/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/init/case2/final/Gopkg.lock
@@ -1,4 +1,8 @@
-memo = "b4fe6e8bceac924197838b6ea47989abbdd3a8d31035d20ee0a1dabc0994c368"
+
+[inputs]
+  analyzerName = "dep"
+  analyzerVersion = 1
+  memo = "b4fe6e8bceac924197838b6ea47989abbdd3a8d31035d20ee0a1dabc0994c368"
 
 [[projects]]
   name = "github.com/sdboyer/deptest"

--- a/cmd/dep/testdata/harness_tests/init/case2/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/init/case2/final/Gopkg.lock
@@ -14,6 +14,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-hash = "b4fe6e8bceac924197838b6ea47989abbdd3a8d31035d20ee0a1dabc0994c368"
+  inputs-digest = "b4fe6e8bceac924197838b6ea47989abbdd3a8d31035d20ee0a1dabc0994c368"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/dep/testdata/harness_tests/init/case2/testcase.json
+++ b/cmd/dep/testdata/harness_tests/init/case2/testcase.json
@@ -2,6 +2,7 @@
   "commands": [
     ["init", "-no-examples"]
   ],
+  "error-expected": "",
   "gopath-initial": {
     "github.com/sdboyer/deptest": "v0.8.0"
   },

--- a/cmd/dep/testdata/harness_tests/init/case3/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/init/case3/final/Gopkg.lock
@@ -1,4 +1,8 @@
-memo = "af9a783a5430dabcaaf44683c09e2b729e1c0d61f13bfdf6677c4fd0b41387ca"
+
+[inputs]
+  analyzerName = "dep"
+  analyzerVersion = 1
+  memo = "af9a783a5430dabcaaf44683c09e2b729e1c0d61f13bfdf6677c4fd0b41387ca"
 
 [[projects]]
   branch = "master"

--- a/cmd/dep/testdata/harness_tests/init/case3/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/init/case3/final/Gopkg.lock
@@ -1,9 +1,4 @@
 
-[inputs]
-  analyzerName = "dep"
-  analyzerVersion = 1
-  memo = "af9a783a5430dabcaaf44683c09e2b729e1c0d61f13bfdf6677c4fd0b41387ca"
-
 [[projects]]
   branch = "master"
   name = "github.com/sdboyer/deptest"
@@ -14,3 +9,10 @@
   name = "github.com/sdboyer/deptestdos"
   packages = ["."]
   revision = "a0196baa11ea047dd65037287451d36b861b00ea"
+
+[solve-meta]
+  analyzer-name = "dep"
+  analyzer-version = 1
+  inputs-hash = "af9a783a5430dabcaaf44683c09e2b729e1c0d61f13bfdf6677c4fd0b41387ca"
+  solver-name = "gps-cdcl"
+  solver-version = 1

--- a/cmd/dep/testdata/harness_tests/init/case3/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/init/case3/final/Gopkg.lock
@@ -13,6 +13,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-hash = "af9a783a5430dabcaaf44683c09e2b729e1c0d61f13bfdf6677c4fd0b41387ca"
+  inputs-digest = "af9a783a5430dabcaaf44683c09e2b729e1c0d61f13bfdf6677c4fd0b41387ca"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/dep/testdata/harness_tests/init/case3/testcase.json
+++ b/cmd/dep/testdata/harness_tests/init/case3/testcase.json
@@ -2,6 +2,7 @@
   "commands": [
     ["init", "-no-examples"]
   ],
+  "error-expected": "",
   "gopath-initial": {
     "github.com/sdboyer/deptestdos": "a0196baa11ea047dd65037287451d36b861b00ea"
   },

--- a/cmd/dep/testdata/harness_tests/init/manifest-exists/testcase.json
+++ b/cmd/dep/testdata/harness_tests/init/manifest-exists/testcase.json
@@ -1,6 +1,7 @@
 {
-   "commands": [
-     ["init"]
-   ],
-   "error-expected" : "manifest already exists:"
- }
+  "commands": [
+    ["init"]
+  ],
+  "error-expected": "manifest already exists:",
+  "vendor-final": []
+}

--- a/cmd/dep/testdata/harness_tests/init/skip-hidden/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/init/skip-hidden/final/Gopkg.lock
@@ -8,6 +8,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-hash = "14b07b05e0f01051b03887ab2bf80b516bc5510ea92f75f76c894b1745d8850c"
+  inputs-digest = "14b07b05e0f01051b03887ab2bf80b516bc5510ea92f75f76c894b1745d8850c"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/dep/testdata/harness_tests/init/skip-hidden/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/init/skip-hidden/final/Gopkg.lock
@@ -1,11 +1,13 @@
 
-[inputs]
-  analyzerName = "dep"
-  analyzerVersion = 1
-  memo = "14b07b05e0f01051b03887ab2bf80b516bc5510ea92f75f76c894b1745d8850c"
-
 [[projects]]
   name = "github.com/sdboyer/deptest"
   packages = ["."]
   revision = "ff2948a2ac8f538c4ecd55962e919d1e13e74baf"
   version = "v1.0.0"
+
+[solve-meta]
+  analyzer-name = "dep"
+  analyzer-version = 1
+  inputs-hash = "14b07b05e0f01051b03887ab2bf80b516bc5510ea92f75f76c894b1745d8850c"
+  solver-name = "gps-cdcl"
+  solver-version = 1

--- a/cmd/dep/testdata/harness_tests/init/skip-hidden/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/init/skip-hidden/final/Gopkg.lock
@@ -1,4 +1,8 @@
-memo = "14b07b05e0f01051b03887ab2bf80b516bc5510ea92f75f76c894b1745d8850c"
+
+[inputs]
+  analyzerName = "dep"
+  analyzerVersion = 1
+  memo = "14b07b05e0f01051b03887ab2bf80b516bc5510ea92f75f76c894b1745d8850c"
 
 [[projects]]
   name = "github.com/sdboyer/deptest"

--- a/cmd/dep/testdata/harness_tests/init/skip-hidden/testcase.json
+++ b/cmd/dep/testdata/harness_tests/init/skip-hidden/testcase.json
@@ -2,6 +2,7 @@
   "commands": [
     ["init", "-no-examples"]
   ],
+  "error-expected": "",
   "vendor-final": [
     "github.com/sdboyer/deptest"
   ]

--- a/cmd/dep/testdata/harness_tests/remove/force/case1/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/remove/force/case1/final/Gopkg.lock
@@ -1,4 +1,8 @@
-memo = "88d2718cda70cce45158f953d2c6ead79c1db38e67e9704aff72be8fddb096e7"
+
+[inputs]
+  analyzerName = "dep"
+  analyzerVersion = 1
+  memo = "88d2718cda70cce45158f953d2c6ead79c1db38e67e9704aff72be8fddb096e7"
 
 [[projects]]
   name = "github.com/sdboyer/deptest"

--- a/cmd/dep/testdata/harness_tests/remove/force/case1/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/remove/force/case1/final/Gopkg.lock
@@ -1,9 +1,4 @@
 
-[inputs]
-  analyzerName = "dep"
-  analyzerVersion = 1
-  memo = "88d2718cda70cce45158f953d2c6ead79c1db38e67e9704aff72be8fddb096e7"
-
 [[projects]]
   name = "github.com/sdboyer/deptest"
   packages = ["."]
@@ -15,3 +10,10 @@
   packages = ["."]
   revision = "5c607206be5decd28e6263ffffdcee067266015e"
   version = "v2.0.0"
+
+[solve-meta]
+  analyzer-name = "dep"
+  analyzer-version = 1
+  inputs-hash = "88d2718cda70cce45158f953d2c6ead79c1db38e67e9704aff72be8fddb096e7"
+  solver-name = "gps-cdcl"
+  solver-version = 1

--- a/cmd/dep/testdata/harness_tests/remove/force/case1/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/remove/force/case1/final/Gopkg.lock
@@ -14,6 +14,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-hash = "88d2718cda70cce45158f953d2c6ead79c1db38e67e9704aff72be8fddb096e7"
+  inputs-digest = "88d2718cda70cce45158f953d2c6ead79c1db38e67e9704aff72be8fddb096e7"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/dep/testdata/harness_tests/remove/force/case1/testcase.json
+++ b/cmd/dep/testdata/harness_tests/remove/force/case1/testcase.json
@@ -2,6 +2,7 @@
   "commands": [
     ["remove", "-force", "github.com/sdboyer/deptestdos", "github.com/not/used"]
   ],
+  "error-expected": "",
   "vendor-final": [
     "github.com/sdboyer/deptest",
     "github.com/sdboyer/deptestdos"

--- a/cmd/dep/testdata/harness_tests/remove/specific/case1/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/remove/specific/case1/final/Gopkg.lock
@@ -1,4 +1,8 @@
-memo = "d414dbf5fc668c1085effa68372d02e54b23d058cc66f9fd19ba094c6a946d9b"
+
+[inputs]
+  analyzerName = "dep"
+  analyzerVersion = 1
+  memo = "d414dbf5fc668c1085effa68372d02e54b23d058cc66f9fd19ba094c6a946d9b"
 
 [[projects]]
   name = "github.com/sdboyer/deptest"

--- a/cmd/dep/testdata/harness_tests/remove/specific/case1/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/remove/specific/case1/final/Gopkg.lock
@@ -1,9 +1,4 @@
 
-[inputs]
-  analyzerName = "dep"
-  analyzerVersion = 1
-  memo = "d414dbf5fc668c1085effa68372d02e54b23d058cc66f9fd19ba094c6a946d9b"
-
 [[projects]]
   name = "github.com/sdboyer/deptest"
   packages = ["."]
@@ -14,3 +9,10 @@
   name = "github.com/sdboyer/deptestdos"
   packages = ["."]
   revision = "a0196baa11ea047dd65037287451d36b861b00ea"
+
+[solve-meta]
+  analyzer-name = "dep"
+  analyzer-version = 1
+  inputs-hash = "d414dbf5fc668c1085effa68372d02e54b23d058cc66f9fd19ba094c6a946d9b"
+  solver-name = "gps-cdcl"
+  solver-version = 1

--- a/cmd/dep/testdata/harness_tests/remove/specific/case1/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/remove/specific/case1/final/Gopkg.lock
@@ -13,6 +13,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-hash = "d414dbf5fc668c1085effa68372d02e54b23d058cc66f9fd19ba094c6a946d9b"
+  inputs-digest = "d414dbf5fc668c1085effa68372d02e54b23d058cc66f9fd19ba094c6a946d9b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/dep/testdata/harness_tests/remove/specific/case1/testcase.json
+++ b/cmd/dep/testdata/harness_tests/remove/specific/case1/testcase.json
@@ -2,6 +2,7 @@
   "commands": [
     ["remove", "github.com/not/used"]
   ],
+  "error-expected": "",
   "vendor-final": [
     "github.com/sdboyer/deptest",
     "github.com/sdboyer/deptestdos"

--- a/cmd/dep/testdata/harness_tests/remove/specific/case2/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/remove/specific/case2/final/Gopkg.lock
@@ -1,11 +1,13 @@
 
-[inputs]
-  analyzerName = "dep"
-  analyzerVersion = 1
-  memo = "38d8431865759ee3bf28fbdfc464f98ee8b56319394ec717df45e9969544cfca"
-
 [[projects]]
   name = "github.com/sdboyer/deptest"
   packages = ["."]
   revision = "ff2948a2ac8f538c4ecd55962e919d1e13e74baf"
   version = "v1.0.0"
+
+[solve-meta]
+  analyzer-name = "dep"
+  analyzer-version = 1
+  inputs-hash = "38d8431865759ee3bf28fbdfc464f98ee8b56319394ec717df45e9969544cfca"
+  solver-name = "gps-cdcl"
+  solver-version = 1

--- a/cmd/dep/testdata/harness_tests/remove/specific/case2/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/remove/specific/case2/final/Gopkg.lock
@@ -8,6 +8,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-hash = "38d8431865759ee3bf28fbdfc464f98ee8b56319394ec717df45e9969544cfca"
+  inputs-digest = "38d8431865759ee3bf28fbdfc464f98ee8b56319394ec717df45e9969544cfca"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/dep/testdata/harness_tests/remove/specific/case2/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/remove/specific/case2/final/Gopkg.lock
@@ -1,4 +1,8 @@
-memo = "38d8431865759ee3bf28fbdfc464f98ee8b56319394ec717df45e9969544cfca"
+
+[inputs]
+  analyzerName = "dep"
+  analyzerVersion = 1
+  memo = "38d8431865759ee3bf28fbdfc464f98ee8b56319394ec717df45e9969544cfca"
 
 [[projects]]
   name = "github.com/sdboyer/deptest"

--- a/cmd/dep/testdata/harness_tests/remove/specific/case2/testcase.json
+++ b/cmd/dep/testdata/harness_tests/remove/specific/case2/testcase.json
@@ -2,6 +2,7 @@
   "commands": [
     ["remove", "github.com/not/used"]
   ],
+  "error-expected": "",
   "vendor-initial": {
     "github.com/sdboyer/deptest": "v0.8.0",
     "github.com/sdboyer/deptestdos": "a0196baa11ea047dd65037287451d36b861b00ea"

--- a/cmd/dep/testdata/harness_tests/remove/unused/case1/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/remove/unused/case1/final/Gopkg.lock
@@ -1,4 +1,8 @@
-memo = "d414dbf5fc668c1085effa68372d02e54b23d058cc66f9fd19ba094c6a946d9b"
+
+[inputs]
+  analyzerName = "dep"
+  analyzerVersion = 1
+  memo = "d414dbf5fc668c1085effa68372d02e54b23d058cc66f9fd19ba094c6a946d9b"
 
 [[projects]]
   name = "github.com/sdboyer/deptest"

--- a/cmd/dep/testdata/harness_tests/remove/unused/case1/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/remove/unused/case1/final/Gopkg.lock
@@ -1,9 +1,4 @@
 
-[inputs]
-  analyzerName = "dep"
-  analyzerVersion = 1
-  memo = "d414dbf5fc668c1085effa68372d02e54b23d058cc66f9fd19ba094c6a946d9b"
-
 [[projects]]
   name = "github.com/sdboyer/deptest"
   packages = ["."]
@@ -14,3 +9,10 @@
   name = "github.com/sdboyer/deptestdos"
   packages = ["."]
   revision = "a0196baa11ea047dd65037287451d36b861b00ea"
+
+[solve-meta]
+  analyzer-name = "dep"
+  analyzer-version = 1
+  inputs-hash = "d414dbf5fc668c1085effa68372d02e54b23d058cc66f9fd19ba094c6a946d9b"
+  solver-name = "gps-cdcl"
+  solver-version = 1

--- a/cmd/dep/testdata/harness_tests/remove/unused/case1/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/remove/unused/case1/final/Gopkg.lock
@@ -13,6 +13,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-hash = "d414dbf5fc668c1085effa68372d02e54b23d058cc66f9fd19ba094c6a946d9b"
+  inputs-digest = "d414dbf5fc668c1085effa68372d02e54b23d058cc66f9fd19ba094c6a946d9b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/dep/testdata/harness_tests/remove/unused/case1/testcase.json
+++ b/cmd/dep/testdata/harness_tests/remove/unused/case1/testcase.json
@@ -2,6 +2,7 @@
   "commands": [
     ["remove", "-unused"]
   ],
+  "error-expected": "",
   "vendor-final": [
     "github.com/sdboyer/deptest",
     "github.com/sdboyer/deptestdos"

--- a/cmd/dep/testdata/harness_tests/status/case1/dot/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/status/case1/dot/final/Gopkg.lock
@@ -1,4 +1,8 @@
-memo = "88d2718cda70cce45158f953d2c6ead79c1db38e67e9704aff72be8fddb096e7"
+
+[inputs]
+  analyzerName = "dep"
+  analyzerVersion = 1
+  memo = "88d2718cda70cce45158f953d2c6ead79c1db38e67e9704aff72be8fddb096e7"
 
 [[projects]]
   name = "github.com/sdboyer/deptest"

--- a/cmd/dep/testdata/harness_tests/status/case1/dot/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/status/case1/dot/final/Gopkg.lock
@@ -1,9 +1,4 @@
 
-[inputs]
-  analyzerName = "dep"
-  analyzerVersion = 1
-  memo = "88d2718cda70cce45158f953d2c6ead79c1db38e67e9704aff72be8fddb096e7"
-
 [[projects]]
   name = "github.com/sdboyer/deptest"
   packages = ["."]
@@ -15,3 +10,10 @@
   packages = ["."]
   revision = "5c607206be5decd28e6263ffffdcee067266015e"
   version = "v2.0.0"
+
+[solve-meta]
+  analyzer-name = "dep"
+  analyzer-version = 1
+  inputs-hash = "88d2718cda70cce45158f953d2c6ead79c1db38e67e9704aff72be8fddb096e7"
+  solver-name = "gps-cdcl"
+  solver-version = 1

--- a/cmd/dep/testdata/harness_tests/status/case1/dot/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/status/case1/dot/final/Gopkg.lock
@@ -14,6 +14,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-hash = "88d2718cda70cce45158f953d2c6ead79c1db38e67e9704aff72be8fddb096e7"
+  inputs-digest = "88d2718cda70cce45158f953d2c6ead79c1db38e67e9704aff72be8fddb096e7"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/dep/testdata/harness_tests/status/case1/dot/testcase.json
+++ b/cmd/dep/testdata/harness_tests/status/case1/dot/testcase.json
@@ -1,8 +1,9 @@
 {
   "commands": [
     ["ensure"],
-    ["status","-dot"]
+    ["status", "-dot"]
   ],
+  "error-expected": "",
   "vendor-final": [
     "github.com/sdboyer/deptest",
     "github.com/sdboyer/deptestdos"

--- a/cmd/dep/testdata/harness_tests/status/case1/json/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/status/case1/json/final/Gopkg.lock
@@ -1,4 +1,8 @@
-memo = "88d2718cda70cce45158f953d2c6ead79c1db38e67e9704aff72be8fddb096e7"
+
+[inputs]
+  analyzerName = "dep"
+  analyzerVersion = 1
+  memo = "88d2718cda70cce45158f953d2c6ead79c1db38e67e9704aff72be8fddb096e7"
 
 [[projects]]
   name = "github.com/sdboyer/deptest"

--- a/cmd/dep/testdata/harness_tests/status/case1/json/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/status/case1/json/final/Gopkg.lock
@@ -1,9 +1,4 @@
 
-[inputs]
-  analyzerName = "dep"
-  analyzerVersion = 1
-  memo = "88d2718cda70cce45158f953d2c6ead79c1db38e67e9704aff72be8fddb096e7"
-
 [[projects]]
   name = "github.com/sdboyer/deptest"
   packages = ["."]
@@ -15,3 +10,10 @@
   packages = ["."]
   revision = "5c607206be5decd28e6263ffffdcee067266015e"
   version = "v2.0.0"
+
+[solve-meta]
+  analyzer-name = "dep"
+  analyzer-version = 1
+  inputs-hash = "88d2718cda70cce45158f953d2c6ead79c1db38e67e9704aff72be8fddb096e7"
+  solver-name = "gps-cdcl"
+  solver-version = 1

--- a/cmd/dep/testdata/harness_tests/status/case1/json/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/status/case1/json/final/Gopkg.lock
@@ -14,6 +14,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-hash = "88d2718cda70cce45158f953d2c6ead79c1db38e67e9704aff72be8fddb096e7"
+  inputs-digest = "88d2718cda70cce45158f953d2c6ead79c1db38e67e9704aff72be8fddb096e7"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/dep/testdata/harness_tests/status/case1/json/testcase.json
+++ b/cmd/dep/testdata/harness_tests/status/case1/json/testcase.json
@@ -1,8 +1,9 @@
 {
   "commands": [
     ["ensure"],
-    ["status","-json"]
+    ["status", "-json"]
   ],
+  "error-expected": "",
   "vendor-final": [
     "github.com/sdboyer/deptest",
     "github.com/sdboyer/deptestdos"

--- a/cmd/dep/testdata/harness_tests/status/case1/table/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/status/case1/table/final/Gopkg.lock
@@ -1,4 +1,8 @@
-memo = "88d2718cda70cce45158f953d2c6ead79c1db38e67e9704aff72be8fddb096e7"
+
+[inputs]
+  analyzerName = "dep"
+  analyzerVersion = 1
+  memo = "88d2718cda70cce45158f953d2c6ead79c1db38e67e9704aff72be8fddb096e7"
 
 [[projects]]
   name = "github.com/sdboyer/deptest"

--- a/cmd/dep/testdata/harness_tests/status/case1/table/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/status/case1/table/final/Gopkg.lock
@@ -1,9 +1,4 @@
 
-[inputs]
-  analyzerName = "dep"
-  analyzerVersion = 1
-  memo = "88d2718cda70cce45158f953d2c6ead79c1db38e67e9704aff72be8fddb096e7"
-
 [[projects]]
   name = "github.com/sdboyer/deptest"
   packages = ["."]
@@ -15,3 +10,10 @@
   packages = ["."]
   revision = "5c607206be5decd28e6263ffffdcee067266015e"
   version = "v2.0.0"
+
+[solve-meta]
+  analyzer-name = "dep"
+  analyzer-version = 1
+  inputs-hash = "88d2718cda70cce45158f953d2c6ead79c1db38e67e9704aff72be8fddb096e7"
+  solver-name = "gps-cdcl"
+  solver-version = 1

--- a/cmd/dep/testdata/harness_tests/status/case1/table/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/status/case1/table/final/Gopkg.lock
@@ -14,6 +14,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-hash = "88d2718cda70cce45158f953d2c6ead79c1db38e67e9704aff72be8fddb096e7"
+  inputs-digest = "88d2718cda70cce45158f953d2c6ead79c1db38e67e9704aff72be8fddb096e7"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/dep/testdata/harness_tests/status/case1/table/testcase.json
+++ b/cmd/dep/testdata/harness_tests/status/case1/table/testcase.json
@@ -3,6 +3,7 @@
     ["ensure"],
     ["status"]
   ],
+  "error-expected": "",
   "vendor-final": [
     "github.com/sdboyer/deptest",
     "github.com/sdboyer/deptestdos"

--- a/internal/gps/lock.go
+++ b/internal/gps/lock.go
@@ -17,9 +17,6 @@ import (
 // solution is all that would be necessary to constitute a lock file, though
 // tools can include whatever other information they want in their storage.
 type Lock interface {
-	// Indicates the version of the solver used to generate this lock data
-	//SolverVersion() string
-
 	// The hash of inputs to gps that resulted in this lock data
 	InputHash() []byte
 

--- a/internal/gps/result.go
+++ b/internal/gps/result.go
@@ -16,8 +16,12 @@ type Solution interface {
 	Lock
 	// The name of the ProjectAnalyzer used in generating this solution.
 	AnalyzerName() string
-	// The version of the ProjectAanalyzer used in generating this solution.
+	// The version of the ProjectAnalyzer used in generating this solution.
 	AnalyzerVersion() int
+	// The name of the Solver used in generating this solution.
+	SolverName() string
+	// The version of the Solver used in generating this solution.
+	SolverVersion() int
 	Attempts() int
 }
 
@@ -36,6 +40,9 @@ type solution struct {
 
 	// The analyzer version
 	analyzerVersion int
+
+	// The solver used in producing this solution
+	solv Solver
 }
 
 // WriteDepTree takes a basedir and a Lock, and exports all the projects
@@ -93,4 +100,12 @@ func (r solution) AnalyzerName() string {
 
 func (r solution) AnalyzerVersion() int {
 	return r.analyzerVersion
+}
+
+func (r solution) SolverName() string {
+	return r.solv.Name()
+}
+
+func (r solution) SolverVersion() int {
+	return r.solv.Version()
 }

--- a/internal/gps/result.go
+++ b/internal/gps/result.go
@@ -14,6 +14,10 @@ import (
 // additional methods that report information about the solve run.
 type Solution interface {
 	Lock
+	// The name of the ProjectAnalyzer used in generating this solution.
+	AnalyzerName() string
+	// The version of the ProjectAanalyzer used in generating this solution.
+	AnalyzerVersion() int
 	Attempts() int
 }
 
@@ -26,6 +30,12 @@ type solution struct {
 
 	// The hash digest of the input opts
 	hd []byte
+
+	// The analyzer name
+	analyzerName string
+
+	// The analyzer version
+	analyzerVersion int
 }
 
 // WriteDepTree takes a basedir and a Lock, and exports all the projects
@@ -75,4 +85,12 @@ func (r solution) Attempts() int {
 
 func (r solution) InputHash() []byte {
 	return r.hd
+}
+
+func (r solution) AnalyzerName() string {
+	return r.analyzerName
+}
+
+func (r solution) AnalyzerVersion() int {
+	return r.analyzerVersion
 }

--- a/internal/gps/result_test.go
+++ b/internal/gps/result_test.go
@@ -35,6 +35,7 @@ func init() {
 			}, nil),
 		},
 	}
+	basicResult.analyzerName, basicResult.analyzerVersion = (naiveAnalyzer{}).Info()
 
 	// just in case something needs punishing, kubernetes is happy to oblige
 	kub = atom{

--- a/internal/gps/solver.go
+++ b/internal/gps/solver.go
@@ -358,7 +358,7 @@ func (s *solver) Solve() (Solution, error) {
 		soln = solution{
 			att: s.attempts,
 		}
-
+		soln.analyzerName, soln.analyzerVersion = s.rd.an.Info()
 		soln.hd = s.HashInputs()
 
 		// Convert ProjectAtoms into LockedProjects

--- a/lock.go
+++ b/lock.go
@@ -149,15 +149,11 @@ func (l *Lock) MarshalTOML() ([]byte, error) {
 	return result, errors.Wrap(err, "Unable to marshal lock to TOML string")
 }
 
-// LockFromInterface converts an arbitrary gps.Lock to dep's representation of a
-// lock. If the input is already dep's *lock, the input is returned directly.
+// LockFromSolution converts a gps.Solution to dep's representation of a lock.
 //
 // Data is defensively copied wherever necessary to ensure the resulting *lock
 // shares no memory with the original lock.
-//
-// As gps.Solution is a superset of gps.Lock, this can also be used to convert
-// solutions to dep's lock format.
-func LockFromInterface(in gps.Solution) *Lock {
+func LockFromSolution(in gps.Solution) *Lock {
 	h, p := in.InputHash(), in.Projects()
 
 	l := &Lock{

--- a/lock.go
+++ b/lock.go
@@ -36,7 +36,7 @@ type rawLock struct {
 }
 
 type solveMeta struct {
-	Memo            string `toml:"inputs-hash"`
+	InputsDigest    string `toml:"inputs-digest"`
 	AnalyzerName    string `toml:"analyzer-name"`
 	AnalyzerVersion int    `toml:"analyzer-version"`
 	SolverName      string `toml:"solver-name"`
@@ -74,7 +74,7 @@ func fromRawLock(raw rawLock) (*Lock, error) {
 		P: make([]gps.LockedProject, len(raw.Projects)),
 	}
 
-	l.SolveMeta.Memo, err = hex.DecodeString(raw.SolveMeta.Memo)
+	l.SolveMeta.Memo, err = hex.DecodeString(raw.SolveMeta.InputsDigest)
 	if err != nil {
 		return nil, errors.Errorf("invalid hash digest in lock's memo field")
 	}
@@ -121,7 +121,7 @@ func (l *Lock) Projects() []gps.LockedProject {
 func (l *Lock) toRaw() rawLock {
 	raw := rawLock{
 		SolveMeta: solveMeta{
-			Memo:            hex.EncodeToString(l.SolveMeta.Memo),
+			InputsDigest:    hex.EncodeToString(l.SolveMeta.Memo),
 			AnalyzerName:    l.SolveMeta.AnalyzerName,
 			AnalyzerVersion: l.SolveMeta.AnalyzerVersion,
 			SolverName:      l.SolveMeta.SolverName,

--- a/lock_test.go
+++ b/lock_test.go
@@ -28,7 +28,7 @@ func TestReadLock(t *testing.T) {
 
 	b, _ := hex.DecodeString("2252a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e")
 	want := &Lock{
-		Inputs: InputInfo{
+		SolveMeta: SolveMeta{
 			Memo: b,
 		},
 		P: []gps.LockedProject{
@@ -54,7 +54,7 @@ func TestReadLock(t *testing.T) {
 
 	b, _ = hex.DecodeString("2252a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e")
 	want = &Lock{
-		Inputs: InputInfo{
+		SolveMeta: SolveMeta{
 			Memo: b,
 		},
 		P: []gps.LockedProject{
@@ -79,7 +79,7 @@ func TestWriteLock(t *testing.T) {
 	want := h.GetTestFileString(golden)
 	memo, _ := hex.DecodeString("2252a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e")
 	l := &Lock{
-		Inputs: InputInfo{
+		SolveMeta: SolveMeta{
 			Memo: memo,
 		},
 		P: []gps.LockedProject{
@@ -110,7 +110,7 @@ func TestWriteLock(t *testing.T) {
 	want = h.GetTestFileString(golden)
 	memo, _ = hex.DecodeString("2252a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e")
 	l = &Lock{
-		Inputs: InputInfo{
+		SolveMeta: SolveMeta{
 			Memo: memo,
 		},
 		P: []gps.LockedProject{

--- a/lock_test.go
+++ b/lock_test.go
@@ -28,7 +28,9 @@ func TestReadLock(t *testing.T) {
 
 	b, _ := hex.DecodeString("2252a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e")
 	want := &Lock{
-		Memo: b,
+		Inputs: InputInfo{
+			Memo: b,
+		},
 		P: []gps.LockedProject{
 			gps.NewLockedProject(
 				gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot("github.com/golang/dep/internal/gps")},
@@ -52,7 +54,9 @@ func TestReadLock(t *testing.T) {
 
 	b, _ = hex.DecodeString("2252a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e")
 	want = &Lock{
-		Memo: b,
+		Inputs: InputInfo{
+			Memo: b,
+		},
 		P: []gps.LockedProject{
 			gps.NewLockedProject(
 				gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot("github.com/golang/dep/internal/gps")},
@@ -75,7 +79,9 @@ func TestWriteLock(t *testing.T) {
 	want := h.GetTestFileString(golden)
 	memo, _ := hex.DecodeString("2252a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e")
 	l := &Lock{
-		Memo: memo,
+		Inputs: InputInfo{
+			Memo: memo,
+		},
 		P: []gps.LockedProject{
 			gps.NewLockedProject(
 				gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot("github.com/golang/dep/internal/gps")},
@@ -104,7 +110,9 @@ func TestWriteLock(t *testing.T) {
 	want = h.GetTestFileString(golden)
 	memo, _ = hex.DecodeString("2252a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e")
 	l = &Lock{
-		Memo: memo,
+		Inputs: InputInfo{
+			Memo: memo,
+		},
 		P: []gps.LockedProject{
 			gps.NewLockedProject(
 				gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot("github.com/golang/dep/internal/gps")},

--- a/testdata/lock/error0.toml
+++ b/testdata/lock/error0.toml
@@ -1,5 +1,5 @@
 [solve-meta]
-inputs-hash = "2252a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e"
+  inputs-digest = "2252a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e"
 
 [[projects]]
   name = "github.com/golang/dep/internal/gps"

--- a/testdata/lock/error0.toml
+++ b/testdata/lock/error0.toml
@@ -1,4 +1,5 @@
-memo = "2252a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e"
+[solve-meta]
+inputs-hash = "2252a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e"
 
 [[projects]]
   name = "github.com/golang/dep/internal/gps"

--- a/testdata/lock/error1.toml
+++ b/testdata/lock/error1.toml
@@ -1,3 +1,4 @@
+[inputs]
 memo = "000aaa2a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e"
 
 [[projects]]

--- a/testdata/lock/error1.toml
+++ b/testdata/lock/error1.toml
@@ -5,5 +5,5 @@
   packages = ["."]
 
 [solve-meta]
-  inputs-hash = "000aaa2a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e"
+  inputs-digest = "000aaa2a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e"
 

--- a/testdata/lock/error1.toml
+++ b/testdata/lock/error1.toml
@@ -1,8 +1,9 @@
-[inputs]
-memo = "000aaa2a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e"
-
 [[projects]]
   name = "github.com/golang/dep/internal/gps"
   branch = "master"
   revision = "d05d5aca9f895d19e9265839bffeadd74a2d2ecb"
   packages = ["."]
+
+[solve-meta]
+  inputs-hash = "000aaa2a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e"
+

--- a/testdata/lock/error2.toml
+++ b/testdata/lock/error2.toml
@@ -3,5 +3,5 @@
   packages = ["."]
 
 [solve-meta]
-  inputs-hash = "2252a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e"
+  inputs-digest = "2252a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e"
 

--- a/testdata/lock/error2.toml
+++ b/testdata/lock/error2.toml
@@ -1,5 +1,7 @@
-memo = "2252a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e"
-
 [[projects]]
   name = "github.com/golang/dep/internal/gps"
   packages = ["."]
+
+[solve-meta]
+  inputs-hash = "2252a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e"
+

--- a/testdata/lock/golden0.toml
+++ b/testdata/lock/golden0.toml
@@ -1,11 +1,13 @@
 
-[inputs]
-  analyzerName = ""
-  analyzerVersion = 0
-  memo = "2252a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e"
-
 [[projects]]
   branch = "master"
   name = "github.com/golang/dep/internal/gps"
   packages = ["."]
   revision = "d05d5aca9f895d19e9265839bffeadd74a2d2ecb"
+
+[solve-meta]
+  analyzer-name = ""
+  analyzer-version = 0
+  inputs-hash = "2252a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e"
+  solver-name = ""
+  solver-version = 0

--- a/testdata/lock/golden0.toml
+++ b/testdata/lock/golden0.toml
@@ -8,6 +8,6 @@
 [solve-meta]
   analyzer-name = ""
   analyzer-version = 0
-  inputs-hash = "2252a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e"
+  inputs-digest = "2252a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e"
   solver-name = ""
   solver-version = 0

--- a/testdata/lock/golden0.toml
+++ b/testdata/lock/golden0.toml
@@ -1,4 +1,8 @@
-memo = "2252a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e"
+
+[inputs]
+  analyzerName = ""
+  analyzerVersion = 0
+  memo = "2252a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e"
 
 [[projects]]
   branch = "master"

--- a/testdata/lock/golden1.toml
+++ b/testdata/lock/golden1.toml
@@ -1,4 +1,8 @@
-memo = "2252a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e"
+
+[inputs]
+  analyzerName = ""
+  analyzerVersion = 0
+  memo = "2252a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e"
 
 [[projects]]
   name = "github.com/golang/dep/internal/gps"

--- a/testdata/lock/golden1.toml
+++ b/testdata/lock/golden1.toml
@@ -1,11 +1,13 @@
 
-[inputs]
-  analyzerName = ""
-  analyzerVersion = 0
-  memo = "2252a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e"
-
 [[projects]]
   name = "github.com/golang/dep/internal/gps"
   packages = ["."]
   revision = "d05d5aca9f895d19e9265839bffeadd74a2d2ecb"
   version = "0.12.2"
+
+[solve-meta]
+  analyzer-name = ""
+  analyzer-version = 0
+  inputs-hash = "2252a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e"
+  solver-name = ""
+  solver-version = 0

--- a/testdata/lock/golden1.toml
+++ b/testdata/lock/golden1.toml
@@ -8,6 +8,6 @@
 [solve-meta]
   analyzer-name = ""
   analyzer-version = 0
-  inputs-hash = "2252a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e"
+  inputs-digest = "2252a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e"
   solver-name = ""
   solver-version = 0

--- a/testdata/txn_writer/expected_diff_output.txt
+++ b/testdata/txn_writer/expected_diff_output.txt
@@ -1,5 +1,3 @@
-Memo: 595716d270828e763c811ef79c9c41f85b1d1bfbdfe85280036405c03772206c -> 2252a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e
-
 Add:
 [[projects]]
   name = "github.com/sdboyer/deptest"

--- a/testdata/txn_writer/expected_diff_output.txt
+++ b/testdata/txn_writer/expected_diff_output.txt
@@ -1,3 +1,4 @@
+Memo: 595716d270828e763c811ef79c9c41f85b1d1bfbdfe85280036405c03772206c -> 2252a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e
 Add:
 [[projects]]
   name = "github.com/sdboyer/deptest"

--- a/testdata/txn_writer/expected_lock.toml
+++ b/testdata/txn_writer/expected_lock.toml
@@ -1,4 +1,8 @@
-memo = "595716d270828e763c811ef79c9c41f85b1d1bfbdfe85280036405c03772206c"
+
+[inputs]
+  analyzerName = ""
+  analyzerVersion = 0
+  memo = "595716d270828e763c811ef79c9c41f85b1d1bfbdfe85280036405c03772206c"
 
 [[projects]]
   name = "github.com/sdboyer/dep-test"

--- a/testdata/txn_writer/expected_lock.toml
+++ b/testdata/txn_writer/expected_lock.toml
@@ -8,6 +8,6 @@
 [solve-meta]
   analyzer-name = ""
   analyzer-version = 0
-  inputs-hash = "595716d270828e763c811ef79c9c41f85b1d1bfbdfe85280036405c03772206c"
+  inputs-digest = "595716d270828e763c811ef79c9c41f85b1d1bfbdfe85280036405c03772206c"
   solver-name = ""
   solver-version = 0

--- a/testdata/txn_writer/expected_lock.toml
+++ b/testdata/txn_writer/expected_lock.toml
@@ -1,11 +1,13 @@
 
-[inputs]
-  analyzerName = ""
-  analyzerVersion = 0
-  memo = "595716d270828e763c811ef79c9c41f85b1d1bfbdfe85280036405c03772206c"
-
 [[projects]]
   name = "github.com/sdboyer/dep-test"
   packages = ["."]
   revision = "2a3a211e171803acb82d1d5d42ceb53228f51751"
   version = "1.0.0"
+
+[solve-meta]
+  analyzer-name = ""
+  analyzer-version = 0
+  inputs-hash = "595716d270828e763c811ef79c9c41f85b1d1bfbdfe85280036405c03772206c"
+  solver-name = ""
+  solver-version = 0

--- a/testdata/txn_writer/original_lock.toml
+++ b/testdata/txn_writer/original_lock.toml
@@ -1,4 +1,5 @@
-memo = "595716d270828e763c811ef79c9c41f85b1d1bfbdfe85280036405c03772206c"
+[solve-meta]
+  inputs-hash = "595716d270828e763c811ef79c9c41f85b1d1bfbdfe85280036405c03772206c"
 
 [[projects]]
   name = "github.com/foo/bar"

--- a/testdata/txn_writer/original_lock.toml
+++ b/testdata/txn_writer/original_lock.toml
@@ -1,5 +1,5 @@
 [solve-meta]
-  inputs-hash = "595716d270828e763c811ef79c9c41f85b1d1bfbdfe85280036405c03772206c"
+  inputs-digest = "2252a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e"
 
 [[projects]]
   name = "github.com/foo/bar"

--- a/testdata/txn_writer/updated_lock.toml
+++ b/testdata/txn_writer/updated_lock.toml
@@ -1,5 +1,5 @@
 [solve-meta]
-  inputs-hash = "595716d270828e763c811ef79c9c41f85b1d1bfbdfe85280036405c03772206c"
+  inputs-digest = "595716d270828e763c811ef79c9c41f85b1d1bfbdfe85280036405c03772206c"
 
 [[projects]]
   name = "github.com/foo/bar"

--- a/testdata/txn_writer/updated_lock.toml
+++ b/testdata/txn_writer/updated_lock.toml
@@ -1,4 +1,5 @@
-memo = "2252a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e"
+[solve-meta]
+  inputs-hash = "595716d270828e763c811ef79c9c41f85b1d1bfbdfe85280036405c03772206c"
 
 [[projects]]
   name = "github.com/foo/bar"

--- a/txn_writer_test.go
+++ b/txn_writer_test.go
@@ -261,7 +261,7 @@ func TestSafeWriter_ModifiedLock(t *testing.T) {
 
 	originalLock := new(Lock)
 	*originalLock = *pc.Project.Lock
-	originalLock.Memo = []byte{} // zero out the input hash to ensure non-equivalency
+	originalLock.Inputs.Memo = []byte{} // zero out the input hash to ensure non-equivalency
 	sw, _ := NewSafeWriter(nil, originalLock, pc.Project.Lock, VendorOnChanged)
 
 	// Verify prepared actions
@@ -308,7 +308,7 @@ func TestSafeWriter_ModifiedLockSkipVendor(t *testing.T) {
 
 	originalLock := new(Lock)
 	*originalLock = *pc.Project.Lock
-	originalLock.Memo = []byte{} // zero out the input hash to ensure non-equivalency
+	originalLock.Inputs.Memo = []byte{} // zero out the input hash to ensure non-equivalency
 	sw, _ := NewSafeWriter(nil, originalLock, pc.Project.Lock, VendorNever)
 
 	// Verify prepared actions

--- a/txn_writer_test.go
+++ b/txn_writer_test.go
@@ -261,18 +261,18 @@ func TestSafeWriter_ModifiedLock(t *testing.T) {
 
 	originalLock := new(Lock)
 	*originalLock = *pc.Project.Lock
-	originalLock.Inputs.Memo = []byte{} // zero out the input hash to ensure non-equivalency
+	originalLock.SolveMeta.Memo = []byte{} // zero out the input hash to ensure non-equivalency
 	sw, _ := NewSafeWriter(nil, originalLock, pc.Project.Lock, VendorOnChanged)
 
 	// Verify prepared actions
 	if sw.HasManifest() {
-		t.Fatal("Did not expect the payload to contain the manifest")
+		t.Fatal("Did not expect the manifest to be written")
 	}
 	if !sw.HasLock() {
-		t.Fatal("Expected the payload to contain the lock")
+		t.Fatal("Expected that the writer should plan to write the lock")
 	}
 	if !sw.HasVendor() {
-		t.Fatal("Expected the payload to contain the vendor directory")
+		t.Fatal("Expected that the writer should plan to write the vendor directory")
 	}
 
 	// Write changes
@@ -308,7 +308,7 @@ func TestSafeWriter_ModifiedLockSkipVendor(t *testing.T) {
 
 	originalLock := new(Lock)
 	*originalLock = *pc.Project.Lock
-	originalLock.Inputs.Memo = []byte{} // zero out the input hash to ensure non-equivalency
+	originalLock.SolveMeta.Memo = []byte{} // zero out the input hash to ensure non-equivalency
 	sw, _ := NewSafeWriter(nil, originalLock, pc.Project.Lock, VendorNever)
 
 	// Verify prepared actions


### PR DESCRIPTION
Fixes #508 
Fixes #421 

The essential changes are as follows:

* `Lock` now has a `Lock.Inputs` that contains the three bits of input info we want to track (for now): the old top-level `Memo` property, plus the name and version of the analyzer.
* `gps.Solution` adds two methods to return the name and version of the `ProjectAnalyzer` that was used to create the solution.
* `LockFromInterface(in gps.Lock) *Lock` becomes `LockFromSolution(in gps.Solution) *Lock`.