### PR TITLE
simplify Ctx.LoadProject

### DIFF
--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -108,7 +108,7 @@ func (cmd *ensureCommand) Run(ctx *dep.Ctx, args []string) error {
 		return nil
 	}
 
-	p, err := ctx.LoadProject("")
+	p, err := ctx.LoadProject()
 	if err != nil {
 		return err
 	}

--- a/cmd/dep/hash_in.go
+++ b/cmd/dep/hash_in.go
@@ -24,7 +24,7 @@ func (cmd *hashinCommand) Register(fs *flag.FlagSet) {}
 type hashinCommand struct{}
 
 func (hashinCommand) Run(ctx *dep.Ctx, args []string) error {
-	p, err := ctx.LoadProject("")
+	p, err := ctx.LoadProject()
 	if err != nil {
 		return err
 	}

--- a/cmd/dep/prune.go
+++ b/cmd/dep/prune.go
@@ -36,7 +36,7 @@ func (cmd *pruneCommand) Register(fs *flag.FlagSet) {
 }
 
 func (cmd *pruneCommand) Run(ctx *dep.Ctx, args []string) error {
-	p, err := ctx.LoadProject("")
+	p, err := ctx.LoadProject()
 	if err != nil {
 		return err
 	}

--- a/cmd/dep/status.go
+++ b/cmd/dep/status.go
@@ -182,7 +182,7 @@ func (out *dotOutput) MissingLine(ms *MissingStatus) {}
 func (out *dotOutput) MissingFooter()                {}
 
 func (cmd *statusCommand) Run(ctx *dep.Ctx, args []string) error {
-	p, err := ctx.LoadProject("")
+	p, err := ctx.LoadProject()
 	if err != nil {
 		return err
 	}

--- a/context.go
+++ b/context.go
@@ -98,32 +98,18 @@ func (c *Ctx) SourceManager() (*gps.SourceMgr, error) {
 	return gps.NewSourceManager(filepath.Join(c.GOPATH, "pkg", "dep"))
 }
 
-// LoadProject takes a path and searches up the directory tree for
-// a project root.  If an absolute path is given, the search begins in that
-// directory.  If a relative or empty path is given, the search start is computed
-// from the current working directory.  The search stops when a file with the
-// name ManifestName (Gopkg.toml, by default) is located.
+// LoadProject starts from the current working directory and searches up the
+// directory tree for a project root.  The search stops when a file with the name
+// ManifestName (Gopkg.toml, by default) is located.
 //
 // The Project contains the parsed manifest as well as a parsed lock file, if
 // present.  The import path is calculated as the remaining path segment
 // below Ctx.GOPATH/src.
-func (c *Ctx) LoadProject(path string) (*Project, error) {
+func (c *Ctx) LoadProject() (*Project, error) {
 	var err error
 	p := new(Project)
 
-	if path != "" {
-		path, err = filepath.Abs(path)
-		if err != nil {
-			return nil, err
-		}
-	}
-	switch path {
-	case "":
-		p.AbsRoot, err = findProjectRoot(c.WorkingDir)
-	default:
-		p.AbsRoot, err = findProjectRoot(path)
-	}
-
+	p.AbsRoot, err = findProjectRoot(c.WorkingDir)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This change simplifies the `LoadProject` method by removing the sole `path` argument, since every usage (besides tests) passes an empty string.

Have I overlooked some future usage for this functionality (internal or external)?
#672 