### PR TITLE
Stricter manifest validation - errors & warnings

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -20,6 +20,12 @@ import (
 // ManifestName is the manifest file name used by dep.
 const ManifestName = "Gopkg.toml"
 
+// Errors
+var errInvalidConstraint = errors.New("\"constraint\" must be a TOML array of tables")
+var errInvalidOverride = errors.New("\"override\" must be a TOML array of tables")
+var errInvalidRequired = errors.New("\"required\" must be a TOML list of strings")
+var errInvalidIgnored = errors.New("\"ignored\" must be a TOML list of strings")
+
 // Manifest holds manifest file data and implements gps.RootManifest.
 type Manifest struct {
 	Constraints gps.ProjectConstraints
@@ -44,11 +50,11 @@ type rawProject struct {
 }
 
 func validateManifest(s string) ([]error, error) {
-	var errs []error
+	var warns []error
 	// Load the TomlTree from string
 	tree, err := toml.Load(s)
 	if err != nil {
-		return errs, errors.Wrap(err, "Unable to load TomlTree from string")
+		return warns, errors.Wrap(err, "Unable to load TomlTree from string")
 	}
 	// Convert tree to a map
 	manifest := tree.ToMap()
@@ -61,46 +67,83 @@ func validateManifest(s string) ([]error, error) {
 		case "metadata":
 			// Check if metadata is of Map type
 			if reflect.TypeOf(val).Kind() != reflect.Map {
-				errs = append(errs, errors.New("metadata should be a TOML table"))
+				warns = append(warns, errors.New("metadata should be a TOML table"))
 			}
 		case "constraint", "override":
+			valid := true
 			// Invalid if type assertion fails. Not a TOML array of tables.
 			if rawProj, ok := val.([]interface{}); ok {
-				// Iterate through each array of tables
-				for _, v := range rawProj {
-					// Check the individual field's key to be valid
-					for key, value := range v.(map[string]interface{}) {
-						// Check if the key is valid
-						switch key {
-						case "name", "branch", "version", "source":
-							// valid key
-						case "revision":
-							if valueStr, ok := value.(string); ok {
-								if abbrevRevHash.MatchString(valueStr) {
-									errs = append(errs, fmt.Errorf("revision %q should not be in abbreviated form", valueStr))
+				// Check element type. Must be a map. Checking one element would be
+				// enough because TOML doesn't allow mixing of types.
+				if reflect.TypeOf(rawProj[0]).Kind() != reflect.Map {
+					valid = false
+				}
+
+				if valid {
+					// Iterate through each array of tables
+					for _, v := range rawProj {
+						// Check the individual field's key to be valid
+						for key, value := range v.(map[string]interface{}) {
+							// Check if the key is valid
+							switch key {
+							case "name", "branch", "version", "source":
+								// valid key
+							case "revision":
+								if valueStr, ok := value.(string); ok {
+									if abbrevRevHash.MatchString(valueStr) {
+										warns = append(warns, fmt.Errorf("revision %q should not be in abbreviated form", valueStr))
+									}
 								}
+							case "metadata":
+								// Check if metadata is of Map type
+								if reflect.TypeOf(value).Kind() != reflect.Map {
+									warns = append(warns, fmt.Errorf("metadata in %q should be a TOML table", prop))
+								}
+							default:
+								// unknown/invalid key
+								warns = append(warns, fmt.Errorf("Invalid key %q in %q", key, prop))
 							}
-						case "metadata":
-							// Check if metadata is of Map type
-							if reflect.TypeOf(value).Kind() != reflect.Map {
-								errs = append(errs, fmt.Errorf("metadata in %q should be a TOML table", prop))
-							}
-						default:
-							// unknown/invalid key
-							errs = append(errs, fmt.Errorf("Invalid key %q in %q", key, prop))
 						}
 					}
 				}
 			} else {
-				errs = append(errs, fmt.Errorf("%v should be a TOML array of tables", prop))
+				valid = false
+			}
+
+			if !valid {
+				if prop == "constraint" {
+					return warns, errInvalidConstraint
+				}
+				if prop == "override" {
+					return warns, errInvalidOverride
+				}
 			}
 		case "ignored", "required":
+			valid := true
+			if rawList, ok := val.([]interface{}); ok {
+				// Check element type of the array. TOML doesn't let mixing of types in
+				// array. Checking one element would be enough.
+				if reflect.TypeOf(rawList[0]).Kind() != reflect.String {
+					valid = false
+				}
+			} else {
+				valid = false
+			}
+
+			if !valid {
+				if prop == "ignored" {
+					return warns, errInvalidIgnored
+				}
+				if prop == "required" {
+					return warns, errInvalidRequired
+				}
+			}
 		default:
-			errs = append(errs, fmt.Errorf("Unknown field in manifest: %v", prop))
+			warns = append(warns, fmt.Errorf("Unknown field in manifest: %v", prop))
 		}
 	}
 
-	return errs, nil
+	return warns, nil
 }
 
 // readManifest returns a Manifest read from r and a slice of validation warnings.

--- a/manifest.go
+++ b/manifest.go
@@ -122,8 +122,8 @@ func validateManifest(s string) ([]error, error) {
 			valid := true
 			if rawList, ok := val.([]interface{}); ok {
 				// Check element type of the array. TOML doesn't let mixing of types in
-				// array. Checking one element would be enough.
-				if reflect.TypeOf(rawList[0]).Kind() != reflect.String {
+				// array. Checking one element would be enough. Empty array is valid.
+				if len(rawList) > 0 && reflect.TypeOf(rawList[0]).Kind() != reflect.String {
 					valid = false
 				}
 			} else {

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -143,6 +143,13 @@ func TestValidateManifest(t *testing.T) {
 		},
 		{
 			tomlString: `
+			required = []
+			`,
+			wantWarn:  []error{},
+			wantError: nil,
+		},
+		{
+			tomlString: `
 			required = [1, 2, 3]
 			`,
 			wantWarn:  []error{},
@@ -169,6 +176,13 @@ func TestValidateManifest(t *testing.T) {
 			`,
 			wantWarn:  []error{},
 			wantError: errInvalidIgnored,
+		},
+		{
+			tomlString: `
+			ignored = []
+			`,
+			wantWarn:  []error{},
+			wantError: nil,
 		},
 		{
 			tomlString: `
@@ -233,6 +247,13 @@ func TestValidateManifest(t *testing.T) {
 		},
 		{
 			tomlString: `
+			[[constraint]]
+			`,
+			wantWarn:  []error{},
+			wantError: nil,
+		},
+		{
+			tomlString: `
 			constraint = "foo"
 			`,
 			wantWarn:  []error{},
@@ -249,6 +270,13 @@ func TestValidateManifest(t *testing.T) {
 			tomlString: `
 			[[override]]
 			  name = "github.com/foo/bar"
+			`,
+			wantWarn:  []error{},
+			wantError: nil,
+		},
+		{
+			tomlString: `
+			[[override]]
 			`,
 			wantWarn:  []error{},
 			wantError: nil,

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -124,14 +124,66 @@ func TestReadManifestErrors(t *testing.T) {
 func TestValidateManifest(t *testing.T) {
 	cases := []struct {
 		tomlString string
-		want       []error
+		wantWarn   []error
+		wantError  error
 	}{
 		{
 			tomlString: `
-			[[constraint]]
-			  name = "github.com/foo/bar"
+			required = ["github.com/foo/bar"]
 			`,
-			want: []error{},
+			wantWarn:  []error{},
+			wantError: nil,
+		},
+		{
+			tomlString: `
+			required = "github.com/foo/bar"
+			`,
+			wantWarn:  []error{},
+			wantError: errInvalidRequired,
+		},
+		{
+			tomlString: `
+			required = [1, 2, 3]
+			`,
+			wantWarn:  []error{},
+			wantError: errInvalidRequired,
+		},
+		{
+			tomlString: `
+			[[required]]
+			  name = "foo"
+			`,
+			wantWarn:  []error{},
+			wantError: errInvalidRequired,
+		},
+		{
+			tomlString: `
+			ignored = ["foo"]
+			`,
+			wantWarn:  []error{},
+			wantError: nil,
+		},
+		{
+			tomlString: `
+			ignored = "foo"
+			`,
+			wantWarn:  []error{},
+			wantError: errInvalidIgnored,
+		},
+		{
+			tomlString: `
+			ignored = [1, 2, 3]
+			`,
+			wantWarn:  []error{},
+			wantError: errInvalidIgnored,
+		},
+		{
+			tomlString: `
+			[[ignored]]
+			  name = "foo"
+			`,
+			wantWarn:  []error{},
+			wantError: errInvalidIgnored,
 		},
 		{
 			tomlString: `
@@ -139,7 +191,8 @@ func TestValidateManifest(t *testing.T) {
 			  authors = "foo"
 			  version = "1.0.0"
 			`,
-			want: []error{},
+			wantWarn:  []error{},
+			wantError: nil,
 		},
 		{
 			tomlString: `
@@ -153,11 +206,12 @@ func TestValidateManifest(t *testing.T) {
 			  name = "github.com/foo/bar"
 			  version = ""
 			`,
-			want: []error{
+			wantWarn: []error{
 				errors.New("Unknown field in manifest: foo"),
 				errors.New("Unknown field in manifest: bar"),
 				errors.New("Unknown field in manifest: version"),
 			},
+			wantError: nil,
 		},
 		{
 			tomlString: `
@@ -166,17 +220,52 @@ func TestValidateManifest(t *testing.T) {
 			[[constraint]]
 			  name = "github.com/foo/bar"
 			`,
-			want: []error{errors.New("metadata should be a TOML table")},
+			wantWarn:  []error{errors.New("metadata should be a TOML table")},
+			wantError: nil,
+		},
+		{
+			tomlString: `
+			[[constraint]]
+			  name = "github.com/foo/bar"
+			`,
+			wantWarn:  []error{},
+			wantError: nil,
 		},
 		{
 			tomlString: `
 			constraint = "foo"
+			`,
+			wantWarn:  []error{},
+			wantError: errInvalidConstraint,
+		},
+		{
+			tomlString: `
+			constraint = ["foo", "bar"]
+			`,
+			wantWarn:  []error{},
+			wantError: errInvalidConstraint,
+		},
+		{
+			tomlString: `
+			[[override]]
+			  name = "github.com/foo/bar"
+			`,
+			wantWarn:  []error{},
+			wantError: nil,
+		},
+		{
+			tomlString: `
 			override = "bar"
 			`,
-			want: []error{
-				errors.New("constraint should be a TOML array of tables"),
-				errors.New("override should be a TOML array of tables"),
-			},
+			wantWarn:  []error{},
+			wantError: errInvalidOverride,
+		},
+		{
+			tomlString: `
+			override = ["foo", "bar"]
+			`,
+			wantWarn:  []error{},
+			wantError: errInvalidOverride,
 		},
 		{
 			tomlString: `
@@ -189,12 +278,13 @@ func TestValidateManifest(t *testing.T) {
 			[[override]]
 			  nick = "foo"
 			`,
-			want: []error{
+			wantWarn: []error{
 				errors.New("Invalid key \"location\" in \"constraint\""),
 				errors.New("Invalid key \"link\" in \"constraint\""),
 				errors.New("Invalid key \"nick\" in \"override\""),
 				errors.New("metadata in \"constraint\" should be a TOML table"),
 			},
+			wantError: nil,
 		},
 		{
 			tomlString: `
@@ -204,7 +294,8 @@ func TestValidateManifest(t *testing.T) {
 			  [constraint.metadata]
 			    color = "blue"
 			`,
-			want: []error{},
+			wantWarn:  []error{},
+			wantError: nil,
 		},
 		{
 			tomlString: `
@@ -212,7 +303,8 @@ func TestValidateManifest(t *testing.T) {
 			  name = "github.com/foo/bar"
 			  revision = "b86ad16"
 			`,
-			want: []error{errors.New("revision \"b86ad16\" should not be in abbreviated form")},
+			wantWarn:  []error{errors.New("revision \"b86ad16\" should not be in abbreviated form")},
+			wantError: nil,
 		},
 		{
 			tomlString: `
@@ -220,7 +312,8 @@ func TestValidateManifest(t *testing.T) {
 			  name = "foobar.com/hg"
 			  revision = "8d43f8c0b836"
 			`,
-			want: []error{errors.New("revision \"8d43f8c0b836\" should not be in abbreviated form")},
+			wantWarn:  []error{errors.New("revision \"8d43f8c0b836\" should not be in abbreviated form")},
+			wantError: nil,
 		},
 	}
 
@@ -236,19 +329,21 @@ func TestValidateManifest(t *testing.T) {
 
 	for _, c := range cases {
 		errs, err := validateManifest(c.tomlString)
-		if err != nil {
-			t.Fatal(err)
+
+		// compare validation errors
+		if err != c.wantError {
+			t.Fatalf("Manifest errors are not as expected: \n\t(GOT) %v \n\t(WNT) %v", err, c.wantError)
 		}
 
 		// compare length of error slice
-		if len(errs) != len(c.want) {
-			t.Fatalf("Number of manifest errors are not as expected: \n\t(GOT) %v errors(%v)\n\t(WNT) %v errors(%v).", len(errs), errs, len(c.want), c.want)
+		if len(errs) != len(c.wantWarn) {
+			t.Fatalf("Number of manifest errors are not as expected: \n\t(GOT) %v errors(%v)\n\t(WNT) %v errors(%v).", len(errs), errs, len(c.wantWarn), c.wantWarn)
 		}
 
 		// check if the expected errors exist in actual errors slice
 		for _, er := range errs {
-			if !contains(c.want, er) {
-				t.Fatalf("Manifest errors are not as expected: \n\t(MISSING) %v\n\t(FROM) %v", er, c.want)
+			if !contains(c.wantWarn, er) {
+				t.Fatalf("Manifest errors are not as expected: \n\t(MISSING) %v\n\t(FROM) %v", er, c.wantWarn)
 			}
 		}
 	}


### PR DESCRIPTION
Makes manifest validation stricter with **separate errors and warnings**.

Errors are raised for invalid syntax of known elements (required, ignored,
constraint, override), which are processed later.

Warnings are raised for unknown elements and less important (metadata)
elements that are not processed later.

Fixes #702 