### PR TITLE
Fix failing test build

### DIFF
--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -797,7 +797,7 @@ func TestIsSymlink(t *testing.T) {
 		inaccessibleSymlink string
 	)
 
-	err, cleanup := setupInaccessibleDir(func(dir string) error {
+	cleanup := setupInaccessibleDir(t, func(dir string) error {
 		inaccessibleFile = filepath.Join(dir, "file")
 		if fh, err := os.Create(inaccessibleFile); err != nil {
 			return err
@@ -809,9 +809,6 @@ func TestIsSymlink(t *testing.T) {
 		return os.Symlink(inaccessibleFile, inaccessibleSymlink)
 	})
 	defer cleanup()
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	tests := map[string]struct {
 		expected bool


### PR DESCRIPTION
No clue why this didn't cause #643 to bomb out? `go test` was failing with

https://travis-ci.org/golang/dep/jobs/238875170#L183
```
# github.com/golang/dep/internal/fs
internal/fs/fs_test.go:800: assignment count mismatch: 2 = 1
internal/fs/fs_test.go:810: not enough arguments in call to setupInaccessibleDir
	have (func(string) error)
	want (*testing.T, func(string) error)
```