### PR TITLE
improve godoc; replace Loggers with embeded fields; refactor Ctx api

### DIFF
--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -104,7 +104,7 @@ type ensureCommand struct {
 
 func (cmd *ensureCommand) Run(ctx *dep.Ctx, args []string) error {
 	if cmd.examples {
-		ctx.Loggers.Err.Println(strings.TrimSpace(ensureExamples))
+		ctx.Err.Println(strings.TrimSpace(ensureExamples))
 		return nil
 	}
 
@@ -121,8 +121,8 @@ func (cmd *ensureCommand) Run(ctx *dep.Ctx, args []string) error {
 	defer sm.Release()
 
 	params := p.MakeParams()
-	if ctx.Loggers.Verbose {
-		params.TraceLogger = ctx.Loggers.Err
+	if ctx.Verbose {
+		params.TraceLogger = ctx.Err
 	}
 	params.RootPackageTree, err = pkgtree.ListPackages(p.AbsRoot, string(p.ImportRoot))
 	if err != nil {
@@ -136,7 +136,7 @@ func (cmd *ensureCommand) Run(ctx *dep.Ctx, args []string) error {
 	if cmd.update {
 		applyUpdateArgs(args, &params)
 	} else {
-		err := applyEnsureArgs(ctx.Loggers.Err, args, cmd.overrides, p, sm, &params)
+		err := applyEnsureArgs(ctx.Err, args, cmd.overrides, p, sm, &params)
 		if err != nil {
 			return err
 		}
@@ -169,7 +169,7 @@ func (cmd *ensureCommand) Run(ctx *dep.Ctx, args []string) error {
 		return err
 	}
 	if cmd.dryRun {
-		return sw.PrintPreparedActions(ctx.Loggers.Out)
+		return sw.PrintPreparedActions(ctx.Out)
 	}
 
 	return errors.Wrap(sw.Write(p.AbsRoot, sm, false), "grouped write of manifest, lock and vendor")

--- a/cmd/dep/glide_importer_test.go
+++ b/cmd/dep/glide_importer_test.go
@@ -21,16 +21,16 @@ import (
 const testGlideProjectRoot = "github.com/golang/notexist"
 
 var (
-	discardLogger  = log.New(ioutil.Discard, "", 0)
-	discardLoggers = &dep.Loggers{Out: discardLogger, Err: discardLogger}
+	discardLogger = log.New(ioutil.Discard, "", 0)
 )
 
 func newTestContext(h *test.Helper) *dep.Ctx {
 	h.TempDir("src")
 	pwd := h.Path(".")
 	return &dep.Ctx{
-		GOPATH:  pwd,
-		Loggers: discardLoggers,
+		GOPATH: pwd,
+		Out:    discardLogger,
+		Err:    discardLogger,
 	}
 }
 

--- a/cmd/dep/gopath_scanner.go
+++ b/cmd/dep/gopath_scanner.go
@@ -46,7 +46,7 @@ func newGopathScanner(ctx *dep.Ctx, directDeps map[string]bool, sm gps.SourceMan
 func (g *gopathScanner) InitializeRootManifestAndLock(rootM *dep.Manifest, rootL *dep.Lock) error {
 	var err error
 
-	g.ctx.Loggers.Err.Println("Searching GOPATH for projects...")
+	g.ctx.Err.Println("Searching GOPATH for projects...")
 	g.pd, err = g.scanGopathForDependencies()
 	if err != nil {
 		return err
@@ -123,7 +123,7 @@ func (g *gopathScanner) overlay(rootM *dep.Manifest, rootL *dep.Lock) {
 		unlockedProjects = append(unlockedProjects, string(pr))
 	}
 	if len(unlockedProjects) > 0 {
-		g.ctx.Loggers.Err.Printf("Following dependencies were not found in GOPATH. "+
+		g.ctx.Err.Printf("Following dependencies were not found in GOPATH. "+
 			"Dep will use the most recent versions of these projects.\n  %s",
 			strings.Join(unlockedProjects, "\n  "))
 	}
@@ -211,7 +211,7 @@ func (g *gopathScanner) scanGopathForDependencies() (projectData, error) {
 	var syncDepGroup sync.WaitGroup
 	syncDep := func(pr gps.ProjectRoot, sm gps.SourceManager) {
 		if err := sm.SyncSourceFor(gps.ProjectIdentifier{ProjectRoot: pr}); err != nil {
-			g.ctx.Loggers.Err.Printf("%+v", errors.Wrapf(err, "Unable to cache %s", pr))
+			g.ctx.Err.Printf("%+v", errors.Wrapf(err, "Unable to cache %s", pr))
 		}
 		syncDepGroup.Done()
 	}

--- a/cmd/dep/hash_in.go
+++ b/cmd/dep/hash_in.go
@@ -51,6 +51,6 @@ func (hashinCommand) Run(ctx *dep.Ctx, args []string) error {
 	if err != nil {
 		return errors.Wrap(err, "prepare solver")
 	}
-	ctx.Loggers.Out.Println(gps.HashingInputsAsString(s))
+	ctx.Out.Println(gps.HashingInputsAsString(s))
 	return nil
 }

--- a/cmd/dep/init.go
+++ b/cmd/dep/init.go
@@ -135,8 +135,8 @@ func (cmd *initCommand) Run(ctx *dep.Ctx, args []string) error {
 		ProjectAnalyzer: rootAnalyzer,
 	}
 
-	if ctx.Loggers.Verbose {
-		params.TraceLogger = ctx.Loggers.Err
+	if ctx.Verbose {
+		params.TraceLogger = ctx.Err
 	}
 
 	s, err := gps.Prepare(params, sm)
@@ -169,7 +169,7 @@ func (cmd *initCommand) Run(ctx *dep.Ctx, args []string) error {
 		return err
 	}
 	if vendorbak != "" {
-		ctx.Loggers.Err.Printf("Old vendor backed up to %v", vendorbak)
+		ctx.Err.Printf("Old vendor backed up to %v", vendorbak)
 	}
 
 	sw, err := dep.NewSafeWriter(m, nil, l, dep.VendorAlways)

--- a/cmd/dep/prune.go
+++ b/cmd/dep/prune.go
@@ -59,8 +59,8 @@ func (cmd *pruneCommand) Run(ctx *dep.Ctx, args []string) error {
 	params := p.MakeParams()
 	params.RootPackageTree = ptree
 
-	if ctx.Loggers.Verbose {
-		params.TraceLogger = ctx.Loggers.Err
+	if ctx.Verbose {
+		params.TraceLogger = ctx.Err
 	}
 
 	s, err := gps.Prepare(params, sm)
@@ -77,8 +77,8 @@ func (cmd *pruneCommand) Run(ctx *dep.Ctx, args []string) error {
 	}
 
 	var pruneLogger *log.Logger
-	if ctx.Loggers.Verbose {
-		pruneLogger = ctx.Loggers.Err
+	if ctx.Verbose {
+		pruneLogger = ctx.Err
 	}
 	return dep.PruneProject(p, sm, pruneLogger)
 }

--- a/cmd/dep/root_analyzer.go
+++ b/cmd/dep/root_analyzer.go
@@ -77,7 +77,7 @@ func (a *rootAnalyzer) importManifestAndLock(dir string, pr gps.ProjectRoot, sup
 
 	for _, i := range importers {
 		if i.HasDepMetadata(dir) {
-			a.ctx.Loggers.Err.Printf("Importing configuration from %s. These are only initial constraints, and are further refined during the solve process.", i.Name())
+			a.ctx.Err.Printf("Importing configuration from %s. These are only initial constraints, and are further refined during the solve process.", i.Name())
 			m, l, err := i.Import(dir, pr)
 			a.removeTransitiveDependencies(m)
 			return m, l, err

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package dep is a prototype dependency management library.
+package dep

--- a/project_test.go
+++ b/project_test.go
@@ -80,30 +80,6 @@ func TestProjectMakeParams(t *testing.T) {
 	}
 }
 
-func TestSlashedGOPATH(t *testing.T) {
-	h := test.NewHelper(t)
-	defer h.Cleanup()
-	h.TempDir("src")
-
-	wd, err := os.Getwd()
-	if err != nil {
-		t.Fatal("failed to get work directory:", err)
-	}
-	env := os.Environ()
-
-	h.Setenv("GOPATH", filepath.ToSlash(h.Path(".")))
-	_, err = NewContext(wd, env, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	h.Setenv("GOPATH", filepath.FromSlash(h.Path(".")))
-	_, err = NewContext(wd, env, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
 func TestBackupVendor(t *testing.T) {
 	h := test.NewHelper(t)
 	defer h.Cleanup()

--- a/test_project_context_test.go
+++ b/test_project_context_test.go
@@ -37,7 +37,11 @@ func NewTestProjectContext(h *test.Helper, projectName string) *TestProjectConte
 
 	// Set up a Source Manager
 	var err error
-	pc.Context = &Ctx{GOPATH: pc.tempDir, Loggers: discardLoggers}
+	pc.Context = &Ctx{
+		GOPATH: pc.tempDir,
+		Out:    discardLogger,
+		Err:    discardLogger,
+	}
 	pc.SourceManager, err = pc.Context.SourceManager()
 	h.Must(errors.Wrap(err, "Unable to create a SourceManager"))
 
@@ -64,7 +68,7 @@ func (pc *TestProjectContext) Load() {
 		var warns []error
 		m, warns, err = readManifest(mf)
 		for _, warn := range warns {
-			pc.Context.Loggers.Err.Printf("dep: WARNING: %v\n", warn)
+			pc.Context.Err.Printf("dep: WARNING: %v\n", warn)
 		}
 		pc.h.Must(errors.Wrapf(err, "Unable to read manifest at %s", mp))
 	}


### PR DESCRIPTION
#672

This PR improves documentation, and refactors the API around `Ctx`, primarily by dissolving the `Loggers` struct and embedding the fields directly.