### PR TITLE
Add support for -unstable gopkg.in imports

### DIFF
--- a/internal/gps/maybe_source.go
+++ b/internal/gps/maybe_source.go
@@ -131,6 +131,8 @@ type maybeGopkginSource struct {
 	url *url.URL
 	// the major version to apply for filtering
 	major uint64
+	// whether or not the source package is "unstable"
+	unstable bool
 }
 
 func (m maybeGopkginSource) try(ctx context.Context, cachedir string, c singleSourceCache, superv *supervisor) (source, sourceState, error) {
@@ -151,7 +153,8 @@ func (m maybeGopkginSource) try(ctx context.Context, cachedir string, c singleSo
 				repo: &gitRepo{r},
 			},
 		},
-		major: m.major,
+		major:    m.major,
+		unstable: m.unstable,
 	}
 
 	var vl []PairedVersion

--- a/internal/gps/vcs_source.go
+++ b/internal/gps/vcs_source.go
@@ -315,7 +315,7 @@ func (s *gopkginSource) listVersions(ctx context.Context) ([]PairedVersion, erro
 
 			// Gopkg.in has a special "-unstable" suffix which we need to handle
 			// separately.
-			if s.unstable && !strings.HasSuffix(tv.name, gopkgUnstableSuffix) {
+			if s.unstable != strings.HasSuffix(tv.name, gopkgUnstableSuffix) {
 				continue
 			}
 

--- a/internal/gps/vcs_source.go
+++ b/internal/gps/vcs_source.go
@@ -298,7 +298,7 @@ func (s *gopkginSource) listVersions(ctx context.Context) ([]PairedVersion, erro
 		pv := v.(versionPair)
 		switch tv := pv.v.(type) {
 		case semVersion:
-			if tv.sv.Major() == s.major {
+			if tv.sv.Major() == s.major && !s.unstable {
 				vlist[k] = v
 				k++
 			}

--- a/internal/gps/vcs_source.go
+++ b/internal/gps/vcs_source.go
@@ -278,7 +278,8 @@ func (s *gitSource) listVersions(ctx context.Context) (vlist []PairedVersion, er
 // according to the input URL.
 type gopkginSource struct {
 	gitSource
-	major uint64
+	major    uint64
+	unstable bool
 }
 
 func (s *gopkginSource) listVersions(ctx context.Context) ([]PairedVersion, error) {
@@ -304,13 +305,17 @@ func (s *gopkginSource) listVersions(ctx context.Context) ([]PairedVersion, erro
 		case branchVersion:
 			// The semver lib isn't exactly the same as gopkg.in's logic, but
 			// it's close enough that it's probably fine to use. We can be more
-			// exact if real problems crop up. The most obvious vector for
-			// problems is that we totally ignore the "unstable" designation
-			// right now.
+			// exact if real problems crop up.
 			sv, err := semver.NewVersion(tv.name)
 			if err != nil || sv.Major() != s.major {
 				// not a semver-shaped branch name at all, or not the same major
 				// version as specified in the import path constraint
+				continue
+			}
+
+			// Gopkg.in has a special "-unstable" suffix which we need to handle
+			// separately.
+			if s.unstable && !strings.HasSuffix(tv.name, gopkgUnstableSuffix) {
 				continue
 			}
 

--- a/internal/gps/vcs_source_test.go
+++ b/internal/gps/vcs_source_test.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os/exec"
 	"reflect"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -152,10 +153,12 @@ func testGopkginSourceInteractions(t *testing.T) {
 			t.Errorf("URL was bad, lolwut? errtext: %s", err)
 			return
 		}
+		unstable := strings.HasSuffix(opath, gopkgUnstableSuffix)
 		mb := maybeGopkginSource{
-			opath: opath,
-			url:   u,
-			major: major,
+			opath:    opath,
+			url:      u,
+			major:    major,
+			unstable: unstable,
 		}
 
 		ctx := context.Background()
@@ -240,7 +243,7 @@ func testGopkginSourceInteractions(t *testing.T) {
 
 	// simultaneously run for v1, v2, and v3 filters of the target repo
 	wg := &sync.WaitGroup{}
-	wg.Add(3)
+	wg.Add(4)
 	go func() {
 		tfunc("gopkg.in/sdboyer/gpkt.v1", "github.com/sdboyer/gpkt", 1, []Version{
 			NewVersion("v1.1.0").Is(Revision("b2cb48dda625f6640b34d9ffb664533359ac8b91")),
@@ -261,6 +264,13 @@ func testGopkginSourceInteractions(t *testing.T) {
 	go func() {
 		tfunc("gopkg.in/sdboyer/gpkt.v3", "github.com/sdboyer/gpkt", 3, []Version{
 			newDefaultBranch("v3").Is(Revision("4a54adf81c75375d26d376459c00d5ff9b703e5e")),
+		})
+		wg.Done()
+	}()
+
+	go func() {
+		tfunc("gopkg.in/mgo.v2-unstable", "github.com/go-mgo/mgo", 2, []Version{
+			newDefaultBranch("v2-unstable").Is(Revision("9a2573d4ae52a2bf9f5b7900a50e2f8bcceeb774")),
 		})
 		wg.Done()
 	}()

--- a/internal/gps/vcs_source_test.go
+++ b/internal/gps/vcs_source_test.go
@@ -269,8 +269,8 @@ func testGopkginSourceInteractions(t *testing.T) {
 	}()
 
 	go func() {
-		tfunc("gopkg.in/mgo.v2-unstable", "github.com/go-mgo/mgo", 2, []Version{
-			newDefaultBranch("v2-unstable").Is(Revision("9a2573d4ae52a2bf9f5b7900a50e2f8bcceeb774")),
+		tfunc("github.com/sdboyer/gpkt2.v1-unstable", "github.com/sdboyer/gpkt2", 1, []Version{
+			newDefaultBranch("v1-unstable").Is(Revision("24de0be8f4a0b8a44321562117749b257bfcef69")),
 		})
 		wg.Done()
 	}()


### PR DESCRIPTION
Fixes #425

```bash
dep-test - master! ❯ dep ensure -v gopkg.in/mgo.v2-unstable
dep: No constraint or alternate source specified for "gopkg.in/mgo.v2-unstable", omitting from manifest
Root project is "scratch/dep-test"
 1 transitively valid internal packages
 2 external packages imported from 2 projects
(0)   ✓ select (root)
(1)     ? attempt github.com/pkg/errors with 1 pkgs; at least 1 versions to try
(1)         try github.com/pkg/errors@v0.8.0
(1)     ✓ select github.com/pkg/errors@v0.8.0 w/1 pkgs
(2)     ? attempt gopkg.in/mgo.v2-unstable with 1 pkgs; 1 versions to try
(2)         try gopkg.in/mgo.v2-unstable@v2-unstable
(2)     ✓ select gopkg.in/mgo.v2-unstable@v2-unstable w/5 pkgs
  ✓ found solution with 6 packages from 2 projects

Solver wall times by segment:
         b-list-pkgs: 637.471037ms
              b-gmal: 398.518303ms
     b-source-exists: 156.043538ms
             satisfy:    550.358µs
         select-atom:    358.518µs
            new-atom:    240.444µs
         select-root:     83.551µs
  b-deduce-proj-root:     15.934µs
               other:     14.055µs
     b-list-versions:     11.312µs

  TOTAL: 1.19330705s

dep-test - master! ❯ cat Gopkg.lock
memo = "842e27492a249b7020fca265003afa2ef25e260ebaae9e0242ccb02decac74ef"

[[projects]]
  name = "github.com/pkg/errors"
  packages = ["."]
  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
  version = "v0.8.0"

[[projects]]
  branch = "v2-unstable"
  name = "gopkg.in/mgo.v2-unstable"
  packages = [".","bson","internal/json","internal/sasl","internal/scram"]
  revision = "9a2573d4ae52a2bf9f5b7900a50e2f8bcceeb774"
```

If this is the right approach, I'll have @sdboyer push an -unstable version to the gopkt testbed instead of using mgo, which was just an example from the wild.