### PR TITLE
Fixes #675. Changes to HasFilepathPrefix to handle Windows better.

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -29,8 +29,18 @@ import (
 // will return true. The implementation is *not* OS-specific, so a FAT32
 // filesystem mounted on Linux will be handled correctly.
 func HasFilepathPrefix(path, prefix string) bool {
-	if filepath.VolumeName(path) != filepath.VolumeName(prefix) {
+	// no need to check isCaseSensitiveFilesystem because VolumeName return
+	// empty string on all non-Windows machines
+	vnPath := strings.ToLower(filepath.VolumeName(path))
+	vnPrefix := strings.ToLower(filepath.VolumeName(prefix))
+	if vnPath != vnPrefix {
 		return false
+	}
+	if strings.HasSuffix(vnPath, ":") {
+		vnPath += string(os.PathSeparator)
+	}
+	if strings.HasSuffix(vnPrefix, ":") {
+		vnPrefix += string(os.PathSeparator)
 	}
 
 	var dn string
@@ -53,7 +63,8 @@ func HasFilepathPrefix(path, prefix string) bool {
 		return false
 	}
 
-	var d, p string
+	d := vnPath
+	p := vnPrefix
 
 	for i := range prefixes {
 		// need to test each component of the path for

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -15,6 +15,19 @@ import (
 	"github.com/golang/dep/internal/test"
 )
 
+// This function tests HadFilepathPrefix. It should test it on both case
+// sensitive and insensitive situations. However, the only reliable way to test
+// case-insensitive behaviour is if using case-insensitive filesystem.  This
+// cannot be guaranteed in an automated test. Therefore, the behaviour of the
+// tests is not to test case sensitivity on *nix and to assume that Windows is
+// case-insensitive. Please see link below for some background.
+//
+// https://superuser.com/questions/266110/how-do-you-make-windows-7-fully-case-sensitive-with-respect-to-the-filesystem
+//
+// NOTE: NTFS can be made case-sensitive. However many Windows programs,
+// including Windows Explorer do not handle gracefully multiple files that
+// differ only in capitalization. It is possible that this can cause these tests
+// to fail on some setups.
 func TestHasFilepathPrefix(t *testing.T) {
 	dir, err := ioutil.TempDir("", "dep")
 	if err != nil {
@@ -68,6 +81,19 @@ func TestHasFilepathPrefix(t *testing.T) {
 	}
 }
 
+// This function tests HadFilepathPrefix. It should test it on both case
+// sensitive and insensitive situations. However, the only reliable way to test
+// case-insensitive behaviour is if using case-insensitive filesystem.  This
+// cannot be guaranteed in an automated test. Therefore, the behaviour of the
+// tests is not to test case sensitivity on *nix and to assume that Windows is
+// case-insensitive. Please see link below for some background.
+//
+// https://superuser.com/questions/266110/how-do-you-make-windows-7-fully-case-sensitive-with-respect-to-the-filesystem
+//
+// NOTE: NTFS can be made case-sensitive. However many Windows programs,
+// including Windows Explorer do not handle gracefully multiple files that
+// differ only in capitalization. It is possible that this can cause these tests
+// to fail on some setups.
 func TestHasFilepathPrefix_Files(t *testing.T) {
 	dir, err := ioutil.TempDir("", "dep")
 	if err != nil {

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/golang/dep/internal/test"
@@ -21,25 +22,35 @@ func TestHasFilepathPrefix(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
+	// dir2 is the same as dir but with different capitalization on Windows to
+	// test case insensitivity
+	var dir2 string
+	if runtime.GOOS == "windows" {
+		dir = strings.ToLower(dir)
+		dir2 = strings.ToUpper(dir)
+	} else {
+		dir2 = dir
+	}
+
 	cases := []struct {
 		path   string
 		prefix string
 		want   bool
 	}{
-		{filepath.Join(dir, "a", "b"), filepath.Join(dir), true},
-		{filepath.Join(dir, "a", "b"), filepath.Join(dir, "a"), true},
-		{filepath.Join(dir, "a", "b"), filepath.Join(dir, "a", "b"), true},
-		{filepath.Join(dir, "a", "b"), filepath.Join(dir, "c"), false},
-		{filepath.Join(dir, "a", "b"), filepath.Join(dir, "a", "d", "b"), false},
-		{filepath.Join(dir, "a", "b"), filepath.Join(dir, "a", "b2"), false},
-		{filepath.Join(dir), filepath.Join(dir, "a", "b"), false},
-		{filepath.Join(dir, "ab"), filepath.Join(dir, "a", "b"), false},
-		{filepath.Join(dir, "ab"), filepath.Join(dir, "a"), false},
-		{filepath.Join(dir, "123"), filepath.Join(dir, "123"), true},
-		{filepath.Join(dir, "123"), filepath.Join(dir, "1"), false},
-		{filepath.Join(dir, "⌘"), filepath.Join(dir, "⌘"), true},
-		{filepath.Join(dir, "a"), filepath.Join(dir, "⌘"), false},
-		{filepath.Join(dir, "⌘"), filepath.Join(dir, "a"), false},
+		{filepath.Join(dir, "a", "b"), filepath.Join(dir2), true},
+		{filepath.Join(dir, "a", "b"), filepath.Join(dir2, "a"), true},
+		{filepath.Join(dir, "a", "b"), filepath.Join(dir2, "a", "b"), true},
+		{filepath.Join(dir, "a", "b"), filepath.Join(dir2, "c"), false},
+		{filepath.Join(dir, "a", "b"), filepath.Join(dir2, "a", "d", "b"), false},
+		{filepath.Join(dir, "a", "b"), filepath.Join(dir2, "a", "b2"), false},
+		{filepath.Join(dir), filepath.Join(dir2, "a", "b"), false},
+		{filepath.Join(dir, "ab"), filepath.Join(dir2, "a", "b"), false},
+		{filepath.Join(dir, "ab"), filepath.Join(dir2, "a"), false},
+		{filepath.Join(dir, "123"), filepath.Join(dir2, "123"), true},
+		{filepath.Join(dir, "123"), filepath.Join(dir2, "1"), false},
+		{filepath.Join(dir, "⌘"), filepath.Join(dir2, "⌘"), true},
+		{filepath.Join(dir, "a"), filepath.Join(dir2, "⌘"), false},
+		{filepath.Join(dir, "⌘"), filepath.Join(dir2, "a"), false},
 	}
 
 	for _, c := range cases {
@@ -64,6 +75,16 @@ func TestHasFilepathPrefix_Files(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
+	// dir2 is the same as dir but with different capitalization on Windows to
+	// test case insensitivity
+	var dir2 string
+	if runtime.GOOS == "windows" {
+		dir = strings.ToLower(dir)
+		dir2 = strings.ToUpper(dir)
+	} else {
+		dir2 = dir
+	}
+
 	existingFile := filepath.Join(dir, "exists")
 	if _, err := os.Create(existingFile); err != nil {
 		t.Fatal(err)
@@ -76,8 +97,8 @@ func TestHasFilepathPrefix_Files(t *testing.T) {
 		prefix string
 		want   bool
 	}{
-		{existingFile, filepath.Join(dir), false},
-		{nonExistingFile, filepath.Join(dir), true},
+		{existingFile, filepath.Join(dir2), false},
+		{nonExistingFile, filepath.Join(dir2), true},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
Fixes #675. Old logic lost the drive letter hence subsequent comparisons
were often wrong. New code adds logic to handle volume name
separately. Test changed to always have mismatching case on
windows.