### PR TITLE
de-globalize mkBridge function var

### DIFF
--- a/internal/gps/bridge.go
+++ b/internal/gps/bridge.go
@@ -75,9 +75,8 @@ type bridge struct {
 	down bool
 }
 
-// Global factory func to create a bridge. This exists solely to allow tests to
-// override it with a custom bridge and sm.
-var mkBridge = func(s *solver, sm SourceManager, down bool) sourceBridge {
+// mkBridge creates a bridge
+func mkBridge(s *solver, sm SourceManager, down bool) *bridge {
 	return &bridge{
 		sm:     sm,
 		s:      s,

--- a/internal/gps/hash_test.go
+++ b/internal/gps/hash_test.go
@@ -22,6 +22,7 @@ func TestHashInputs(t *testing.T) {
 		Manifest:        fix.rootmanifest(),
 		ProjectAnalyzer: naiveAnalyzer{},
 		stdLibFn:        func(string) bool { return false },
+		mkBridgeFn:      overrideMkBridge,
 	}
 
 	s, err := Prepare(params, newdepspecSM(fix.ds, nil))
@@ -74,6 +75,7 @@ func TestHashInputsReqsIgs(t *testing.T) {
 		Manifest:        rm,
 		ProjectAnalyzer: naiveAnalyzer{},
 		stdLibFn:        func(string) bool { return false },
+		mkBridgeFn:      overrideMkBridge,
 	}
 
 	s, err := Prepare(params, newdepspecSM(fix.ds, nil))
@@ -204,6 +206,7 @@ func TestHashInputsOverrides(t *testing.T) {
 		Manifest:        rm,
 		ProjectAnalyzer: naiveAnalyzer{},
 		stdLibFn:        func(string) bool { return false },
+		mkBridgeFn:      overrideMkBridge,
 	}
 
 	table := []struct {

--- a/internal/gps/rootdata_test.go
+++ b/internal/gps/rootdata_test.go
@@ -18,6 +18,7 @@ func TestRootdataExternalImports(t *testing.T) {
 		Manifest:        fix.rootmanifest(),
 		ProjectAnalyzer: naiveAnalyzer{},
 		stdLibFn:        func(string) bool { return false },
+		mkBridgeFn:      overrideMkBridge,
 	}
 
 	is, err := Prepare(params, newdepspecSM(fix.ds, nil))
@@ -72,6 +73,7 @@ func TestGetApplicableConstraints(t *testing.T) {
 		Manifest:        fix.rootmanifest(),
 		ProjectAnalyzer: naiveAnalyzer{},
 		stdLibFn:        func(string) bool { return false },
+		mkBridgeFn:      overrideMkBridge,
 	}
 
 	is, err := Prepare(params, newdepspecSM(fix.ds, nil))


### PR DESCRIPTION
This change converts the global `mkBridge` function var into a regular function, and instead provides an un-exported field (`SolveParameters.mkBridgeFn`) for test overrides, analogous to (`SolveParameters.stdLibFn`).