### PR TITLE
Assume an implied caret when a semver doesn't have an explicit constraint

### DIFF
--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -329,7 +329,7 @@ func getProjectConstraint(arg string, sm gps.SourceManager) (gps.ProjectConstrai
 // semver, a revision, or as a fallback, a plain tag
 func deduceConstraint(s string) gps.Constraint {
 	// always semver if we can
-	c, err := gps.NewSemverConstraint(s)
+	c, err := gps.NewSemverConstraintIC(s)
 	if err == nil {
 		return c
 	}

--- a/cmd/dep/ensure_test.go
+++ b/cmd/dep/ensure_test.go
@@ -13,7 +13,7 @@ import (
 func TestDeduceConstraint(t *testing.T) {
 	t.Parallel()
 
-	sv, err := gps.NewSemverConstraint("v1.2.3")
+	sv, err := gps.NewSemverConstraintIC("v1.2.3")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/dep/ensure_test.go
+++ b/cmd/dep/ensure_test.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/golang/dep/internal/gps"
@@ -31,10 +32,16 @@ func TestDeduceConstraint(t *testing.T) {
 		"20120425195858-psty8c35ve2oej8t":           gps.NewVersion("20120425195858-psty8c35ve2oej8t"),
 	}
 
-	for str, expected := range constraints {
-		c := deduceConstraint(str)
-		if c != expected {
-			t.Fatalf("expected: %#v, got %#v for %s", expected, c, str)
+	for str, want := range constraints {
+		got := deduceConstraint(str)
+
+		wantT := reflect.TypeOf(want)
+		gotT := reflect.TypeOf(got)
+		if wantT != gotT {
+			t.Errorf("expected type: %s, got %s, for input %s", wantT, gotT, str)
+		}
+		if got.String() != want.String() {
+			t.Errorf("expected value: %s, got %s for input %s", want, got, str)
 		}
 	}
 }

--- a/cmd/dep/init.go
+++ b/cmd/dep/init.go
@@ -319,8 +319,7 @@ func getProjectPropertiesFromVersion(v gps.Version) gps.ProjectProperties {
 	case gps.IsBranch, gps.IsVersion:
 		pp.Constraint = v
 	case gps.IsSemver:
-		// TODO: remove "^" when https://github.com/golang/dep/issues/225 is ready.
-		c, err := gps.NewSemverConstraint("^" + v.String())
+		c, err := gps.NewSemverConstraintIC(v.String())
 		if err != nil {
 			panic(err)
 		}

--- a/cmd/dep/init_test.go
+++ b/cmd/dep/init_test.go
@@ -27,7 +27,7 @@ func TestContains(t *testing.T) {
 func TestGetProjectPropertiesFromVersion(t *testing.T) {
 	t.Parallel()
 
-	wantSemver, _ := gps.NewSemverConstraint("^v1.0.0")
+	wantSemver, _ := gps.NewSemverConstraintIC("v1.0.0")
 	cases := []struct {
 		version, want gps.Constraint
 	}{

--- a/cmd/dep/testdata/harness_tests/ensure/empty/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/ensure/empty/case1/final/Gopkg.toml
@@ -53,4 +53,4 @@
 
 [[dependencies]]
   name = "github.com/sdboyer/deptest"
-  version = "^1.0.0"
+  version = "1.0.0"

--- a/cmd/dep/testdata/harness_tests/ensure/override/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/ensure/override/case1/final/Gopkg.toml
@@ -53,4 +53,4 @@
 
 [[dependencies]]
   name = "github.com/sdboyer/deptest"
-  version = "^1.0.0"
+  version = "1.0.0"

--- a/cmd/dep/testdata/harness_tests/ensure/override/case1/testcase.json
+++ b/cmd/dep/testdata/harness_tests/ensure/override/case1/testcase.json
@@ -1,7 +1,7 @@
 {
   "commands": [
     ["init"],
-    ["ensure", "-override", "github.com/sdboyer/deptest@1.0.0"]
+    ["ensure", "-override", "github.com/sdboyer/deptest@=1.0.0"]
   ],
   "error-expected": "",
   "vendor-final": [

--- a/cmd/dep/testdata/harness_tests/init/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/case1/final/Gopkg.toml
@@ -1,4 +1,4 @@
 
 [[dependencies]]
   name = "github.com/sdboyer/deptest"
-  version = "^0.8.0"
+  version = "0.8.0"

--- a/cmd/dep/testdata/harness_tests/init/case2/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/case2/final/Gopkg.toml
@@ -1,8 +1,8 @@
 
 [[dependencies]]
   name = "github.com/sdboyer/deptest"
-  version = "^0.8.0"
+  version = "0.8.0"
 
 [[dependencies]]
   name = "github.com/sdboyer/deptestdos"
-  version = "^2.0.0"
+  version = "2.0.0"

--- a/cmd/dep/testdata/harness_tests/init/skip-hidden/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/skip-hidden/final/Gopkg.toml
@@ -1,4 +1,4 @@
 
 [[dependencies]]
   name = "github.com/sdboyer/deptest"
-  version = "^1.0.0"
+  version = "1.0.0"

--- a/internal/gps/constraint_test.go
+++ b/internal/gps/constraint_test.go
@@ -674,6 +674,28 @@ func TestSemverConstraintOps(t *testing.T) {
 	}
 }
 
+func TestSemverConstraint_ImpliedCaret(t *testing.T) {
+	c, _ := NewSemverConstraintIC("1.0.0")
+
+	wantS := "^1.0.0"
+	gotS := c.String()
+	if wantS != gotS {
+		t.Errorf("Expected string %s, got %s", wantS, gotS)
+	}
+
+	wantI := "1.0.0"
+	gotI := c.ImpliedCaretString()
+	if wantI != gotI {
+		t.Errorf("Expected implied string %s, got %s", wantI, gotI)
+	}
+
+	wantT := "svc-^1.0.0"
+	gotT := c.typedString()
+	if wantT != gotT {
+		t.Errorf("Expected type string %s, got %s", wantT, gotT)
+	}
+}
+
 // Test that certain types of cross-version comparisons work when they are
 // expressed as a version union (but that others don't).
 func TestVersionUnion(t *testing.T) {

--- a/internal/gps/constraints.go
+++ b/internal/gps/constraints.go
@@ -25,6 +25,14 @@ var (
 type Constraint interface {
 	fmt.Stringer
 
+	// ImpliedCaretString converts the Constraint to a string in the same manner
+	// as String(), but treats the empty operator as equivalent to ^, rather
+	// than =.
+	//
+	// In the same way that String() is the inverse of NewConstraint(), this
+	// method is the inverse of to NewSemverConstraintIC().
+	ImpliedCaretString() string
+
 	// Matches indicates if the provided Version is allowed by the Constraint.
 	Matches(Version) bool
 
@@ -64,12 +72,40 @@ func NewSemverConstraint(body string) (Constraint, error) {
 	return semverConstraint{c: c}, nil
 }
 
+// NewSemverConstraintIC attempts to construct a semver Constraint object from the
+// input string, defaulting to a caret, ^, when no constraint is specified.
+//
+// If the input string cannot be made into a valid semver Constraint, an error
+// is returned.
+func NewSemverConstraintIC(body string) (Constraint, error) {
+	c, err := semver.NewConstraintIC(body)
+	if err != nil {
+		return nil, err
+	}
+	// If we got a simple semver.Version, simplify by returning our
+	// corresponding type
+	if sv, ok := c.(semver.Version); ok {
+		return semVersion{sv: sv}, nil
+	}
+	return semverConstraint{c: c}, nil
+}
+
 type semverConstraint struct {
 	c semver.Constraint
 }
 
 func (c semverConstraint) String() string {
 	return c.c.String()
+}
+
+// ImpliedCaretString converts the Constraint to a string in the same manner
+// as String(), but treats the empty operator as equivalent to ^, rather
+// than =.
+//
+// In the same way that String() is the inverse of NewConstraint(), this
+// method is the inverse of to NewSemverConstraintIC().
+func (c semverConstraint) ImpliedCaretString() string {
+	return c.c.ImpliedCaretString()
 }
 
 func (c semverConstraint) typedString() string {
@@ -153,6 +189,10 @@ func (anyConstraint) String() string {
 	return "*"
 }
 
+func (anyConstraint) ImpliedCaretString() string {
+	return "*"
+}
+
 func (anyConstraint) typedString() string {
 	return "any-*"
 }
@@ -174,6 +214,10 @@ func (anyConstraint) Intersect(c Constraint) Constraint {
 type noneConstraint struct{}
 
 func (noneConstraint) String() string {
+	return ""
+}
+
+func (noneConstraint) ImpliedCaretString() string {
 	return ""
 }
 

--- a/internal/gps/version.go
+++ b/internal/gps/version.go
@@ -119,6 +119,10 @@ func (r Revision) String() string {
 	return string(r)
 }
 
+func (r Revision) ImpliedCaretString() string {
+	return r.String()
+}
+
 func (r Revision) typedString() string {
 	return "r-" + string(r)
 }
@@ -193,6 +197,10 @@ type branchVersion struct {
 
 func (v branchVersion) String() string {
 	return string(v.name)
+}
+
+func (v branchVersion) ImpliedCaretString() string {
+	return v.String()
 }
 
 func (v branchVersion) typedString() string {
@@ -270,6 +278,10 @@ type plainVersion string
 
 func (v plainVersion) String() string {
 	return string(v)
+}
+
+func (v plainVersion) ImpliedCaretString() string {
+	return v.String()
 }
 
 func (v plainVersion) typedString() string {
@@ -355,6 +367,10 @@ func (v semVersion) String() string {
 	return str
 }
 
+func (v semVersion) ImpliedCaretString() string {
+	return v.sv.ImpliedCaretString()
+}
+
 func (v semVersion) typedString() string {
 	return fmt.Sprintf("sv-%s", v.String())
 }
@@ -437,6 +453,10 @@ type versionPair struct {
 
 func (v versionPair) String() string {
 	return v.v.String()
+}
+
+func (v versionPair) ImpliedCaretString() string {
+	return v.v.ImpliedCaretString()
 }
 
 func (v versionPair) typedString() string {

--- a/internal/gps/version_unifier.go
+++ b/internal/gps/version_unifier.go
@@ -184,6 +184,13 @@ func (vtu versionTypeUnion) String() string {
 	panic("versionTypeUnion should never be turned into a string; it is solver internal-only")
 }
 
+// This should generally not be called, but is required for the interface. If it
+// is called, we have a bigger problem (the type has escaped the solver); thus,
+// panic.
+func (vtu versionTypeUnion) ImpliedCaretString() string {
+	panic("versionTypeUnion should never be turned into a string; it is solver internal-only")
+}
+
 func (vtu versionTypeUnion) typedString() string {
 	panic("versionTypeUnion should never be turned into a string; it is solver internal-only")
 }

--- a/manifest.go
+++ b/manifest.go
@@ -162,7 +162,7 @@ func toProject(raw rawProject) (n gps.ProjectRoot, pp gps.ProjectProperties, err
 		}
 
 		// always semver if we can
-		pp.Constraint, err = gps.NewSemverConstraint(raw.Version)
+		pp.Constraint, err = gps.NewSemverConstraintIC(raw.Version)
 		if err != nil {
 			// but if not, fall back on plain versions
 			pp.Constraint = gps.NewVersion(raw.Version)
@@ -236,7 +236,7 @@ func toRawProject(name gps.ProjectRoot, project gps.ProjectProperties) rawProjec
 		case gps.IsBranch:
 			raw.Branch = v.String()
 		case gps.IsSemver, gps.IsVersion:
-			raw.Version = v.String()
+			raw.Version = v.ImpliedCaretString()
 		}
 		return raw
 	}
@@ -248,7 +248,7 @@ func toRawProject(name gps.ProjectRoot, project gps.ProjectProperties) rawProjec
 	// if !gps.IsAny(pp.Constraint) && !gps.IsNone(pp.Constraint) {
 	if !gps.IsAny(project.Constraint) && project.Constraint != nil {
 		// Has to be a semver range.
-		raw.Version = project.Constraint.String()
+		raw.Version = project.Constraint.ImpliedCaretString()
 	}
 	return raw
 }

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -25,7 +25,7 @@ func TestReadManifest(t *testing.T) {
 		t.Fatalf("Should have read Manifest correctly, but got err %q", err)
 	}
 
-	c, _ := gps.NewSemverConstraint(">=0.12.0, <1.0.0")
+	c, _ := gps.NewSemverConstraint("^0.12.0")
 	want := Manifest{
 		Dependencies: map[gps.ProjectRoot]gps.ProjectProperties{
 			gps.ProjectRoot("github.com/golang/dep/internal/gps"): {
@@ -61,7 +61,7 @@ func TestWriteManifest(t *testing.T) {
 
 	golden := "manifest/golden.toml"
 	want := h.GetTestFileString(golden)
-	c, _ := gps.NewSemverConstraint(">=0.12.0, <1.0.0")
+	c, _ := gps.NewSemverConstraint("^0.12.0")
 	m := &Manifest{
 		Dependencies: map[gps.ProjectRoot]gps.ProjectProperties{
 			gps.ProjectRoot("github.com/golang/dep/internal/gps"): {

--- a/testdata/manifest/golden.toml
+++ b/testdata/manifest/golden.toml
@@ -6,7 +6,7 @@ ignored = ["github.com/foo/bar"]
 
 [[dependencies]]
   name = "github.com/golang/dep/internal/gps"
-  version = ">=0.12.0, <1.0.0"
+  version = "0.12.0"
 
 [[overrides]]
   branch = "master"


### PR DESCRIPTION
Fixes #225 

When reading in a manifest, and no constraint has been applied to a version, assume the caret `^` constraint by default. Now a user must add the `=` prefix to restrict a version to exactly the version specified and maintain the previous behavior.

~I decided to accept implied carets but never write out implied carets, i.e. be liberal in what we accept and strict in what we output. So when `init` generates a manifest, it continues to output carets as `dep` does today. I prefer this over outputting bare versions because it is more clear to users; it should cut down on issues where someone is surprised that the version wasn't "pinned". I left comments in as to why we aren't using ImpliedCaretString.~

Existing tests which relied upon a bare version being interpreted with an `=` constraint have been updated with explicit `=` prefixes.