### PR TITLE
Copy vendor/ when backing up and preserve .git

### DIFF
--- a/project.go
+++ b/project.go
@@ -82,8 +82,8 @@ func BackupVendor(vpath, suffix string) (string, error) {
 		vendorbak := filepath.Join(vpathDir, "_"+name+"-"+suffix)
 		// Check if a directory with same name exists
 		if _, err = os.Stat(vendorbak); os.IsNotExist(err) {
-			// Rename existing vendor to vendor-{suffix}
-			if err := fs.RenameWithFallback(vpath, vendorbak); err != nil {
+			// Copy existing vendor to vendor-{suffix}
+			if err := fs.CopyDir(vpath, vendorbak); err != nil {
 				return "", err
 			}
 			return vendorbak, nil

--- a/project_test.go
+++ b/project_test.go
@@ -138,10 +138,6 @@ func TestBackupVendor(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Create another vendor directory. Previous vendor moved as backup.
-	os.MkdirAll("vendor", 0777)
-	pc.CopyFile(dummyFile, "txn_writer/badinput_fileroot")
-
 	// Should return error on creating backup with existing filename
 	vendorbak, err = BackupVendor("vendor", "sfx")
 


### PR DESCRIPTION
Replaces renaming with copying vendor/ while backing up. This keeps the
original vendor/ and lets SafeWriter.Write() preserve vendor/.git if
any.

Fixes #698 