### PR TITLE
parallelize many cmd/dep tests

### DIFF
--- a/cmd/dep/ensure_test.go
+++ b/cmd/dep/ensure_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestDeduceConstraint(t *testing.T) {
+	t.Parallel()
+
 	sv, err := gps.NewSemverConstraint("v1.2.3")
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/dep/graphviz_test.go
+++ b/cmd/dep/graphviz_test.go
@@ -11,9 +11,11 @@ import (
 )
 
 func TestEmptyProject(t *testing.T) {
-	g := new(graphviz).New()
 	h := test.NewHelper(t)
+	h.Parallel()
 	defer h.Cleanup()
+
+	g := new(graphviz).New()
 
 	b := g.output()
 	want := h.GetTestFileString("graphviz/empty.dot")
@@ -24,9 +26,11 @@ func TestEmptyProject(t *testing.T) {
 }
 
 func TestSimpleProject(t *testing.T) {
-	g := new(graphviz).New()
 	h := test.NewHelper(t)
+	h.Parallel()
 	defer h.Cleanup()
+
+	g := new(graphviz).New()
 
 	g.createNode("project", "", []string{"foo", "bar"})
 	g.createNode("foo", "master", []string{"bar"})
@@ -40,9 +44,11 @@ func TestSimpleProject(t *testing.T) {
 }
 
 func TestNoLinks(t *testing.T) {
-	g := new(graphviz).New()
 	h := test.NewHelper(t)
+	h.Parallel()
 	defer h.Cleanup()
+
+	g := new(graphviz).New()
 
 	g.createNode("project", "", []string{})
 
@@ -54,6 +60,8 @@ func TestNoLinks(t *testing.T) {
 }
 
 func TestIsPathPrefix(t *testing.T) {
+	t.Parallel()
+
 	tcs := []struct {
 		path string
 		pre  string

--- a/cmd/dep/init_test.go
+++ b/cmd/dep/init_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestContains(t *testing.T) {
+	t.Parallel()
+
 	a := []string{"a", "b", "abcd"}
 
 	if !contains(a, "a") {
@@ -23,6 +25,8 @@ func TestContains(t *testing.T) {
 }
 
 func TestIsStdLib(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]bool{
 		"github.com/Sirupsen/logrus": false,
 		"encoding/json":              true,
@@ -40,6 +44,8 @@ func TestIsStdLib(t *testing.T) {
 }
 
 func TestGetProjectPropertiesFromVersion(t *testing.T) {
+	t.Parallel()
+
 	wantSemver, _ := gps.NewSemverConstraint("^v1.0.0")
 	cases := []struct {
 		version, want gps.Constraint

--- a/cmd/dep/integration_test.go
+++ b/cmd/dep/integration_test.go
@@ -18,6 +18,8 @@ import (
 )
 
 func TestIntegration(t *testing.T) {
+	t.Parallel()
+
 	test.NeedsExternalNetwork(t)
 	test.NeedsGit(t)
 

--- a/cmd/dep/remove_test.go
+++ b/cmd/dep/remove_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestRemoveErrors(t *testing.T) {
+	t.Parallel()
+
 	test.NeedsExternalNetwork(t)
 	test.NeedsGit(t)
 
@@ -27,6 +29,8 @@ func TestRemoveErrors(t *testing.T) {
 
 func removeErrors(name, wd string, externalProc bool, run test.RunFunc) func(*testing.T) {
 	return func(t *testing.T) {
+		t.Parallel()
+
 		testCase := test.NewTestCase(t, name, wd)
 		testProj := test.NewTestProject(t, testCase.InitialPath(), wd, externalProc, run)
 		defer testProj.Cleanup()

--- a/cmd/dep/status_test.go
+++ b/cmd/dep/status_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestStatusFormatVersion(t *testing.T) {
+	t.Parallel()
+
 	tests := map[gps.Version]string{
 		nil: "",
 		gps.NewBranch("master"):        "branch master",

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -77,8 +77,8 @@ func (h *Helper) check(err error) {
 	}
 }
 
-// parallel runs the test in parallel by calling t.Parallel.
-func (h *Helper) parallel() {
+// Parallel runs the test in parallel by calling t.Parallel.
+func (h *Helper) Parallel() {
 	if h.ran {
 		h.t.Fatalf("%+v", errors.New("internal testsuite error: call to parallel after run"))
 	}


### PR DESCRIPTION
This change parallelizes many of the `cmd/dep` tests, and reduces the running time for `go test ./cmd/dep/...` on my machine from ~21s to ~18s, with room for more improvement with more parallelism (beyond GOMAXPROCS). With `go test -parallel 16 ./cmd/dep/...`, I can get it down to ~8s. In fact, most of the `-parallel 16` speedup comes from pre-existing parallelism, and runs about ~10s on master.

So this PR offers around ~10% speedup, and it may be worth considering a CI test script change to run with more parallelism for an even better payoff.