### PR TITLE
internal/fs: update error message when rename fallback fails

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -105,7 +105,7 @@ func renameByCopy(src, dst string) error {
 	}
 
 	if cerr != nil {
-		return errors.Wrapf(cerr, "second attempt failed: cannot rename %s to %s", src, dst)
+		return errors.Wrapf(cerr, "rename fallback failed: cannot rename %s to %s", src, dst)
 	}
 
 	return errors.Wrapf(os.RemoveAll(src), "cannot delete %s", src)

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -100,8 +100,14 @@ func renameByCopy(src, dst string) error {
 	var cerr error
 	if dir, _ := IsDir(src); dir {
 		cerr = CopyDir(src, dst)
+		if cerr != nil {
+			cerr = errors.Wrap(cerr, "copying directory failed")
+		}
 	} else {
 		cerr = copyFile(src, dst)
+		if cerr != nil {
+			cerr = errors.Wrap(cerr, "copying file failed")
+		}
 	}
 
 	if cerr != nil {
@@ -222,13 +228,13 @@ func CopyDir(src, dst string) error {
 
 		if entry.IsDir() {
 			if err = CopyDir(srcPath, dstPath); err != nil {
-				return err
+				return errors.Wrap(err, "copying directory failed")
 			}
 		} else {
 			// This will include symlinks, which is what we want when
 			// copying things.
 			if err = copyFile(srcPath, dstPath); err != nil {
-				return err
+				return errors.Wrap(err, "copying file failed")
 			}
 		}
 	}


### PR DESCRIPTION
Would clarify errors like (from #651):

> safe write of manifest and lock: second attempt failed: cannot rename /tmp/dep666066408/vendor to /home/ser/workspace/src/foo/vendor: read /tmp/dep666066408/vendor/github.com/prometheus/procfs/fixtures/self: is a directory

to become:
> safe write of manifest and lock: **rename fallback failed**: cannot rename /tmp/dep666066408/vendor to /home/ser/workspace/src/foo/vendor: **copying file failed:** read /tmp/dep666066408/vendor/github.com/prometheus/procfs/fixtures/self: is a directory