### PR TITLE
internal/fs: handle symlinks in copyFile()

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -246,10 +246,7 @@ func copyFile(src, dst string) (err error) {
 		return errors.Wrapf(err, "could not lstat %s", src)
 	} else if isSymlink {
 		err := copySymlink(src, dst)
-		if err != nil {
-			return err
-		}
-		return nil
+		return err
 	}
 
 	in, err := os.Open(src)

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -296,8 +296,11 @@ func copySymlink(src, dst string) error {
 	}
 
 	err = os.Symlink(resolved, dst)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create symlink %s to %s", src, resolved)
+	}
 
-	return errors.Wrapf(err, "failed to create symlink %s to %s", src, resolved)
+	return nil
 }
 
 // IsDir determines is the path given is a directory or not.

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -243,7 +243,7 @@ func CopyDir(src, dst string) error {
 // the copied data is synced/flushed to stable storage.
 func copyFile(src, dst string) (err error) {
 	if sym, err := IsSymlink(src); err != nil {
-		return errors.Wrapf(err, "could not lstat %s", src)
+		return err
 	} else if sym {
 		err := copySymlink(src, dst)
 		return err
@@ -296,11 +296,8 @@ func copySymlink(src, dst string) error {
 	}
 
 	err = os.Symlink(resolved, dst)
-	if err != nil {
-		return errors.Wrapf(err, "failed to create symlink %s to %s", src, resolved)
-	}
 
-	return nil
+	return errors.Wrapf(err, "failed to create symlink %s to %s", src, resolved)
 }
 
 // IsDir determines is the path given is a directory or not.

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -242,9 +242,9 @@ func CopyDir(src, dst string) error {
 // of the source file. The file mode will be copied from the source and
 // the copied data is synced/flushed to stable storage.
 func copyFile(src, dst string) (err error) {
-	if isSymlink, err := IsSymlink(src); err != nil {
+	if sym, err := IsSymlink(src); err != nil {
 		return errors.Wrapf(err, "could not lstat %s", src)
-	} else if isSymlink {
+	} else if sym {
 		err := copySymlink(src, dst)
 		return err
 	}

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -242,6 +242,16 @@ func CopyDir(src, dst string) error {
 // of the source file. The file mode will be copied from the source and
 // the copied data is synced/flushed to stable storage.
 func copyFile(src, dst string) (err error) {
+	if isSymlink, err := IsSymlink(src); err != nil {
+		return errors.Wrapf(err, "could not lstat %s", src)
+	} else if isSymlink {
+		err := copySymlink(src, dst)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
 	in, err := os.Open(src)
 	if err != nil {
 		return
@@ -278,6 +288,22 @@ func copyFile(src, dst string) (err error) {
 	}
 
 	return
+}
+
+// copySymlink will resolve the src symlink and create a new symlink in dst.
+// If src is a relative symlink, dst will also be a relative symlink.
+func copySymlink(src, dst string) error {
+	resolved, err := os.Readlink(src)
+	if err != nil {
+		return errors.Wrap(err, "failed to resolve symlink")
+	}
+
+	err = os.Symlink(resolved, dst)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create symlink %s to %s", src, resolved)
+	}
+
+	return nil
 }
 
 // IsDir determines is the path given is a directory or not.
@@ -336,4 +362,14 @@ func IsRegular(name string) (bool, error) {
 		return false, errors.Errorf("%q is a directory, should be a file", name)
 	}
 	return true, nil
+}
+
+// IsSymlink determines if the given path is a symbolic link.
+func IsSymlink(path string) (bool, error) {
+	l, err := os.Lstat(path)
+	if err != nil {
+		return false, err
+	}
+
+	return l.Mode()&os.ModeSymlink == os.ModeSymlink, nil
 }

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -772,6 +772,13 @@ func TestIsEmpty(t *testing.T) {
 }
 
 func TestIsSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// XXX: creating symlinks is not supported in Go on
+		// Microsoft Windows. Skipping this this until a solution
+		// for creating symlinks is is provided.
+		t.Skip("skipping on windows")
+	}
+
 	dir, err := ioutil.TempDir("", "dep")
 	if err != nil {
 		t.Fatal(err)
@@ -834,22 +841,15 @@ func TestIsSymlink(t *testing.T) {
 	}
 
 	for path, want := range tests {
-		if runtime.GOOS == "windows" {
-			// XXX: setting permissions works differently in
-			// Microsoft Windows. Skipping this this until a
-			// compatible implementation is provided.
-			t.Skip("skipping on windows")
-		}
-
 		got, err := IsSymlink(path)
 		if err != nil {
 			if !want.err {
-				t.Fatalf("expected no error, got %v", err)
+				t.Errorf("expected no error, got %v", err)
 			}
 		}
 
 		if got != want.expected {
-			t.Fatalf("expected %t for %s, got %t", want.expected, path, got)
+			t.Errorf("expected %t for %s, got %t", want.expected, path, got)
 		}
 	}
 }

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -820,8 +820,7 @@ func TestIsSymlink(t *testing.T) {
 		}
 
 		inaccessibleSymlink = filepath.Join(dir, "symlink")
-		err = os.Symlink(inaccessibleFile, inaccessibleSymlink)
-		return err
+		return os.Symlink(inaccessibleFile, inaccessibleSymlink)
 	})
 	defer cleanup()
 	if err != nil {

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -780,13 +780,13 @@ func TestIsSymlink(t *testing.T) {
 
 	dirPath := filepath.Join(dir, "directory")
 	if err = os.MkdirAll(dirPath, 0777); err != nil {
-
+		t.Fatal(err)
 	}
 
 	filePath := filepath.Join(dir, "file")
 	f, err := os.Create(filePath)
 	if err != nil {
-
+		t.Fatal(err)
 	}
 	f.Close()
 
@@ -811,11 +811,10 @@ func TestIsSymlink(t *testing.T) {
 		} else if err = fh.Close(); err != nil {
 			return err
 		}
+
 		inaccessibleSymlink = filepath.Join(dir, "symlink")
-		if err = os.Symlink(inaccessibleFile, inaccessibleSymlink); err != nil {
-			return err
-		}
-		return nil
+		err = os.Symlink(inaccessibleFile, inaccessibleSymlink)
+		return err
 	})
 	defer cleanup()
 	if err != nil {
@@ -835,6 +834,13 @@ func TestIsSymlink(t *testing.T) {
 	}
 
 	for path, want := range tests {
+		if runtime.GOOS == "windows" {
+			// XXX: setting permissions works differently in
+			// Microsoft Windows. Skipping this this until a
+			// compatible implementation is provided.
+			t.Skip("skipping on windows")
+		}
+
 		got, err := IsSymlink(path)
 		if err != nil {
 			if !want.err {


### PR DESCRIPTION
`fs.copyFile()` currently fails when `src` is a symlink to a directory.

This PR adds 2 functions:
* `fs.IsSymlink()` to check if a path is a symbolic link.
* `fs.copySymlink()` to copy a symlink (preserves relative symlinks)

And update `fs.copyFile()` to handle symlinks correctly.

Should solve #651 .

