### PR TITLE
Print the error when unable to cache

### DIFF
--- a/cmd/dep/init.go
+++ b/cmd/dep/init.go
@@ -348,7 +348,7 @@ func getProjectData(ctx *dep.Ctx, pkgT pkgtree.PackageTree, cpr string, sm gps.S
 	var syncDepGroup sync.WaitGroup
 	syncDep := func(pr gps.ProjectRoot, sm gps.SourceManager) {
 		if err := sm.SyncSourceFor(gps.ProjectIdentifier{ProjectRoot: pr}); err != nil {
-			ctx.Loggers.Err.Printf("Unable to cache %s", pr)
+			ctx.Loggers.Err.Printf("%+v", errors.Wrapf(err, "Unable to cache %s", pr))
 		}
 		syncDepGroup.Done()
 	}


### PR DESCRIPTION
As [reported in Slack](https://gophers.slack.com/archives/C0M5YP9LN/p1496097063859182), when dep is unable to cache a project, it is not printing why. This wraps the error and prints it with a stack trace. I can remove the stack trace if we don't want that(?) but since I couldn't reproduce, I'm not sure how helpful the error message will be in pinpointing the problem.

```
Unable to cache github.com/go-sql-driver/mysql
Unable to cache github.com/newrelic/go-agent
Unable to cache github.com/jmoiron/sqlx
```