### PR TITLE
Removed dead code

### DIFF
--- a/txn_writer.go
+++ b/txn_writer.go
@@ -151,10 +151,6 @@ func (diff rawStringDiff) MarshalTOML() ([]byte, error) {
 	return []byte(diff.String()), nil
 }
 
-type rawLockDiff struct {
-	*gps.LockDiff
-}
-
 type rawLockedProjectDiff struct {
 	Name     gps.ProjectRoot `toml:"name"`
 	Source   *rawStringDiff  `toml:"source,omitempty"`
@@ -570,22 +566,6 @@ func calculatePrune(vendorDir string, keep []string) ([]string, error) {
 		return nil
 	})
 	return toDelete, err
-}
-
-func writeFile(path string, in toml.Marshaler) error {
-	f, err := os.Create(path)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	s, err := in.MarshalTOML()
-	if err != nil {
-		return err
-	}
-
-	_, err = f.Write(s)
-	return err
 }
 
 func deleteDirs(toDelete []string) error {


### PR DESCRIPTION
writeFile function is duplicate of writeFile in fs.go (removed in ee9843c)
rawLockDiff struct introduced in 34bbce0 and never used

@carolynvs can you please confirm rawLockDiff removal. 