### PR TITLE
internal/fs: IsRegular returns an error on any non regular file

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -324,7 +324,6 @@ func IsNonEmptyDir(name string) (bool, error) {
 
 // IsRegular determines if the path given is a regular file or not.
 func IsRegular(name string) (bool, error) {
-	// TODO: lstat?
 	fi, err := os.Stat(name)
 	if os.IsNotExist(err) {
 		return false, nil
@@ -332,8 +331,9 @@ func IsRegular(name string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if fi.IsDir() {
-		return false, errors.Errorf("%q is a directory, should be a file", name)
+	mode := fi.Mode()
+	if mode&os.ModeType != 0 {
+		return false, errors.Errorf("%q is a %v, expected a file", name, mode)
 	}
 	return true, nil
 }


### PR DESCRIPTION
Updates #632

IsRegular would previously return true if any file that was _not_ a
directory were presented. With this change IsRegular rejects any file
with a mode bit in the os.ModeType bitset--only regular files will pass
this test.