### PR TITLE
SplitAbsoluteProjectRoot re-name/doc

### DIFF
--- a/cmd/dep/init.go
+++ b/cmd/dep/init.go
@@ -116,9 +116,9 @@ func (cmd *initCommand) Run(ctx *dep.Ctx, args []string) error {
 		return errors.Errorf("invalid state: manifest %q does not exist, but lock %q does", mf, lf)
 	}
 
-	ip, err := ctx.SplitAbsoluteProjectRoot(root)
+	ip, err := ctx.ImportForAbs(root)
 	if err != nil {
-		return errors.Wrap(err, "determineProjectRoot")
+		return errors.Wrap(err, "root project import")
 	}
 	p.ImportRoot = gps.ProjectRoot(ip)
 

--- a/context.go
+++ b/context.go
@@ -131,9 +131,9 @@ func (c *Ctx) LoadProject() (*Project, error) {
 		return nil, err
 	}
 
-	ip, err := c.SplitAbsoluteProjectRoot(p.AbsRoot)
+	ip, err := c.ImportForAbs(p.AbsRoot)
 	if err != nil {
-		return nil, errors.Wrap(err, "split absolute project root")
+		return nil, errors.Wrap(err, "root project import")
 	}
 	p.ImportRoot = gps.ProjectRoot(ip)
 
@@ -237,14 +237,9 @@ func (c *Ctx) detectGOPATH(path string) (string, error) {
 	return "", errors.Errorf("%s is not within a known GOPATH", path)
 }
 
-// SplitAbsoluteProjectRoot takes an absolute path and compares it against the detected
-// GOPATH to determine what portion of the input path should be treated as an
-// import path - as a project root.
-func (c *Ctx) SplitAbsoluteProjectRoot(path string) (string, error) {
-	if c.GOPATH == "" {
-		return "", errors.Errorf("no GOPATH detected in this context")
-	}
-
+// ImportForAbs returns the import path for an absolute project path by trimming the
+// `$GOPATH/src/` prefix.  Returns an error for paths equal to, or without this prefix.
+func (c *Ctx) ImportForAbs(path string) (string, error) {
 	srcprefix := filepath.Join(c.GOPATH, "src") + string(filepath.Separator)
 	if fs.HasFilepathPrefix(path, srcprefix) {
 		if len(path) <= len(srcprefix) {
@@ -256,7 +251,7 @@ func (c *Ctx) SplitAbsoluteProjectRoot(path string) (string, error) {
 		return filepath.ToSlash(path[len(srcprefix):]), nil
 	}
 
-	return "", errors.Errorf("%s not in any GOPATH", path)
+	return "", errors.Errorf("%s not in GOPATH", path)
 }
 
 // absoluteProjectRoot determines the absolute path to the project root

--- a/context_test.go
+++ b/context_test.go
@@ -22,7 +22,7 @@ var (
 	discardLogger = log.New(ioutil.Discard, "", 0)
 )
 
-func TestSplitAbsoluteProjectRoot(t *testing.T) {
+func TestCtx_ProjectImport(t *testing.T) {
 	h := test.NewHelper(t)
 	defer h.Cleanup()
 
@@ -38,7 +38,7 @@ func TestSplitAbsoluteProjectRoot(t *testing.T) {
 
 	for _, want := range importPaths {
 		fullpath := filepath.Join(depCtx.GOPATH, "src", want)
-		got, err := depCtx.SplitAbsoluteProjectRoot(fullpath)
+		got, err := depCtx.ImportForAbs(fullpath)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -48,13 +48,13 @@ func TestSplitAbsoluteProjectRoot(t *testing.T) {
 	}
 
 	// test where it should return an error when directly within $GOPATH/src
-	got, err := depCtx.SplitAbsoluteProjectRoot(filepath.Join(depCtx.GOPATH, "src"))
+	got, err := depCtx.ImportForAbs(filepath.Join(depCtx.GOPATH, "src"))
 	if err == nil || !strings.Contains(err.Error(), "GOPATH/src") {
 		t.Fatalf("should have gotten an error for use directly in GOPATH/src, but got %s", got)
 	}
 
 	// test where it should return an error
-	got, err = depCtx.SplitAbsoluteProjectRoot("tra/la/la/la")
+	got, err = depCtx.ImportForAbs("tra/la/la/la")
 	if err == nil {
 		t.Fatalf("should have gotten an error but did not for tra/la/la/la: %s", got)
 	}
@@ -345,7 +345,7 @@ func TestCaseInsentitiveGOPATH(t *testing.T) {
 
 	ip := "github.com/pkg/errors"
 	fullpath := filepath.Join(depCtx.GOPATH, "src", ip)
-	pr, err := depCtx.SplitAbsoluteProjectRoot(fullpath)
+	pr, err := depCtx.ImportForAbs(fullpath)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The doc for (and name of) `SplitAbsoluteProjectRoot` is stale (seems it used to check multiple GOPATHs and return the matched one).  This change proposes updates, but it's exported api so let's get the name right. Anyone have other suggestions?
#672 