### PR TITLE
Don't add unconstrained deps to Manifest on init.

### DIFF
--- a/cmd/dep/init.go
+++ b/cmd/dep/init.go
@@ -410,10 +410,6 @@ func getProjectData(ctx *dep.Ctx, pkgT pkgtree.PackageTree, cpr string, sm gps.S
 		pp := getProjectPropertiesFromVersion(v)
 		if pp.Constraint != nil || pp.Source != "" {
 			constraints[pr] = pp
-		} else {
-			if ctx.Loggers.Verbose {
-				ctx.Loggers.Err.Printf("dep: \"%v\" is unconstrained. Not adding to project data.\n", pr)
-			}
 		}
 
 		feedback(v, pr, fb.DepTypeDirect, ctx)

--- a/cmd/dep/init.go
+++ b/cmd/dep/init.go
@@ -407,7 +407,14 @@ func getProjectData(ctx *dep.Ctx, pkgT pkgtree.PackageTree, cpr string, sm gps.S
 		}
 
 		ondisk[pr] = v
-		constraints[pr] = getProjectPropertiesFromVersion(v)
+		pp := getProjectPropertiesFromVersion(v)
+		if pp.Constraint != nil || pp.Source != "" {
+			constraints[pr] = pp
+		} else {
+			if ctx.Loggers.Verbose {
+				ctx.Loggers.Err.Printf("dep: \"%v\" is unconstrained. Not adding to project data.\n", pr)
+			}
+		}
 
 		feedback(v, pr, fb.DepTypeDirect, ctx)
 	}

--- a/cmd/dep/testdata/harness_tests/init/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/case1/final/Gopkg.toml
@@ -2,6 +2,3 @@
 [[dependencies]]
   name = "github.com/sdboyer/deptest"
   version = ">=0.8.0, <1.0.0"
-
-[[dependencies]]
-  name = "github.com/sdboyer/deptestdos"

--- a/cmd/dep/testdata/harness_tests/init/case3/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/case3/final/Gopkg.toml
@@ -2,6 +2,3 @@
 [[dependencies]]
   branch = "master"
   name = "github.com/sdboyer/deptest"
-
-[[dependencies]]
-  name = "github.com/sdboyer/deptestdos"


### PR DESCRIPTION
Attempts to fix #574.

Ran `dep ensure` before I built this locally to get dependencies. It added all of the vendor files and not sure if they should be there.

Also, I wasn't sure if this was better suited being moved into the gps package instead of just in the init.

Thanks,
