### PR TITLE
[WIP] [#302] Solution now exposes messages and warnings.

### DIFF
--- a/internal/gps/hash.go
+++ b/internal/gps/hash.go
@@ -61,7 +61,8 @@ func (s *solver) writeHashingInputs(w io.Writer) {
 	// getApplicableConstraints will apply overrides, incorporate requireds,
 	// apply local ignores, drop stdlib imports, and finally trim out
 	// ineffectual constraints.
-	for _, pd := range s.rd.getApplicableConstraints(s.stdLibFn) {
+	applicable, _ := s.rd.getApplicableConstraints(s.stdLibFn)
+	for _, pd := range applicable {
 		writeString(string(pd.Ident.ProjectRoot))
 		writeString(pd.Ident.Source)
 		writeString(pd.Constraint.typedString())

--- a/internal/gps/result.go
+++ b/internal/gps/result.go
@@ -23,6 +23,8 @@ type Solution interface {
 	// The version of the Solver used in generating this solution.
 	SolverVersion() int
 	Attempts() int
+	// Warnings and messages produced by the solver
+	Messages() []string
 }
 
 type solution struct {
@@ -43,6 +45,9 @@ type solution struct {
 
 	// The solver used in producing this solution
 	solv Solver
+
+	// Warnings and messages produced by the solver
+	msgs []string
 }
 
 // WriteDepTree takes a basedir and a Lock, and exports all the projects
@@ -108,4 +113,8 @@ func (r solution) SolverName() string {
 
 func (r solution) SolverVersion() int {
 	return r.solv.Version()
+}
+
+func (r solution) Messages() []string {
+	return r.msgs
 }

--- a/internal/gps/rootdata.go
+++ b/internal/gps/rootdata.go
@@ -79,7 +79,7 @@ func (rd rootdata) externalImportList(stdLibFn func(string) bool) []string {
 	return reach
 }
 
-func (rd rootdata) getApplicableConstraints(stdLibFn func(string) bool) []workingConstraint {
+func (rd rootdata) getApplicableConstraints(stdLibFn func(string) bool) (applicable, ineffectual []workingConstraint) {
 	// Merge the normal and test constraints together
 	pc := rd.rm.DependencyConstraints().merge(rd.rm.TestDependencyConstraints())
 
@@ -125,17 +125,17 @@ func (rd rootdata) getApplicableConstraints(stdLibFn func(string) bool) []workin
 		}
 	}
 
-	var ret []workingConstraint
-
 	xt.Walk(func(s string, v interface{}) bool {
 		wcc := v.(wccount)
 		if wcc.count > 0 {
-			ret = append(ret, wcc.wc)
+			applicable = append(applicable, wcc.wc)
+		} else {
+			ineffectual = append(ineffectual, wcc.wc)
 		}
 		return false
 	})
 
-	return ret
+	return applicable, ineffectual
 }
 
 func (rd rootdata) combineConstraints() []workingConstraint {

--- a/internal/gps/rootdata_test.go
+++ b/internal/gps/rootdata_test.go
@@ -83,9 +83,10 @@ func TestGetApplicableConstraints(t *testing.T) {
 	rd := is.(*solver).rd
 
 	table := []struct {
-		name   string
-		mut    func()
-		result []workingConstraint
+		name         string
+		mut          func()
+		result       []workingConstraint
+		ineffectuals []workingConstraint
 	}{
 		{
 			name: "base case, two constraints",
@@ -100,6 +101,7 @@ func TestGetApplicableConstraints(t *testing.T) {
 					Constraint: mkSVC("1.0.0"),
 				},
 			},
+			ineffectuals: nil,
 		},
 		{
 			name: "with unconstrained require",
@@ -117,6 +119,7 @@ func TestGetApplicableConstraints(t *testing.T) {
 					Constraint: mkSVC("1.0.0"),
 				},
 			},
+			ineffectuals: nil,
 		},
 		{
 			name: "with unconstrained import",
@@ -136,6 +139,7 @@ func TestGetApplicableConstraints(t *testing.T) {
 					Constraint: mkSVC("1.0.0"),
 				},
 			},
+			ineffectuals: nil,
 		},
 		{
 			name: "constraint on required",
@@ -158,6 +162,7 @@ func TestGetApplicableConstraints(t *testing.T) {
 					Constraint: NewBranch("foo"),
 				},
 			},
+			ineffectuals: nil,
 		},
 		{
 			name: "override on imported",
@@ -185,6 +190,7 @@ func TestGetApplicableConstraints(t *testing.T) {
 					overrConstraint: true,
 				},
 			},
+			ineffectuals: nil,
 		},
 		{
 			// It is certainly the simplest and most rule-abiding solution to
@@ -208,6 +214,13 @@ func TestGetApplicableConstraints(t *testing.T) {
 					Constraint: NewBranch("foo"),
 				},
 			},
+			ineffectuals: []workingConstraint{
+				{
+					Ident:           mkPI("d"),
+					Constraint:      NewBranch("bar"),
+					overrConstraint: true,
+				},
+			},
 		},
 	}
 
@@ -215,9 +228,12 @@ func TestGetApplicableConstraints(t *testing.T) {
 		t.Run(fix.name, func(t *testing.T) {
 			fix.mut()
 
-			got := rd.getApplicableConstraints(params.stdLibFn)
+			got, ineffectuals := rd.getApplicableConstraints(params.stdLibFn)
 			if !reflect.DeepEqual(fix.result, got) {
 				t.Errorf("unexpected applicable constraint set:\n\t(GOT): %+v\n\t(WNT): %+v", got, fix.result)
+			}
+			if !reflect.DeepEqual(fix.ineffectuals, ineffectuals) {
+				t.Errorf("unexpected ineffectuals:\n\t(GOT): %+v\n\t(WNT): %+v", ineffectuals, fix.ineffectuals)
 			}
 		})
 	}

--- a/internal/gps/solve_basic_test.go
+++ b/internal/gps/solve_basic_test.go
@@ -175,7 +175,7 @@ func mkPCstrnt(info string) ProjectConstraint {
 
 // mkCDep composes a completeDep struct from the inputs.
 //
-// The only real work here is passing the initial string to mkPDep. All the
+// The only real work here is passing the initial string to mkPCstrnt. All the
 // other args are taken as package names.
 func mkCDep(pdep string, pl ...string) completeDep {
 	pc := mkPCstrnt(pdep)
@@ -327,6 +327,12 @@ func mksolution(inputs ...interface{}) map[ProjectIdentifier]LockedProject {
 	return m
 }
 
+// mkWarn creates warning string for ineffectual contraints for the specified
+// package.
+func mkWarn(pkg string) string {
+	return fmt.Sprintf("WARN: ineffectual constraint: %s", pkg)
+}
+
 // mklp creates a LockedProject from string inputs
 func mklp(pair string, pkgs ...string) LockedProject {
 	a := mkAtom(pair)
@@ -381,6 +387,7 @@ type specfix interface {
 	maxTries() int
 	solution() map[ProjectIdentifier]LockedProject
 	failure() error
+	messages() []string
 }
 
 // A basicFixture is a declarative test fixture that can cover a wide variety of
@@ -412,6 +419,8 @@ type basicFixture struct {
 	l fixLock
 	// solve failure expected, if any
 	fail error
+	// solve warnings, if any
+	msgs []string
 	// overrides, if any
 	ovr ProjectConstraints
 	// request up/downgrade to all projects
@@ -473,6 +482,10 @@ func (f basicFixture) rootTree() pkgtree.PackageTree {
 
 func (f basicFixture) failure() error {
 	return f.fail
+}
+
+func (f basicFixture) messages() []string {
+	return f.msgs
 }
 
 // A table of basicFixtures, used in the basic solving test set.

--- a/internal/gps/solve_basic_test.go
+++ b/internal/gps/solve_basic_test.go
@@ -330,7 +330,7 @@ func mksolution(inputs ...interface{}) map[ProjectIdentifier]LockedProject {
 // mkWarn creates warning string for ineffectual contraints for the specified
 // package.
 func mkWarn(pkg string) string {
-	return fmt.Sprintf("WARN: ineffectual constraint: %s", pkg)
+	return fmt.Sprintf("WARNING: ineffectual constraint: %s", pkg)
 }
 
 // mklp creates a LockedProject from string inputs

--- a/internal/gps/solve_bimodal_test.go
+++ b/internal/gps/solve_bimodal_test.go
@@ -154,6 +154,9 @@ var bimodalFixtures = map[string]bimodalFixture{
 			"a 1.0.0",
 			"b 1.1.0",
 		),
+		msgs: []string{
+			mkWarn("b 1.0.0"),
+		},
 	},
 	// Constraints apply only if the project that declares them has a
 	// reachable import - non-root
@@ -406,6 +409,9 @@ var bimodalFixtures = map[string]bimodalFixture{
 			),
 		},
 		r: mksolution(),
+		msgs: []string{
+			mkWarn("a 1.0.0"),
+		},
 	},
 	// Transitive deps from one project (a) get incrementally included as other
 	// deps incorporate its various packages.
@@ -847,10 +853,13 @@ var bimodalFixtures = map[string]bimodalFixture{
 			"foo 1.0.0",
 			"bar from baz 1.0.0",
 		),
+		msgs: []string{
+			mkWarn("bar *"),
+		},
 	},
 	"overridden mismatched net addrs, alt in root": {
 		ds: []depspec{
-			dsp(mkDepspec("root 0.0.0", "bar from baz 1.0.0"),
+			dsp(mkDepspec("root 0.0.0", "bar from baz 2.0.0"),
 				pkg("root", "foo")),
 			dsp(mkDepspec("foo 1.0.0"),
 				pkg("foo", "bar")),
@@ -868,10 +877,13 @@ var bimodalFixtures = map[string]bimodalFixture{
 			"foo 1.0.0",
 			"bar from baz 1.0.0",
 		),
+		msgs: []string{
+			mkWarn("bar 2.0.0"),
+		},
 	},
 	"require package": {
 		ds: []depspec{
-			dsp(mkDepspec("root 0.0.0", "bar 1.0.0"),
+			dsp(mkDepspec("root 0.0.0", "bar 2.0.0"),
 				pkg("root", "foo")),
 			dsp(mkDepspec("foo 1.0.0"),
 				pkg("foo", "bar")),
@@ -886,10 +898,13 @@ var bimodalFixtures = map[string]bimodalFixture{
 			"bar 1.0.0",
 			"baz 1.0.0",
 		),
+		msgs: []string{
+			mkWarn("bar 2.0.0"),
+		},
 	},
 	"require subpackage": {
 		ds: []depspec{
-			dsp(mkDepspec("root 0.0.0", "bar 1.0.0"),
+			dsp(mkDepspec("root 0.0.0", "bar 2.0.0"),
 				pkg("root", "foo")),
 			dsp(mkDepspec("foo 1.0.0"),
 				pkg("foo", "bar")),
@@ -905,6 +920,9 @@ var bimodalFixtures = map[string]bimodalFixture{
 			"bar 1.0.0",
 			mklp("baz 1.0.0", "qux"),
 		),
+		msgs: []string{
+			mkWarn("bar 2.0.0"),
+		},
 	},
 	"require impossible subpackage": {
 		ds: []depspec{
@@ -1058,6 +1076,8 @@ type bimodalFixture struct {
 	lm map[string]fixLock
 	// solve failure expected, if any
 	fail error
+	// warnings, if any
+	msgs []string
 	// overrides, if any
 	ovr ProjectConstraints
 	// request up/downgrade to all projects
@@ -1126,6 +1146,10 @@ func (f bimodalFixture) rootTree() pkgtree.PackageTree {
 
 func (f bimodalFixture) failure() error {
 	return f.fail
+}
+
+func (f bimodalFixture) messages() []string {
+	return f.msgs
 }
 
 // bmSourceManager is an SM specifically for the bimodal fixtures. It composes

--- a/internal/gps/solve_test.go
+++ b/internal/gps/solve_test.go
@@ -239,6 +239,21 @@ func fixtureSolveSimpleChecks(fix specfix, soln Solution, err error, t *testing.
 				t.Errorf("Unexpected project %s@%s present in results, with pkgs:\n\t%s", ppi(id), pv(lp.Version()), lp.pkgs)
 			}
 		}
+
+		// Check warnings and messages
+		expectedMessages := make(map[string]bool)
+		for _, msg := range fix.messages() {
+			expectedMessages[msg] = true
+		}
+		for _, msg := range soln.Messages() {
+			if !expectedMessages[msg] {
+				t.Errorf("Unexpected warning: %s", msg)
+			}
+			delete(expectedMessages, msg)
+		}
+		for msg, _ := range expectedMessages {
+			t.Errorf("Did not receive expected warning: %s", msg)
+		}
 	}
 
 	return soln, err

--- a/internal/gps/solver.go
+++ b/internal/gps/solver.go
@@ -420,7 +420,7 @@ func (s *solver) Solve() (Solution, error) {
 		var msgs []string
 		_, ineffectuals := s.rd.getApplicableConstraints(s.stdLibFn)
 		for _, wc := range ineffectuals {
-			msgs = append(msgs, fmt.Sprintf("WARN: ineffectual constraint: %s %s", wc.Ident.ProjectRoot, wc.Constraint.String()))
+			msgs = append(msgs, fmt.Sprintf("WARNING: ineffectual constraint: %s %s", wc.Ident.ProjectRoot, wc.Constraint.String()))
 		}
 		soln.msgs = msgs
 	}

--- a/internal/gps/solver.go
+++ b/internal/gps/solver.go
@@ -415,6 +415,14 @@ func (s *solver) Solve() (Solution, error) {
 			soln.p[k] = pa2lp(pa, pl)
 			k++
 		}
+
+		// list warnings
+		var msgs []string
+		_, ineffectuals := s.rd.getApplicableConstraints(s.stdLibFn)
+		for _, wc := range ineffectuals {
+			msgs = append(msgs, fmt.Sprintf("WARN: ineffectual constraint: %s %s", wc.Ident.ProjectRoot, wc.Constraint.String()))
+		}
+		soln.msgs = msgs
 	}
 
 	s.traceFinish(soln, err)


### PR DESCRIPTION
WIP for issue #302, attempting to report ineffectual constraints. Considering solver.Solve() and Solution struct have no way of reporting messages/warnings, I have decided to add generic Solution.Messages() []string method that can return generic string messages.

The fix is using rootdata.getApplicableConstraints(), where I have modified it to return both applicable and ineffectual (not applicable) ones.

I need a bit of help/hint with the one of the test cases. In the test TestBasicSolves/override_dep's_constraint I do not understand why is "b 2.0.0" reported as ineffectual, because it is also part of the solution.

I would also like your opinions if you are OK with this way of reporting warnings, or would you like a more elaborate, i.e. struct based rather then string warnings, that can return actionable meta data.