### PR TITLE
Use pointer to versionUnifier in solver

### DIFF
--- a/internal/gps/selection.go
+++ b/internal/gps/selection.go
@@ -7,7 +7,7 @@ package gps
 type selection struct {
 	projects []selected
 	deps     map[ProjectRoot][]dependency
-	vu       versionUnifier
+	vu       *versionUnifier
 }
 
 type selected struct {

--- a/internal/gps/solver.go
+++ b/internal/gps/solver.go
@@ -125,7 +125,7 @@ type solver struct {
 
 	// A versionUnifier, to facilitate cross-type version comparison and set
 	// operations.
-	vUnify versionUnifier
+	vUnify *versionUnifier
 
 	// A stack containing projects and packages that are currently "selected" -
 	// that is, they have passed all satisfiability checks, and are part of the
@@ -300,7 +300,7 @@ func Prepare(params SolveParameters, sm SourceManager) (Solver, error) {
 	if err != nil {
 		return nil, err
 	}
-	s.vUnify = versionUnifier{
+	s.vUnify = &versionUnifier{
 		b: s.b,
 	}
 


### PR DESCRIPTION
Using a value caused the versionUnifier attached to the selection queue
to be without a metrics object, resulting in panics on constraint
conflicts. What's odd is that these panics *should* happen all the time,
but seem to actually happen in only a subset of cases.

@bsed, please test that this fixes your issue, as I can't reproduce.

Fixes #725