### PR TITLE
Ignore test run output files in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 /dep
 /testdep
 /dep.exe
+/licenseok
+/profile.out
+/coverage.txt


### PR DESCRIPTION
I like to run the same code checks from travis locally before submitting a PR, which generates a couple extra files that aren't in our `.gitignore`.