### PR TITLE
 slow bzr installation with OSx build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,6 @@ jobs:
     - <<: *simple-test
       os: osx
       go: 1.8.x
-      cache:
-        directories:
-          - $HOME/Library/Caches/Homebrew
-          - /usr/local/bin
       install:
         # brew takes horribly long to update itself despite the above caching
         # attempt; only bzr install if it's not on the $PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ jobs:
       install:
         # brew takes horribly long to update itself despite the above caching
         # attempt; only bzr install if it's not on the $PATH
-        - test $(which bzr) || brew install bzr
+        - test $(which bzr) || HOMEBREW_NO_AUTO_UPDATE=1 brew install bzr
       script:
         # OSX as of El Capitan sets an exit trap that interacts poorly with how
         # travis seems to spawn these shells; if set -e is set, then it can cause

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,10 @@ jobs:
       install:
         # brew takes horribly long to update itself despite the above caching
         # attempt; only bzr install if it's not on the $PATH
-        - test $(which bzr) || HOMEBREW_NO_AUTO_UPDATE=1 brew install bzr
+        - test $(which bzr) || brew install bzr
+      env:
+        - HOMEBREW_NO_AUTO_UPDATE=1
+        - DEPTESTBYPASS501=1
       script:
         # OSX as of El Capitan sets an exit trap that interacts poorly with how
         # travis seems to spawn these shells; if set -e is set, then it can cause


### PR DESCRIPTION
Fixes #662:

 - added flag `HOMEBREW_NO_AUTO_UPDATE` following https://github.com/Homebrew/brew/blob/7d31a70373edae4d8e78d91a4cbc05324bebc3ba/Library/Homebrew/manpages/brew.1.md.erb#L202
- removed cache directories which took around 30s of build time according to https://travis-ci.org/golang/dep/jobs/236664226#L59

Question is if we want `HOMEBREW_NO_AUTO_UPDATE` with command or just put in `env` section, personally I think this is specific for OSx builds and shouldn't affect different platform environments.