### PR TITLE
gps tests: dry and cleanup; remove unused code

### DIFF
--- a/internal/gps/deduce_test.go
+++ b/internal/gps/deduce_test.go
@@ -587,21 +587,16 @@ func TestDeduceFromPath(t *testing.T) {
 			}
 		})
 	}
-	for typ, fixtures := range pathDeductionFixtures {
-		typ, fixtures := typ, fixtures
-		t.Run("first", func(t *testing.T) {
+	runSet := func(t *testing.T) {
+		for typ, fixtures := range pathDeductionFixtures {
 			do(typ, fixtures, t)
-		})
+		}
 	}
+	t.Run("first", runSet)
 
 	// Run the test set twice to ensure results are correct for both cached
 	// and uncached deductions.
-	for typ, fixtures := range pathDeductionFixtures {
-		typ, fixtures := typ, fixtures
-		t.Run("second", func(t *testing.T) {
-			do(typ, fixtures, t)
-		})
-	}
+	t.Run("second", runSet)
 }
 
 func TestVanityDeduction(t *testing.T) {

--- a/internal/gps/manager_test.go
+++ b/internal/gps/manager_test.go
@@ -16,11 +16,7 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
-
-	"github.com/Masterminds/semver"
 )
-
-var bd string
 
 // An analyzer that passes nothing back, but doesn't error. This is the naive
 // case - no constraints, no lock, and no errors. The SourceManager will
@@ -33,15 +29,6 @@ func (naiveAnalyzer) DeriveManifestAndLock(string, ProjectRoot) (Manifest, Lock,
 
 func (a naiveAnalyzer) Info() (name string, version int) {
 	return "naive-analyzer", 1
-}
-
-func sv(s string) semver.Version {
-	sv, err := semver.NewVersion(s)
-	if err != nil {
-		panic(fmt.Sprintf("Error creating semver from %q: %s", s, err))
-	}
-
-	return sv
 }
 
 func mkNaiveSM(t *testing.T) (*SourceMgr, func()) {
@@ -80,11 +67,6 @@ func remakeNaiveSM(osm *SourceMgr, t *testing.T) (*SourceMgr, func()) {
 			t.Errorf("removeAll failed: %s", err)
 		}
 	}
-}
-
-func init() {
-	_, filename, _, _ := runtime.Caller(1)
-	bd = path.Dir(filename)
 }
 
 func TestSourceManagerInit(t *testing.T) {

--- a/internal/gps/result_test.go
+++ b/internal/gps/result_test.go
@@ -34,6 +34,15 @@ func init() {
 			}, nil),
 		},
 	}
+
+	// Just in case something needs punishing, kubernetes offers a complex,
+	// real-world set of dependencies, and this revision is known to work.
+	/*
+		_ = atom{
+			id: pi("github.com/kubernetes/kubernetes"),
+			v:  NewVersion("1.0.0").Is(Revision("528f879e7d3790ea4287687ef0ab3f2a01cc2718")),
+		}
+	*/
 }
 
 func testWriteDepTree(t *testing.T) {

--- a/internal/gps/result_test.go
+++ b/internal/gps/result_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 var basicResult solution
-var kub atom
 
 func pi(n string) ProjectIdentifier {
 	return ProjectIdentifier{
@@ -34,12 +33,6 @@ func init() {
 				v:  NewVersion("1.0.0").Is(Revision("30605f6ac35fcb075ad0bfa9296f90a7d891523e")),
 			}, nil),
 		},
-	}
-
-	// just in case something needs punishing, kubernetes is happy to oblige
-	kub = atom{
-		id: pi("github.com/kubernetes/kubernetes"),
-		v:  NewVersion("1.0.0").Is(Revision("528f879e7d3790ea4287687ef0ab3f2a01cc2718")),
 	}
 }
 


### PR DESCRIPTION
This is a small change to gps tests which removes some unused code, and cleans-up some repeated sub-test code which was unintentionally serial.