### PR TITLE
Fix double usage message

### DIFF
--- a/cmd/dep/main.go
+++ b/cmd/dep/main.go
@@ -120,6 +120,7 @@ func (c *Config) Run() (exitCode int) {
 		if cmd.Name() == cmdName {
 			// Build flag set with global flags in there.
 			fs := flag.NewFlagSet(cmdName, flag.ContinueOnError)
+			fs.SetOutput(c.Stderr)
 			verbose := fs.Bool("v", false, "enable verbose logging")
 
 			// Register the subcommand flags in there, too.
@@ -135,8 +136,9 @@ func (c *Config) Run() (exitCode int) {
 			}
 
 			// Parse the flags the user gave us.
+			// flag package automaticly prints usage and error message in err != nil
+			// or if '-h' flag provided
 			if err := fs.Parse(c.Args[2:]); err != nil {
-				fs.Usage()
 				exitCode = 1
 				return
 			}

--- a/cmd/dep/testdata/harness_tests/init/usage/with_h_flag/testcase.json
+++ b/cmd/dep/testdata/harness_tests/init/usage/with_h_flag/testcase.json
@@ -1,0 +1,6 @@
+{
+  "commands": [
+    ["init", "-h"]
+  ],
+  "error-expected": "Usage: dep init [root]"
+}

--- a/cmd/dep/testdata/harness_tests/init/usage/with_not_defined_flag/testcase.json
+++ b/cmd/dep/testdata/harness_tests/init/usage/with_not_defined_flag/testcase.json
@@ -1,0 +1,6 @@
+{
+  "commands": [
+    ["init", "-not-defined-flag"]
+  ],
+  "error-expected": "flag provided but not defined: -not-defined-flag\nUsage: dep init [root]"
+}

--- a/internal/test/integration_testcase.go
+++ b/internal/test/integration_testcase.go
@@ -164,8 +164,12 @@ func (tc *IntegrationTestCase) CompareError(err error, stderr string) {
 	gotExists, got := stderr != "" && err != nil, stderr
 
 	if wantExists && gotExists {
-		if !strings.Contains(got, want) {
+		switch c := strings.Count(got, want); c {
+		case 0:
 			tc.t.Errorf("expected error containing %s, got error %s", want, got)
+		case 1:
+		default:
+			tc.t.Errorf("expected error %s matches %d times to actual error %s", want, c, got)
 		}
 	} else if !wantExists && gotExists {
 		tc.t.Fatalf("error raised where none was expected: \n%v", stderr)


### PR DESCRIPTION
This fix #626 

Please notice [changes to integration_testcase.go](https://github.com/golang/dep/commit/64d1376f4a4903408952e11022fb17a565d68669)

Without this change it was impossible to write integration test to catch the bug.

Changes to `cmd/dep/main.go` are trivial. 