### PR TITLE
Update the FAQ to use constraint instead of dependencies (reflect #538)

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -35,7 +35,7 @@ Summarize the question and quote the reply, linking back to the original comment
 ## When should I use `constraint`, `override`, `required`, or `ignored` in `Gopkg.toml`?
 
 * Use `constraint` to constrain a [direct dependency](#what-is-a-direct-or-transitive-dependency) to a specific branch, version range, revision, or specify an alternate source such as a fork.
-* Use `override` to constrain a [transitive dependency](#what-is-a-direct-or-transitive-dependency). See [How do I constrain a transitive dependency's version?](#how-do-i-constrain-a-transitive-dependencys-version) for more details on how overrides differ from dependencies. Overrides should be used cautiously, sparingly, and temporarily.
+* Use `override` to constrain a [transitive dependency](#what-is-a-direct-or-transitive-dependency). See [How do I constrain a transitive dependency's version?](#how-do-i-constrain-a-transitive-dependencys-version) for more details on how overrides differ from constraints. Overrides should be used cautiously, sparingly, and temporarily.
 * Use `required` to explicitly add a dependency that is not imported directly or transitively, for example a development package used for code generation.
 * Use `ignored` to ignore a package and any of that package's unique dependencies.
 
@@ -88,7 +88,7 @@ Here are some suggestions for when you could use `dep` or `go get`:
 Only your project's directly imported dependencies are affected by a `dependencies` entry
 in the manifest. Transitive dependencies are unaffected.
 
-Use an `overrides` entry for transitive dependencies.
+Use an `override` entry for transitive dependencies.
 
 ## How do I constrain a transitive dependency's version?
 First, if you're wondering about this because you're trying to keep the version
@@ -104,10 +104,10 @@ dependency, you have a couple of options:
 2. Use an override.
 
 Overrides are a sledgehammer, and should only be used as a last resort. While
-dependencies and overrides are declared in the same way in `Gopkg.toml`, they
+constraints and overrides are declared in the same way in `Gopkg.toml`, they
 behave differently:
 
-* Dependencies:
+* Constraints:
    1. Can be declared by any project's manifest, yours or a dependency
    2. Apply only to direct dependencies of the project declaring the constraint
    3. Must not conflict with the `dependencies` declared in any other project's manifest


### PR DESCRIPTION
### What does this do / why do we need it?
[[dependencies]] was changed to [[constraint]] but the FAQ still has answers that reference the old field.

### Which issue(s) does this PR fix?
Update the FAQ to use `constraints` instead of `dependencies` where the reference is to the manifest field.
