### PR TITLE
SafeWriter.Write noExamples->examples

### DIFF
--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -172,7 +172,7 @@ func (cmd *ensureCommand) Run(ctx *dep.Ctx, args []string) error {
 		return sw.PrintPreparedActions(ctx.Loggers.Out)
 	}
 
-	return errors.Wrap(sw.Write(p.AbsRoot, sm, true), "grouped write of manifest, lock and vendor")
+	return errors.Wrap(sw.Write(p.AbsRoot, sm, false), "grouped write of manifest, lock and vendor")
 }
 
 func applyUpdateArgs(args []string, params *gps.SolveParameters) {

--- a/cmd/dep/init.go
+++ b/cmd/dep/init.go
@@ -231,7 +231,7 @@ func (cmd *initCommand) Run(ctx *dep.Ctx, args []string) error {
 		return err
 	}
 
-	if err := sw.Write(root, sm, cmd.noExamples); err != nil {
+	if err := sw.Write(root, sm, !cmd.noExamples); err != nil {
 		return errors.Wrap(err, "safe write of manifest and lock")
 	}
 

--- a/txn_writer.go
+++ b/txn_writer.go
@@ -297,7 +297,7 @@ func (sw SafeWriter) validate(root string, sm gps.SourceManager) error {
 // operations succeeded. It also does its best to roll back if any moves fail.
 // This mostly guarantees that dep cannot exit with a partial write that would
 // leave an undefined state on disk.
-func (sw *SafeWriter) Write(root string, sm gps.SourceManager, noExamples bool) error {
+func (sw *SafeWriter) Write(root string, sm gps.SourceManager, examples bool) error {
 	err := sw.validate(root, sm)
 	if err != nil {
 		return err
@@ -327,8 +327,8 @@ func (sw *SafeWriter) Write(root string, sm gps.SourceManager, noExamples bool) 
 
 		var initOutput []byte
 
-		// If examples are NOT disabled, use the example text
-		if !noExamples {
+		// If examples are enabled, use the example text
+		if examples {
 			initOutput = exampleTOML
 		}
 

--- a/txn_writer_test.go
+++ b/txn_writer_test.go
@@ -26,7 +26,7 @@ func TestSafeWriter_BadInput_MissingRoot(t *testing.T) {
 	defer pc.Release()
 
 	sw, _ := NewSafeWriter(nil, nil, nil, VendorOnChanged)
-	err := sw.Write("", pc.SourceManager, false)
+	err := sw.Write("", pc.SourceManager, true)
 
 	if err == nil {
 		t.Fatal("should have errored without a root path, but did not")
@@ -44,7 +44,7 @@ func TestSafeWriter_BadInput_MissingSourceManager(t *testing.T) {
 	pc.Load()
 
 	sw, _ := NewSafeWriter(nil, nil, pc.Project.Lock, VendorAlways)
-	err := sw.Write(pc.Project.AbsRoot, nil, false)
+	err := sw.Write(pc.Project.AbsRoot, nil, true)
 
 	if err == nil {
 		t.Fatal("should have errored without a source manager when forceVendor is true, but did not")
@@ -92,7 +92,7 @@ func TestSafeWriter_BadInput_NonexistentRoot(t *testing.T) {
 	sw, _ := NewSafeWriter(nil, nil, nil, VendorOnChanged)
 
 	missingroot := filepath.Join(pc.Project.AbsRoot, "nonexistent")
-	err := sw.Write(missingroot, pc.SourceManager, false)
+	err := sw.Write(missingroot, pc.SourceManager, true)
 
 	if err == nil {
 		t.Fatal("should have errored with nonexistent dir for root path, but did not")
@@ -110,7 +110,7 @@ func TestSafeWriter_BadInput_RootIsFile(t *testing.T) {
 	sw, _ := NewSafeWriter(nil, nil, nil, VendorOnChanged)
 
 	fileroot := pc.CopyFile("fileroot", "txn_writer/badinput_fileroot")
-	err := sw.Write(fileroot, pc.SourceManager, false)
+	err := sw.Write(fileroot, pc.SourceManager, true)
 
 	if err == nil {
 		t.Fatal("should have errored when root path is a file, but did not")
@@ -145,7 +145,7 @@ func TestSafeWriter_Manifest(t *testing.T) {
 	}
 
 	// Write changes
-	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, false)
+	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, true)
 	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
 	// Verify file system changes
@@ -187,7 +187,7 @@ func TestSafeWriter_ManifestAndUnmodifiedLock(t *testing.T) {
 	}
 
 	// Write changes
-	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, false)
+	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, true)
 	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
 	// Verify file system changes
@@ -229,7 +229,7 @@ func TestSafeWriter_ManifestAndUnmodifiedLockWithForceVendor(t *testing.T) {
 	}
 
 	// Write changes
-	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, false)
+	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, true)
 	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
 	// Verify file system changes
@@ -276,7 +276,7 @@ func TestSafeWriter_ModifiedLock(t *testing.T) {
 	}
 
 	// Write changes
-	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, false)
+	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, true)
 	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
 	// Verify file system changes
@@ -323,7 +323,7 @@ func TestSafeWriter_ModifiedLockSkipVendor(t *testing.T) {
 	}
 
 	// Write changes
-	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, false)
+	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, true)
 	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
 	// Verify file system changes
@@ -351,7 +351,7 @@ func TestSafeWriter_ForceVendorWhenVendorAlreadyExists(t *testing.T) {
 	pc.Load()
 
 	sw, _ := NewSafeWriter(nil, pc.Project.Lock, pc.Project.Lock, VendorAlways)
-	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, false)
+	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, true)
 	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
 	// Verify prepared actions
@@ -366,7 +366,7 @@ func TestSafeWriter_ForceVendorWhenVendorAlreadyExists(t *testing.T) {
 		t.Fatal("Expected the payload to contain the vendor directory ")
 	}
 
-	err = sw.Write(pc.Project.AbsRoot, pc.SourceManager, false)
+	err = sw.Write(pc.Project.AbsRoot, pc.SourceManager, true)
 	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
 	// Verify file system changes
@@ -413,7 +413,7 @@ func TestSafeWriter_NewLock(t *testing.T) {
 	}
 
 	// Write changes
-	err = sw.Write(pc.Project.AbsRoot, pc.SourceManager, false)
+	err = sw.Write(pc.Project.AbsRoot, pc.SourceManager, true)
 	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
 	// Verify file system changes
@@ -457,7 +457,7 @@ func TestSafeWriter_NewLockSkipVendor(t *testing.T) {
 	}
 
 	// Write changes
-	err = sw.Write(pc.Project.AbsRoot, pc.SourceManager, false)
+	err = sw.Write(pc.Project.AbsRoot, pc.SourceManager, true)
 	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
 	// Verify file system changes
@@ -547,7 +547,7 @@ func TestSafeWriter_VendorDotGitPreservedWithForceVendor(t *testing.T) {
 		t.Fatal("Expected the payload to contain the vendor directory")
 	}
 
-	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, false)
+	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, true)
 	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
 	// Verify file system changes


### PR DESCRIPTION
#672
This PR proposes inverting a bool method parameter:

```
func (sw *SafeWriter) Write(root string, sm gps.SourceManager, noExamples bool) error 

func (sw *SafeWriter) Write(root string, sm gps.SourceManager, examples bool) error 
```

I see that using a negative makes sense for the command line flag (`no-examples`), but I don't see a compelling reason to propagate that into the library code where it seems unidiomatic and a default/zero value is not relevant.