### PR TITLE
internal/gps: remove unused sortPackageOrErr type

### DIFF
--- a/internal/gps/hash.go
+++ b/internal/gps/hash.go
@@ -11,8 +11,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-
-	"github.com/golang/dep/internal/gps/pkgtree"
 )
 
 // string headers used to demarcate sections in hash input creation
@@ -132,26 +130,4 @@ func HashingInputsAsString(s Solver) string {
 	ts.writeHashingInputs(buf)
 
 	return (*bytes.Buffer)(buf).String()
-}
-
-type sortPackageOrErr []pkgtree.PackageOrErr
-
-func (s sortPackageOrErr) Len() int      { return len(s) }
-func (s sortPackageOrErr) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
-
-func (s sortPackageOrErr) Less(i, j int) bool {
-	a, b := s[i], s[j]
-	if a.Err != nil || b.Err != nil {
-		// Sort errors last.
-		if b.Err == nil {
-			return false
-		}
-		if a.Err == nil {
-			return true
-		}
-		// And then by string.
-		return a.Err.Error() < b.Err.Error()
-	}
-	// And finally, sort by import path.
-	return a.P.ImportPath < b.P.ImportPath
 }


### PR DESCRIPTION
Remove unused, untested, sortPackageOrErr type.

Coverage of internal/gps improved from 81.6% to 81.9% with this change.