### PR TITLE
Print integration test output on a newline

### DIFF
--- a/internal/test/integration_testproj.go
+++ b/internal/test/integration_testproj.go
@@ -174,12 +174,10 @@ func (p *IntegrationTestProject) DoRun(args []string) error {
 
 	if *PrintLogs {
 		if p.stdout.Len() > 0 {
-			p.t.Log("standard output:")
-			p.t.Log(p.stdout.String())
+			p.t.Logf("\nstandard output:%s", p.stdout.String())
 		}
 		if p.stderr.Len() > 0 {
-			p.t.Log("standard error:")
-			p.t.Log(p.stderr.String())
+			p.t.Logf("standard error:\n%s", p.stderr.String())
 		}
 	}
 	return status


### PR DESCRIPTION
This makes is easier to quickly scan the test output, without messing up the section header indents.

Here's a sample of how that looks:

```
integration_testproj.go:180: standard error:
        		Finding dependencies of "github.com/golang/notexist"...
        		  Found 2 dependencies.
        		Detected glide configuration files...
        		  Loading /private/var/folders/_t/fbw4wf_s42dfqdfjq7shdfm40000gn/T/gotest490168315/src/github.com/golang/notexist/glide.yaml
        		  Loading /private/var/folders/_t/fbw4wf_s42dfqdfjq7shdfm40000gn/T/gotest490168315/src/github.com/golang/notexist/glide.lock
        		Converting from glide.yaml and glide.lock...
```