### PR TITLE
dep, internal/gps: Always return an error from Analyzer.DeriveManifestAndLock

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -17,10 +17,6 @@ func (a Analyzer) DeriveManifestAndLock(path string, n gps.ProjectRoot) (gps.Man
 	// TODO: If we decide to support other tools manifest, this is where we would need
 	// to add that support.
 	mf := filepath.Join(path, ManifestName)
-	if fileOK, err := IsRegular(mf); err != nil || !fileOK {
-		// Do not return an error, when does not exist.
-		return nil, nil, nil
-	}
 	f, err := os.Open(mf)
 	if err != nil {
 		return nil, nil, err

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -5,6 +5,7 @@
 package dep
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -55,9 +56,12 @@ func TestAnalyzerDeriveManifestAndLockDoesNotExist(t *testing.T) {
 
 	a := Analyzer{}
 
-	m, l, err := a.DeriveManifestAndLock(h.Path("dep"), "my/fake/project")
-	if m != nil || l != nil || err != nil {
-		t.Fatalf("expected manifest & lock & err to be nil: m -> %#v l -> %#v err-> %#v", m, l, err)
+	_, _, err := a.DeriveManifestAndLock(h.Path("dep"), "my/fake/project")
+	if err == nil {
+		t.Fatalf("expected non nil error for non existant project, got: %v", err)
+	}
+	if !os.IsNotExist(err) {
+		t.Fatalf("expected IsNotExist error for non existant project, got: %v", err)
 	}
 }
 

--- a/internal/gps/vcs_source.go
+++ b/internal/gps/vcs_source.go
@@ -47,6 +47,10 @@ func (bs *baseVCSSource) getManifestAndLock(ctx context.Context, pr ProjectRoot,
 	}
 
 	m, l, err := an.DeriveManifestAndLock(bs.repo.LocalPath(), pr)
+	if os.IsNotExist(err) {
+		return prepManifest(nil), nil, nil
+	}
+
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Analyzer.DeriveManifestAndLock returns a nil error when passed a non existent path. This is rather unidiomatic.

Instead, return the error to gps.getManifestAndLock and adjust it to handle this case explicitly.