### PR TITLE
Fixed order in test output

### DIFF
--- a/internal/test/integration_testcase.go
+++ b/internal/test/integration_testcase.go
@@ -188,7 +188,7 @@ func (tc *IntegrationTestCase) CompareVendorPaths(gotVendorPaths []string) {
 		}
 		for ind := range gotVendorPaths {
 			if gotVendorPaths[ind] != wantVendorPaths[ind] {
-				tc.t.Errorf("Mismatch in vendor paths created: want %s got %s", gotVendorPaths, wantVendorPaths)
+				tc.t.Errorf("Mismatch in vendor paths created: want %s got %s", wantVendorPaths, gotVendorPaths)
 			}
 		}
 	}


### PR DESCRIPTION
CompareVendorPaths was output `got` instead `want` and vice versa