### PR TITLE
Break up Ctx.VersionInWorkspace

### DIFF
--- a/cmd/dep/gopath_scanner.go
+++ b/cmd/dep/gopath_scanner.go
@@ -224,7 +224,7 @@ func (g *gopathScanner) scanGopathForDependencies() (projectData, error) {
 			notondisk[pr] = true
 			continue
 		}
-		v, err := gps.VSCVersion(abs)
+		v, err := gps.VCSVersion(abs)
 		if err != nil {
 			notondisk[pr] = true
 			continue
@@ -294,7 +294,7 @@ func (g *gopathScanner) scanGopathForDependencies() (projectData, error) {
 						notondisk[pr] = true
 						return nil
 					}
-					v, err := gps.VSCVersion(abs)
+					v, err := gps.VCSVersion(abs)
 					if err != nil {
 						// Even if we know it's on disk, errors are still
 						// possible when trying to deduce version. If we

--- a/cmd/dep/gopath_scanner.go
+++ b/cmd/dep/gopath_scanner.go
@@ -224,7 +224,7 @@ func (g *gopathScanner) scanGopathForDependencies() (projectData, error) {
 			notondisk[pr] = true
 			continue
 		}
-		v, err := gps.ProjectVersion(abs)
+		v, err := gps.VSCVersion(abs)
 		if err != nil {
 			notondisk[pr] = true
 			continue
@@ -294,7 +294,7 @@ func (g *gopathScanner) scanGopathForDependencies() (projectData, error) {
 						notondisk[pr] = true
 						return nil
 					}
-					v, err := gps.ProjectVersion(abs)
+					v, err := gps.VSCVersion(abs)
 					if err != nil {
 						// Even if we know it's on disk, errors are still
 						// possible when trying to deduce version. If we

--- a/context_test.go
+++ b/context_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 	"unicode"
 
-	"github.com/golang/dep/internal/gps"
 	"github.com/golang/dep/internal/test"
 )
 
@@ -80,7 +79,7 @@ func TestAbsoluteProjectRoot(t *testing.T) {
 	}
 
 	for i, ok := range importPaths {
-		got, err := depCtx.absoluteProjectRoot(i)
+		got, err := depCtx.AbsForImport(i)
 		if ok {
 			h.Must(err)
 			want := h.Path(filepath.Join("src", i))
@@ -97,54 +96,9 @@ func TestAbsoluteProjectRoot(t *testing.T) {
 
 	// test that a file fails
 	h.TempFile("src/thing/thing.go", "hello world")
-	_, err := depCtx.absoluteProjectRoot("thing/thing.go")
+	_, err := depCtx.AbsForImport("thing/thing.go")
 	if err == nil {
 		t.Fatal("error should not be nil for a file found")
-	}
-}
-
-func TestVersionInWorkspace(t *testing.T) {
-	test.NeedsExternalNetwork(t)
-	test.NeedsGit(t)
-
-	h := test.NewHelper(t)
-	defer h.Cleanup()
-
-	h.TempDir("src")
-	h.Setenv("GOPATH", h.Path("."))
-	depCtx := &Ctx{GOPATH: h.Path(".")}
-
-	importPaths := map[string]struct {
-		rev      gps.Version
-		checkout bool
-	}{
-		"github.com/pkg/errors": {
-			rev:      gps.NewVersion("v0.8.0").Pair("645ef00459ed84a119197bfb8d8205042c6df63d"), // semver
-			checkout: true,
-		},
-		"github.com/Sirupsen/logrus": {
-			rev:      gps.Revision("42b84f9ec624953ecbf81a94feccb3f5935c5edf"), // random sha
-			checkout: true,
-		},
-		"github.com/rsc/go-get-default-branch": {
-			rev: gps.NewBranch("another-branch").Pair("8e6902fdd0361e8fa30226b350e62973e3625ed5"),
-		},
-	}
-
-	// checkout the specified revisions
-	for ip, info := range importPaths {
-		h.RunGo("get", ip)
-		repoDir := h.Path("src/" + ip)
-		if info.checkout {
-			h.RunGit(repoDir, "checkout", info.rev.String())
-		}
-
-		got, err := depCtx.VersionInWorkspace(gps.ProjectRoot(ip))
-		h.Must(err)
-
-		if got != info.rev {
-			t.Fatalf("expected %q, got %q", got.String(), info.rev.String())
-		}
 	}
 }
 

--- a/internal/gps/vcs_version.go
+++ b/internal/gps/vcs_version.go
@@ -11,8 +11,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// VSCVersion returns the current project version for an absolute path.
-func VSCVersion(path string) (Version, error) {
+// VCSVersion returns the current project version for an absolute path.
+func VCSVersion(path string) (Version, error) {
 	repo, err := vcs.NewRepo("", path)
 	if err != nil {
 		return nil, errors.Wrapf(err, "creating new repo for root: %s", path)

--- a/internal/gps/vcs_version.go
+++ b/internal/gps/vcs_version.go
@@ -1,0 +1,67 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gps
+
+import (
+	"strings"
+
+	"github.com/Masterminds/vcs"
+	"github.com/pkg/errors"
+)
+
+// ProjectVersion returns the current project version for an absolute path.
+func ProjectVersion(path string) (Version, error) {
+	repo, err := vcs.NewRepo("", path)
+	if err != nil {
+		return nil, errors.Wrapf(err, "creating new repo for root: %s", path)
+	}
+
+	ver, err := repo.Current()
+	if err != nil {
+		return nil, errors.Wrapf(err, "finding current branch/version for root: %s", path)
+	}
+
+	rev, err := repo.Version()
+	if err != nil {
+		return nil, errors.Wrapf(err, "getting repo version for root: %s", path)
+	}
+
+	// First look through tags.
+	tags, err := repo.Tags()
+	if err != nil {
+		return nil, errors.Wrapf(err, "getting repo tags for root: %s", path)
+	}
+	// Try to match the current version to a tag.
+	if contains(tags, ver) {
+		// Assume semver if it starts with a v.
+		if strings.HasPrefix(ver, "v") {
+			return NewVersion(ver).Pair(Revision(rev)), nil
+		}
+
+		return nil, errors.Errorf("version for root %s does not start with a v: %q", path, ver)
+	}
+
+	// Look for the current branch.
+	branches, err := repo.Branches()
+	if err != nil {
+		return nil, errors.Wrapf(err, "getting repo branch for root: %s")
+	}
+	// Try to match the current version to a branch.
+	if contains(branches, ver) {
+		return NewBranch(ver).Pair(Revision(rev)), nil
+	}
+
+	return Revision(rev), nil
+}
+
+// contains checks if a array of strings contains a value
+func contains(a []string, b string) bool {
+	for _, v := range a {
+		if b == v {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/gps/vcs_version.go
+++ b/internal/gps/vcs_version.go
@@ -11,8 +11,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// ProjectVersion returns the current project version for an absolute path.
-func ProjectVersion(path string) (Version, error) {
+// VSCVersion returns the current project version for an absolute path.
+func VSCVersion(path string) (Version, error) {
 	repo, err := vcs.NewRepo("", path)
 	if err != nil {
 		return nil, errors.Wrapf(err, "creating new repo for root: %s", path)

--- a/internal/gps/vcs_version_test.go
+++ b/internal/gps/vcs_version_test.go
@@ -1,0 +1,57 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gps
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/golang/dep/internal/test"
+)
+
+func TestProjectVersion(t *testing.T) {
+	test.NeedsExternalNetwork(t)
+	test.NeedsGit(t)
+
+	h := test.NewHelper(t)
+	defer h.Cleanup()
+
+	h.TempDir("src")
+	gopath := h.Path(".")
+	h.Setenv("GOPATH", gopath)
+
+	importPaths := map[string]struct {
+		rev      Version
+		checkout bool
+	}{
+		"github.com/pkg/errors": {
+			rev:      NewVersion("v0.8.0").Pair("645ef00459ed84a119197bfb8d8205042c6df63d"), // semver
+			checkout: true,
+		},
+		"github.com/Sirupsen/logrus": {
+			rev:      Revision("42b84f9ec624953ecbf81a94feccb3f5935c5edf"), // random sha
+			checkout: true,
+		},
+		"github.com/rsc/go-get-default-branch": {
+			rev: NewBranch("another-branch").Pair("8e6902fdd0361e8fa30226b350e62973e3625ed5"),
+		},
+	}
+
+	// checkout the specified revisions
+	for ip, info := range importPaths {
+		h.RunGo("get", ip)
+		repoDir := h.Path("src/" + ip)
+		if info.checkout {
+			h.RunGit(repoDir, "checkout", info.rev.String())
+		}
+		abs := filepath.FromSlash(filepath.Join(gopath, "src", ip))
+		got, err := ProjectVersion(abs)
+		h.Must(err)
+
+		if got != info.rev {
+			t.Fatalf("expected %q, got %q", got.String(), info.rev.String())
+		}
+	}
+}

--- a/internal/gps/vcs_version_test.go
+++ b/internal/gps/vcs_version_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/golang/dep/internal/test"
 )
 
-func TestProjectVersion(t *testing.T) {
+func TestVCSVersion(t *testing.T) {
 	test.NeedsExternalNetwork(t)
 	test.NeedsGit(t)
 
@@ -47,7 +47,7 @@ func TestProjectVersion(t *testing.T) {
 			h.RunGit(repoDir, "checkout", info.rev.String())
 		}
 		abs := filepath.FromSlash(filepath.Join(gopath, "src", ip))
-		got, err := ProjectVersion(abs)
+		got, err := VSCVersion(abs)
 		h.Must(err)
 
 		if got != info.rev {

--- a/internal/gps/vcs_version_test.go
+++ b/internal/gps/vcs_version_test.go
@@ -30,7 +30,7 @@ func TestVCSVersion(t *testing.T) {
 			rev:      NewVersion("v0.8.0").Pair("645ef00459ed84a119197bfb8d8205042c6df63d"), // semver
 			checkout: true,
 		},
-		"github.com/Sirupsen/logrus": {
+		"github.com/sirupsen/logrus": {
 			rev:      Revision("42b84f9ec624953ecbf81a94feccb3f5935c5edf"), // random sha
 			checkout: true,
 		},
@@ -47,7 +47,7 @@ func TestVCSVersion(t *testing.T) {
 			h.RunGit(repoDir, "checkout", info.rev.String())
 		}
 		abs := filepath.FromSlash(filepath.Join(gopath, "src", ip))
-		got, err := VSCVersion(abs)
+		got, err := VCSVersion(abs)
 		h.Must(err)
 
 		if got != info.rev {


### PR DESCRIPTION
#672 

The `VersionInWorkspace` logic is coupled to `Ctx` as a method, although it only accesses `Ctx.absoluteProjectRoot()`.
This change proposes dissolving `VersionInWorkspace` in favor of a new func with the interesting logic (`gps.ProjectVersion`) and exporting `absoluteProjectRoot` (currently named `AbsForImport`, but should coordinate with #682 ).