### PR TITLE
dep: unexport Manifest.Ignored

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -21,7 +21,7 @@ const ManifestName = "Gopkg.toml"
 type Manifest struct {
 	Dependencies gps.ProjectConstraints
 	Ovr          gps.ProjectConstraints
-	Ignored      []string
+	ignored      []string
 	Required     []string
 }
 
@@ -119,7 +119,7 @@ func fromRawManifest(raw rawManifest) (*Manifest, error) {
 	m := &Manifest{
 		Dependencies: make(gps.ProjectConstraints, len(raw.Dependencies)),
 		Ovr:          make(gps.ProjectConstraints, len(raw.Overrides)),
-		Ignored:      raw.Ignored,
+		ignored:      raw.Ignored,
 		Required:     raw.Required,
 	}
 
@@ -184,7 +184,7 @@ func (m *Manifest) toRaw() rawManifest {
 	raw := rawManifest{
 		Dependencies: make([]rawProject, 0, len(m.Dependencies)),
 		Overrides:    make([]rawProject, 0, len(m.Ovr)),
-		Ignored:      m.Ignored,
+		Ignored:      m.ignored,
 		Required:     m.Required,
 	}
 	for n, prj := range m.Dependencies {
@@ -267,12 +267,8 @@ func (m *Manifest) Overrides() gps.ProjectConstraints {
 }
 
 func (m *Manifest) IgnoredPackages() map[string]bool {
-	if len(m.Ignored) == 0 {
-		return nil
-	}
-
-	mp := make(map[string]bool, len(m.Ignored))
-	for _, i := range m.Ignored {
+	mp := make(map[string]bool, len(m.ignored))
+	for _, i := range m.ignored {
 		mp[i] = true
 	}
 

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -41,7 +41,7 @@ func TestReadManifest(t *testing.T) {
 				Constraint: gps.NewBranch("master"),
 			},
 		},
-		Ignored: []string{"github.com/foo/bar"},
+		ignored: []string{"github.com/foo/bar"},
 	}
 
 	if !reflect.DeepEqual(got.Dependencies, want.Dependencies) {
@@ -50,7 +50,7 @@ func TestReadManifest(t *testing.T) {
 	if !reflect.DeepEqual(got.Ovr, want.Ovr) {
 		t.Error("Valid manifest's overrides did not parse as expected")
 	}
-	if !reflect.DeepEqual(got.Ignored, want.Ignored) {
+	if !reflect.DeepEqual(got.ignored, want.ignored) {
 		t.Error("Valid manifest's ignored did not parse as expected")
 	}
 }
@@ -77,7 +77,7 @@ func TestWriteManifest(t *testing.T) {
 				Constraint: gps.NewBranch("master"),
 			},
 		},
-		Ignored: []string{"github.com/foo/bar"},
+		ignored: []string{"github.com/foo/bar"},
 	}
 
 	got, err := m.MarshalTOML()

--- a/project_test.go
+++ b/project_test.go
@@ -65,7 +65,7 @@ func TestProjectMakeParams(t *testing.T) {
 	p := Project{
 		AbsRoot:    "someroot",
 		ImportRoot: gps.ProjectRoot("Some project root"),
-		Manifest:   &Manifest{Ignored: []string{"ignoring this"}},
+		Manifest:   &Manifest{ignored: []string{"ignoring this"}},
 		Lock:       &Lock{},
 	}
 


### PR DESCRIPTION
Manifest.Ignored should be accessed via the IgnoredPackages() helper
which returns a copy of the field as a map.