### PR TITLE
appveyor.yml: fix failure to detect windows build errors

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,4 +34,4 @@ deploy: false
 
 test_script:
   - go build github.com/golang/dep/cmd/dep
-  - for /f "" %%G in ('go list github.com/golang/dep/... ^| find /i /v "/vendor/"') do @go test %%G
+  - for /f "" %%G in ('go list github.com/golang/dep/... ^| find /i /v "/vendor/"') do ( go test %%G & IF ERRORLEVEL == 1 EXIT 1)


### PR DESCRIPTION
Updates #542

Try another way to test all the packages in this project, sans vendor/,
without accidentally swallowing the exit status.