### PR TITLE
Version API Method Names

### DIFF
--- a/cmd/dep/glide_importer_test.go
+++ b/cmd/dep/glide_importer_test.go
@@ -189,7 +189,7 @@ func TestGlideConfig_Convert_Project(t *testing.T) {
 	}
 
 	wantRev := "ff2948a2ac8f538c4ecd55962e919d1e13e74baf"
-	gotRev := lpv.Underlying().String()
+	gotRev := lpv.Revision().String()
 	if gotRev != wantRev {
 		t.Fatalf("Expected locked revision to be %s, got %s", wantRev, gotRev)
 	}

--- a/cmd/dep/godep_importer.go
+++ b/cmd/dep/godep_importer.go
@@ -170,7 +170,7 @@ func (g *godepImporter) buildLockedProject(pkg godepPackage) gps.LockedProject {
 
 	if pkg.Comment != "" {
 		ver := gps.NewVersion(pkg.Comment)
-		version = ver.Is(gps.Revision(pkg.Rev))
+		version = ver.Pair(gps.Revision(pkg.Rev))
 	} else {
 		version = gps.Revision(pkg.Rev)
 	}

--- a/cmd/dep/godep_importer_test.go
+++ b/cmd/dep/godep_importer_test.go
@@ -150,7 +150,7 @@ func TestGodepConfig_ConvertProject(t *testing.T) {
 		t.Fatalf("Expected locked version to be PairedVersion but got %T", lv)
 	}
 
-	rev := lpv.Underlying()
+	rev := lpv.Revision()
 	if rev != "ff2948a2ac8f538c4ecd55962e919d1e13e74baf" {
 		t.Fatalf("Expected locked revision to be 'ff2948a2ac8f538c4ecd55962e919d1e13e74baf', got %s", rev)
 	}
@@ -208,7 +208,7 @@ func TestGodepConfig_ConvertProject_EmptyComment(t *testing.T) {
 		t.Fatalf("Expected locked version to be PairedVersion but got %T", lv)
 	}
 
-	rev := lpv.Underlying()
+	rev := lpv.Revision()
 	if rev != "ff2948a2ac8f538c4ecd55962e919d1e13e74baf" {
 		t.Fatalf("Expected locked revision to be 'ff2948a2ac8f538c4ecd55962e919d1e13e74baf', got %s", rev)
 	}

--- a/cmd/dep/gopath_scanner_test.go
+++ b/cmd/dep/gopath_scanner_test.go
@@ -151,11 +151,11 @@ func TestGetProjectPropertiesFromVersion(t *testing.T) {
 			want:    wantSemver,
 		},
 		{
-			version: gps.NewBranch("foo-branch").Is("some-revision"),
+			version: gps.NewBranch("foo-branch").Pair("some-revision"),
 			want:    gps.NewBranch("foo-branch"),
 		},
 		{
-			version: gps.NewVersion("foo-version").Is("some-revision"),
+			version: gps.NewVersion("foo-version").Pair("some-revision"),
 			want:    gps.NewVersion("foo-version"),
 		},
 		{
@@ -163,7 +163,7 @@ func TestGetProjectPropertiesFromVersion(t *testing.T) {
 			want:    nil,
 		},
 		{
-			version: gps.NewVersion("v1.0.0").Is("some-revision"),
+			version: gps.NewVersion("v1.0.0").Pair("some-revision"),
 			want:    wantSemver,
 		},
 	}

--- a/cmd/dep/root_analyzer.go
+++ b/cmd/dep/root_analyzer.go
@@ -205,7 +205,7 @@ func lookupVersionForRevision(rev gps.Revision, pi gps.ProjectIdentifier, sm gps
 
 	gps.SortPairedForUpgrade(versions) // Sort versions in asc order
 	for _, v := range versions {
-		if v.Underlying() == rev {
+		if v.Revision() == rev {
 			return v, nil
 		}
 	}

--- a/cmd/dep/status.go
+++ b/cmd/dep/status.go
@@ -328,7 +328,7 @@ func runStatusAll(ctx *dep.Ctx, out outputter, p *dep.Project, sm gps.SourceMana
 				bs.Revision = tv
 			case gps.PairedVersion:
 				bs.Version = tv.Unpair()
-				bs.Revision = tv.Underlying()
+				bs.Revision = tv.Revision()
 			}
 
 			// Check if the manifest has an override for this project. If so,
@@ -364,7 +364,7 @@ func runStatusAll(ctx *dep.Ctx, out outputter, p *dep.Project, sm gps.SourceMana
 						// upgrade, the first version we encounter that
 						// matches our constraint will be what we want.
 						if c.Constraint.Matches(v) {
-							bs.Latest = v.Underlying()
+							bs.Latest = v.Revision()
 							break
 						}
 					}

--- a/context.go
+++ b/context.go
@@ -290,7 +290,7 @@ func (c *Ctx) VersionInWorkspace(root gps.ProjectRoot) (gps.Version, error) {
 	if contains(tags, ver) {
 		// Assume semver if it starts with a v.
 		if strings.HasPrefix(ver, "v") {
-			return gps.NewVersion(ver).Is(gps.Revision(rev)), nil
+			return gps.NewVersion(ver).Pair(gps.Revision(rev)), nil
 		}
 
 		return nil, errors.Errorf("version for root %s does not start with a v: %q", pr, ver)
@@ -303,7 +303,7 @@ func (c *Ctx) VersionInWorkspace(root gps.ProjectRoot) (gps.Version, error) {
 	}
 	// Try to match the current version to a branch.
 	if contains(branches, ver) {
-		return gps.NewBranch(ver).Is(gps.Revision(rev)), nil
+		return gps.NewBranch(ver).Pair(gps.Revision(rev)), nil
 	}
 
 	return gps.Revision(rev), nil

--- a/context_test.go
+++ b/context_test.go
@@ -156,7 +156,7 @@ func TestVersionInWorkspace(t *testing.T) {
 		checkout bool
 	}{
 		"github.com/pkg/errors": {
-			rev:      gps.NewVersion("v0.8.0").Is("645ef00459ed84a119197bfb8d8205042c6df63d"), // semver
+			rev:      gps.NewVersion("v0.8.0").Pair("645ef00459ed84a119197bfb8d8205042c6df63d"), // semver
 			checkout: true,
 		},
 		"github.com/Sirupsen/logrus": {
@@ -164,7 +164,7 @@ func TestVersionInWorkspace(t *testing.T) {
 			checkout: true,
 		},
 		"github.com/rsc/go-get-default-branch": {
-			rev: gps.NewBranch("another-branch").Is("8e6902fdd0361e8fa30226b350e62973e3625ed5"),
+			rev: gps.NewBranch("another-branch").Pair("8e6902fdd0361e8fa30226b350e62973e3625ed5"),
 		},
 	}
 

--- a/internal/gps/constraint_test.go
+++ b/internal/gps/constraint_test.go
@@ -47,7 +47,7 @@ func TestBranchConstraintOps(t *testing.T) {
 
 	// Add rev to one
 	snuffster := Revision("snuffleupagus")
-	v3 := v1.Is(snuffster).(versionPair)
+	v3 := v1.Pair(snuffster).(versionPair)
 	if v2.Matches(v3) {
 		t.Errorf("%s should not match %s", v2, gu(v3))
 	}
@@ -70,7 +70,7 @@ func TestBranchConstraintOps(t *testing.T) {
 	}
 
 	// Add different rev to the other
-	v4 := v2.Is(Revision("cookie monster")).(versionPair)
+	v4 := v2.Pair(Revision("cookie monster")).(versionPair)
 	if v4.Matches(v3) {
 		t.Errorf("%s should not match %s", gu(v4), gu(v3))
 	}
@@ -96,7 +96,7 @@ func TestBranchConstraintOps(t *testing.T) {
 	// TODO(sdboyer) this might not actually be a good idea, when you consider the
 	// semantics of floating versions...matching on an underlying rev might be
 	// nice in the short term, but it's probably shit most of the time
-	v5 := v2.Is(Revision("snuffleupagus")).(versionPair)
+	v5 := v2.Pair(Revision("snuffleupagus")).(versionPair)
 	if !v5.Matches(v3) {
 		t.Errorf("%s should match %s", gu(v5), gu(v3))
 	}
@@ -122,9 +122,9 @@ func TestBranchConstraintOps(t *testing.T) {
 	cookie := Revision("cookie monster")
 	o1 := NewVersion("master").(plainVersion)
 	o2 := NewVersion("1.0.0").(semVersion)
-	o3 := o1.Is(cookie).(versionPair)
-	o4 := o2.Is(cookie).(versionPair)
-	v6 := v1.Is(cookie).(versionPair)
+	o3 := o1.Pair(cookie).(versionPair)
+	o4 := o2.Pair(cookie).(versionPair)
+	v6 := v1.Pair(cookie).(versionPair)
 
 	if v1.Matches(o1) {
 		t.Errorf("%s (branch) should not match %s (version) across types", v1, o1)
@@ -231,7 +231,7 @@ func TestVersionConstraintOps(t *testing.T) {
 
 	// Add rev to one
 	snuffster := Revision("snuffleupagus")
-	v3 := v1.Is(snuffster).(versionPair)
+	v3 := v1.Pair(snuffster).(versionPair)
 	if v2.Matches(v3) {
 		t.Errorf("%s should not match %s", v2, gu(v3))
 	}
@@ -254,7 +254,7 @@ func TestVersionConstraintOps(t *testing.T) {
 	}
 
 	// Add different rev to the other
-	v4 := v2.Is(Revision("cookie monster")).(versionPair)
+	v4 := v2.Pair(Revision("cookie monster")).(versionPair)
 	if v4.Matches(v3) {
 		t.Errorf("%s should not match %s", gu(v4), gu(v3))
 	}
@@ -277,7 +277,7 @@ func TestVersionConstraintOps(t *testing.T) {
 	}
 
 	// Now add same rev to different versions, and things should line up
-	v5 := v2.Is(Revision("snuffleupagus")).(versionPair)
+	v5 := v2.Pair(Revision("snuffleupagus")).(versionPair)
 	if !v5.Matches(v3) {
 		t.Errorf("%s should match %s", gu(v5), gu(v3))
 	}
@@ -303,9 +303,9 @@ func TestVersionConstraintOps(t *testing.T) {
 	cookie := Revision("cookie monster")
 	o1 := NewBranch("master").(branchVersion)
 	o2 := NewVersion("1.0.0").(semVersion)
-	o3 := o1.Is(cookie).(versionPair)
-	o4 := o2.Is(cookie).(versionPair)
-	v6 := v1.Is(cookie).(versionPair)
+	o3 := o1.Pair(cookie).(versionPair)
+	o4 := o2.Pair(cookie).(versionPair)
+	v6 := v1.Pair(cookie).(versionPair)
 
 	if v1.Matches(o1) {
 		t.Errorf("%s (version) should not match %s (branch) across types", v1, o1)
@@ -412,7 +412,7 @@ func TestSemverVersionConstraintOps(t *testing.T) {
 
 	// Add rev to one
 	snuffster := Revision("snuffleupagus")
-	v3 := v1.Is(snuffster).(versionPair)
+	v3 := v1.Pair(snuffster).(versionPair)
 	if v2.Matches(v3) {
 		t.Errorf("%s should not match %s", v2, gu(v3))
 	}
@@ -435,7 +435,7 @@ func TestSemverVersionConstraintOps(t *testing.T) {
 	}
 
 	// Add different rev to the other
-	v4 := v2.Is(Revision("cookie monster")).(versionPair)
+	v4 := v2.Pair(Revision("cookie monster")).(versionPair)
 	if v4.Matches(v3) {
 		t.Errorf("%s should not match %s", gu(v4), gu(v3))
 	}
@@ -458,7 +458,7 @@ func TestSemverVersionConstraintOps(t *testing.T) {
 	}
 
 	// Now add same rev to different versions, and things should line up
-	v5 := v2.Is(Revision("snuffleupagus")).(versionPair)
+	v5 := v2.Pair(Revision("snuffleupagus")).(versionPair)
 	if !v5.Matches(v3) {
 		t.Errorf("%s should match %s", gu(v5), gu(v3))
 	}
@@ -484,9 +484,9 @@ func TestSemverVersionConstraintOps(t *testing.T) {
 	cookie := Revision("cookie monster")
 	o1 := NewBranch("master").(branchVersion)
 	o2 := NewVersion("ab123").(plainVersion)
-	o3 := o1.Is(cookie).(versionPair)
-	o4 := o2.Is(cookie).(versionPair)
-	v6 := v1.Is(cookie).(versionPair)
+	o3 := o1.Pair(cookie).(versionPair)
+	o4 := o2.Pair(cookie).(versionPair)
+	v6 := v1.Pair(cookie).(versionPair)
 
 	if v1.Matches(o1) {
 		t.Errorf("%s (semver) should not match %s (branch) across types", v1, o1)
@@ -586,9 +586,9 @@ func TestSemverConstraintOps(t *testing.T) {
 	v3 := NewVersion("1.0.0").(semVersion)
 
 	fozzie := Revision("fozzie bear")
-	v4 := v1.Is(fozzie).(versionPair)
-	v5 := v2.Is(fozzie).(versionPair)
-	v6 := v3.Is(fozzie).(versionPair)
+	v4 := v1.Pair(fozzie).(versionPair)
+	v5 := v2.Pair(fozzie).(versionPair)
+	v6 := v3.Pair(fozzie).(versionPair)
 
 	// TODO(sdboyer) we can't use the same range as below b/c semver.rangeConstraint is
 	// still an incomparable type
@@ -702,9 +702,9 @@ func TestVersionUnion(t *testing.T) {
 	rev := Revision("flooboofoobooo")
 	v1 := NewBranch("master")
 	v2 := NewBranch("test")
-	v3 := NewVersion("1.0.0").Is(rev)
+	v3 := NewVersion("1.0.0").Pair(rev)
 	v4 := NewVersion("1.0.1")
-	v5 := NewVersion("v2.0.5").Is(Revision("notamatch"))
+	v5 := NewVersion("v2.0.5").Pair(Revision("notamatch"))
 
 	uv1 := versionTypeUnion{v1, v4, rev}
 	uv2 := versionTypeUnion{v2, v3}
@@ -877,7 +877,7 @@ func TestTypedConstraintString(t *testing.T) {
 	// Also tests typedVersionString(), as this nests down into that
 	rev := Revision("flooboofoobooo")
 	v1 := NewBranch("master")
-	v2 := NewBranch("test").Is(rev)
+	v2 := NewBranch("test").Pair(rev)
 	v3 := NewVersion("1.0.1")
 	v4 := NewVersion("v2.0.5")
 	v5 := NewVersion("2.0.5.2")

--- a/internal/gps/constraint_test.go
+++ b/internal/gps/constraint_test.go
@@ -12,7 +12,7 @@ import (
 // gu - helper func for stringifying what we assume is a VersionPair (otherwise
 // will panic), but is given as a Constraint
 func gu(v Constraint) string {
-	return fmt.Sprintf("%q at rev %q", v, v.(PairedVersion).Underlying())
+	return fmt.Sprintf("%q at rev %q", v, v.(PairedVersion).Revision())
 }
 
 func TestBranchConstraintOps(t *testing.T) {

--- a/internal/gps/lock.go
+++ b/internal/gps/lock.go
@@ -145,7 +145,7 @@ func (lp LockedProject) Version() Version {
 		return lp.r
 	}
 
-	return lp.v.Is(lp.r)
+	return lp.v.Pair(lp.r)
 }
 
 // Eq checks if two LockedProject instances are equal.

--- a/internal/gps/lock_test.go
+++ b/internal/gps/lock_test.go
@@ -36,7 +36,7 @@ func TestLockedProjectsEq(t *testing.T) {
 		NewLockedProject(mkPI("github.com/sdboyer/gps"), NewVersion("v0.10.0"), []string{"gps", "flugle"}),
 		NewLockedProject(mkPI("foo"), NewVersion("nada"), []string{"foo"}),
 		NewLockedProject(mkPI("github.com/sdboyer/gps"), NewVersion("v0.10.0"), []string{"flugle", "gps"}),
-		NewLockedProject(mkPI("github.com/sdboyer/gps"), NewVersion("v0.10.0").Is("278a227dfc3d595a33a77ff3f841fd8ca1bc8cd0"), []string{"gps"}),
+		NewLockedProject(mkPI("github.com/sdboyer/gps"), NewVersion("v0.10.0").Pair("278a227dfc3d595a33a77ff3f841fd8ca1bc8cd0"), []string{"gps"}),
 		NewLockedProject(mkPI("github.com/sdboyer/gps"), NewVersion("v0.11.0"), []string{"gps"}),
 		NewLockedProject(mkPI("github.com/sdboyer/gps"), Revision("278a227dfc3d595a33a77ff3f841fd8ca1bc8cd0"), []string{"gps"}),
 	}
@@ -81,9 +81,9 @@ func TestLockedProjectsEq(t *testing.T) {
 }
 
 func TestLocksAreEq(t *testing.T) {
-	gpl := NewLockedProject(mkPI("github.com/sdboyer/gps"), NewVersion("v0.10.0").Is("278a227dfc3d595a33a77ff3f841fd8ca1bc8cd0"), []string{"gps"})
+	gpl := NewLockedProject(mkPI("github.com/sdboyer/gps"), NewVersion("v0.10.0").Pair("278a227dfc3d595a33a77ff3f841fd8ca1bc8cd0"), []string{"gps"})
 	svpl := NewLockedProject(mkPI("github.com/Masterminds/semver"), NewVersion("v2.0.0"), []string{"semver"})
-	bbbt := NewLockedProject(mkPI("github.com/beeblebrox/browntown"), NewBranch("master").Is("63fc17eb7966a6f4cc0b742bf42731c52c4ac740"), []string{"browntown", "smoochies"})
+	bbbt := NewLockedProject(mkPI("github.com/beeblebrox/browntown"), NewBranch("master").Pair("63fc17eb7966a6f4cc0b742bf42731c52c4ac740"), []string{"browntown", "smoochies"})
 
 	l1 := solution{
 		hd: []byte("foo"),

--- a/internal/gps/manager_test.go
+++ b/internal/gps/manager_test.go
@@ -148,13 +148,13 @@ func TestSourceInit(t *testing.T) {
 		t.Errorf("Expected seven version results from the test repo, got %v", len(pvl))
 	} else {
 		expected := []PairedVersion{
-			NewVersion("v2.0.0").Is(Revision("4a54adf81c75375d26d376459c00d5ff9b703e5e")),
-			NewVersion("v1.1.0").Is(Revision("b2cb48dda625f6640b34d9ffb664533359ac8b91")),
-			NewVersion("v1.0.0").Is(Revision("bf85021c0405edbc4f3648b0603818d641674f72")),
-			newDefaultBranch("master").Is(Revision("bf85021c0405edbc4f3648b0603818d641674f72")),
-			NewBranch("v1").Is(Revision("e3777f683305eafca223aefe56b4e8ecf103f467")),
-			NewBranch("v1.1").Is(Revision("f1fbc520489a98306eb28c235204e39fa8a89c84")),
-			NewBranch("v3").Is(Revision("4a54adf81c75375d26d376459c00d5ff9b703e5e")),
+			NewVersion("v2.0.0").Pair(Revision("4a54adf81c75375d26d376459c00d5ff9b703e5e")),
+			NewVersion("v1.1.0").Pair(Revision("b2cb48dda625f6640b34d9ffb664533359ac8b91")),
+			NewVersion("v1.0.0").Pair(Revision("bf85021c0405edbc4f3648b0603818d641674f72")),
+			newDefaultBranch("master").Pair(Revision("bf85021c0405edbc4f3648b0603818d641674f72")),
+			NewBranch("v1").Pair(Revision("e3777f683305eafca223aefe56b4e8ecf103f467")),
+			NewBranch("v1.1").Pair(Revision("f1fbc520489a98306eb28c235204e39fa8a89c84")),
+			NewBranch("v3").Pair(Revision("4a54adf81c75375d26d376459c00d5ff9b703e5e")),
 		}
 
 		// SourceManager itself doesn't guarantee ordering; sort them here so we
@@ -186,13 +186,13 @@ func TestSourceInit(t *testing.T) {
 		t.Errorf("Expected seven version results from the test repo, got %v", len(vl))
 	} else {
 		expected := []Version{
-			NewVersion("v2.0.0").Is(Revision("4a54adf81c75375d26d376459c00d5ff9b703e5e")),
-			NewVersion("v1.1.0").Is(Revision("b2cb48dda625f6640b34d9ffb664533359ac8b91")),
-			NewVersion("v1.0.0").Is(Revision("bf85021c0405edbc4f3648b0603818d641674f72")),
-			newDefaultBranch("master").Is(Revision("bf85021c0405edbc4f3648b0603818d641674f72")),
-			NewBranch("v1").Is(Revision("e3777f683305eafca223aefe56b4e8ecf103f467")),
-			NewBranch("v1.1").Is(Revision("f1fbc520489a98306eb28c235204e39fa8a89c84")),
-			NewBranch("v3").Is(Revision("4a54adf81c75375d26d376459c00d5ff9b703e5e")),
+			NewVersion("v2.0.0").Pair(Revision("4a54adf81c75375d26d376459c00d5ff9b703e5e")),
+			NewVersion("v1.1.0").Pair(Revision("b2cb48dda625f6640b34d9ffb664533359ac8b91")),
+			NewVersion("v1.0.0").Pair(Revision("bf85021c0405edbc4f3648b0603818d641674f72")),
+			newDefaultBranch("master").Pair(Revision("bf85021c0405edbc4f3648b0603818d641674f72")),
+			NewBranch("v1").Pair(Revision("e3777f683305eafca223aefe56b4e8ecf103f467")),
+			NewBranch("v1.1").Pair(Revision("f1fbc520489a98306eb28c235204e39fa8a89c84")),
+			NewBranch("v3").Pair(Revision("4a54adf81c75375d26d376459c00d5ff9b703e5e")),
 		}
 
 		for k, e := range expected {
@@ -273,9 +273,9 @@ func TestDefaultBranchAssignment(t *testing.T) {
 		brev := Revision("fda020843ac81352004b9dca3fcccdd517600149")
 		mrev := Revision("9f9c3a591773d9b28128309ac7a9a72abcab267d")
 		expected := []PairedVersion{
-			NewBranch("branchone").Is(brev),
-			NewBranch("otherbranch").Is(brev),
-			NewBranch("master").Is(mrev),
+			NewBranch("branchone").Pair(brev),
+			NewBranch("otherbranch").Pair(brev),
+			NewBranch("master").Pair(mrev),
 		}
 
 		SortPairedForUpgrade(v)

--- a/internal/gps/result_test.go
+++ b/internal/gps/result_test.go
@@ -26,11 +26,11 @@ func init() {
 		p: []LockedProject{
 			pa2lp(atom{
 				id: pi("github.com/sdboyer/testrepo"),
-				v:  NewBranch("master").Is(Revision("4d59fb584b15a94d7401e356d2875c472d76ef45")),
+				v:  NewBranch("master").Pair(Revision("4d59fb584b15a94d7401e356d2875c472d76ef45")),
 			}, nil),
 			pa2lp(atom{
 				id: pi("github.com/Masterminds/VCSTestRepo"),
-				v:  NewVersion("1.0.0").Is(Revision("30605f6ac35fcb075ad0bfa9296f90a7d891523e")),
+				v:  NewVersion("1.0.0").Pair(Revision("30605f6ac35fcb075ad0bfa9296f90a7d891523e")),
 			}, nil),
 		},
 	}
@@ -41,7 +41,7 @@ func init() {
 	/*
 		_ = atom{
 			id: pi("github.com/kubernetes/kubernetes"),
-			v:  NewVersion("1.0.0").Is(Revision("528f879e7d3790ea4287687ef0ab3f2a01cc2718")),
+			v:  NewVersion("1.0.0").Pair(Revision("528f879e7d3790ea4287687ef0ab3f2a01cc2718")),
 		}
 	*/
 }
@@ -66,15 +66,15 @@ func testWriteDepTree(t *testing.T) {
 		p: []LockedProject{
 			pa2lp(atom{
 				id: pi("github.com/sdboyer/testrepo"),
-				v:  NewBranch("master").Is(Revision("4d59fb584b15a94d7401e356d2875c472d76ef45")),
+				v:  NewBranch("master").Pair(Revision("4d59fb584b15a94d7401e356d2875c472d76ef45")),
 			}, nil),
 			pa2lp(atom{
 				id: pi("launchpad.net/govcstestbzrrepo"),
-				v:  NewVersion("1.0.0").Is(Revision("matt@mattfarina.com-20150731135137-pbphasfppmygpl68")),
+				v:  NewVersion("1.0.0").Pair(Revision("matt@mattfarina.com-20150731135137-pbphasfppmygpl68")),
 			}, nil),
 			pa2lp(atom{
 				id: pi("bitbucket.org/sdboyer/withbm"),
-				v:  NewVersion("v1.0.0").Is(Revision("aa110802a0c64195d0a6c375c9f66668827c90b4")),
+				v:  NewVersion("v1.0.0").Pair(Revision("aa110802a0c64195d0a6c375c9f66668827c90b4")),
 			}, nil),
 		},
 	}

--- a/internal/gps/solve_basic_test.go
+++ b/internal/gps/solve_basic_test.go
@@ -293,7 +293,7 @@ func mkrevlock(pairs ...string) fixLock {
 	l := make(fixLock, 0)
 	for _, s := range pairs {
 		pa := mkAtom(s)
-		l = append(l, NewLockedProject(pa.id, pa.v.(PairedVersion).Underlying(), nil))
+		l = append(l, NewLockedProject(pa.id, pa.v.(PairedVersion).Revision(), nil))
 	}
 
 	return l
@@ -1419,7 +1419,7 @@ func (sm *depspecSourceManager) ExternalReach(id ProjectIdentifier, v Version) (
 
 func (sm *depspecSourceManager) ListPackages(id ProjectIdentifier, v Version) (pkgtree.PackageTree, error) {
 	pid := pident{n: ProjectRoot(id.normalizedSource()), v: v}
-	if pv, ok := v.(PairedVersion); ok && pv.Underlying() == "FAKEREV" {
+	if pv, ok := v.(PairedVersion); ok && pv.Revision() == "FAKEREV" {
 		// An empty rev may come in here because that's what we produce in
 		// ListVersions(). If that's what we see, then just pretend like we have
 		// an unpaired.
@@ -1568,7 +1568,7 @@ func (b *depspecBridge) listVersions(id ProjectIdentifier) ([]Version, error) {
 	// remove the underlying component.
 	vl := make([]Version, 0, len(pvl))
 	for _, v := range pvl {
-		if v.Underlying() == "FAKEREV" {
+		if v.Revision() == "FAKEREV" {
 			vl = append(vl, v.Unpair())
 		} else {
 			vl = append(vl, v)

--- a/internal/gps/solve_basic_test.go
+++ b/internal/gps/solve_basic_test.go
@@ -113,7 +113,7 @@ func mkAtom(info string) atom {
 	}
 
 	if rev != "" {
-		v = v.(UnpairedVersion).Is(rev)
+		v = v.(UnpairedVersion).Pair(rev)
 	}
 
 	return atom{
@@ -164,7 +164,7 @@ func mkPCstrnt(info string) ProjectConstraint {
 		// Of course, this *will* panic if the predicate is a revision or a
 		// semver constraint, neither of which implement UnpairedVersion. This
 		// is as intended, to prevent bad data from entering the system.
-		c = c.(UnpairedVersion).Is(rev)
+		c = c.(UnpairedVersion).Pair(rev)
 	}
 
 	return ProjectConstraint{
@@ -1482,7 +1482,7 @@ func (sm *depspecSourceManager) ListVersions(id ProjectIdentifier) ([]PairedVers
 		case UnpairedVersion:
 			// Dummy revision; if the fixture doesn't provide it, we know
 			// the test doesn't need revision info, anyway.
-			pvl = append(pvl, tv.Is(Revision("FAKEREV")))
+			pvl = append(pvl, tv.Pair(Revision("FAKEREV")))
 		default:
 			panic(fmt.Sprintf("unreachable: type of version was %#v for spec %s", ds.v, id.errString()))
 		}

--- a/internal/gps/solve_test.go
+++ b/internal/gps/solve_test.go
@@ -176,7 +176,7 @@ func fixtureSolveSimpleChecks(fix specfix, soln Solution, err error, t *testing.
 
 	pv := func(v Version) string {
 		if pv, ok := v.(PairedVersion); ok {
-			return fmt.Sprintf("%s (%s)", pv.Unpair(), pv.Underlying())
+			return fmt.Sprintf("%s (%s)", pv.Unpair(), pv.Revision())
 		}
 		return v.String()
 	}

--- a/internal/gps/source_cache.go
+++ b/internal/gps/source_cache.go
@@ -149,7 +149,7 @@ func (c *singleSourceCacheMemory) storeVersionMap(versionList []PairedVersion, f
 
 	for _, v := range versionList {
 		pv := v.(PairedVersion)
-		u, r := pv.Unpair(), pv.Underlying()
+		u, r := pv.Unpair(), pv.Revision()
 		c.vMap[u] = r
 		c.rMap[r] = append(c.rMap[r], u)
 	}
@@ -191,7 +191,7 @@ func (c *singleSourceCacheMemory) toRevision(v Version) (Revision, bool) {
 	case Revision:
 		return t, true
 	case PairedVersion:
-		return t.Underlying(), true
+		return t.Revision(), true
 	case UnpairedVersion:
 		c.mut.Lock()
 		r, has := c.vMap[t]

--- a/internal/gps/source_cache.go
+++ b/internal/gps/source_cache.go
@@ -174,7 +174,7 @@ func (c *singleSourceCacheMemory) getVersionsFor(r Revision) ([]UnpairedVersion,
 func (c *singleSourceCacheMemory) getAllVersions() []PairedVersion {
 	vlist := make([]PairedVersion, 0, len(c.vMap))
 	for v, r := range c.vMap {
-		vlist = append(vlist, v.Is(r))
+		vlist = append(vlist, v.Pair(r))
 	}
 	return vlist
 }

--- a/internal/gps/source_test.go
+++ b/internal/gps/source_test.go
@@ -81,10 +81,10 @@ func testSourceGateway(t *testing.T) {
 			} else {
 				SortPairedForUpgrade(vlist)
 				evl := []PairedVersion{
-					NewVersion("v1.0.0").Is(Revision("ff2948a2ac8f538c4ecd55962e919d1e13e74baf")),
-					NewVersion("v0.8.1").Is(Revision("3f4c3bea144e112a69bbe5d8d01c1b09a544253f")),
-					NewVersion("v0.8.0").Is(Revision("ff2948a2ac8f538c4ecd55962e919d1e13e74baf")),
-					newDefaultBranch("master").Is(Revision("3f4c3bea144e112a69bbe5d8d01c1b09a544253f")),
+					NewVersion("v1.0.0").Pair(Revision("ff2948a2ac8f538c4ecd55962e919d1e13e74baf")),
+					NewVersion("v0.8.1").Pair(Revision("3f4c3bea144e112a69bbe5d8d01c1b09a544253f")),
+					NewVersion("v0.8.0").Pair(Revision("ff2948a2ac8f538c4ecd55962e919d1e13e74baf")),
+					newDefaultBranch("master").Pair(Revision("3f4c3bea144e112a69bbe5d8d01c1b09a544253f")),
 				}
 				if !reflect.DeepEqual(vlist, evl) {
 					t.Fatalf("Version list was not what we expected:\n\t(GOT): %s\n\t(WNT): %s", vlist, evl)

--- a/internal/gps/vcs_source.go
+++ b/internal/gps/vcs_source.go
@@ -265,7 +265,7 @@ func (s *gitSource) listVersions(ctx context.Context) (vlist []PairedVersion, er
 			if bv, ok := pv.Unpair().(branchVersion); ok {
 				if bv.name != "master" && bv.isDefault {
 					bv.isDefault = false
-					vlist[k] = bv.Is(pv.Underlying())
+					vlist[k] = bv.Is(pv.Revision())
 				}
 			}
 		}

--- a/internal/gps/vcs_source.go
+++ b/internal/gps/vcs_source.go
@@ -229,7 +229,7 @@ func (s *gitSource) listVersions(ctx context.Context) (vlist []PairedVersion, er
 			v = branchVersion{
 				name:      n,
 				isDefault: isdef,
-			}.Is(rev).(PairedVersion)
+			}.Pair(rev).(PairedVersion)
 
 			vlist[uniq] = v
 			uniq++
@@ -247,7 +247,7 @@ func (s *gitSource) listVersions(ctx context.Context) (vlist []PairedVersion, er
 				// version first. Which should be impossible, but this
 				// covers us in case of weirdness, anyway.
 			}
-			v = NewVersion(vstr).Is(Revision(pair[:40])).(PairedVersion)
+			v = NewVersion(vstr).Pair(Revision(pair[:40])).(PairedVersion)
 			smap[vstr] = true
 			vlist[uniq] = v
 			uniq++
@@ -265,7 +265,7 @@ func (s *gitSource) listVersions(ctx context.Context) (vlist []PairedVersion, er
 			if bv, ok := pv.Unpair().(branchVersion); ok {
 				if bv.name != "master" && bv.isDefault {
 					bv.isDefault = false
-					vlist[k] = bv.Is(pv.Revision())
+					vlist[k] = bv.Pair(pv.Revision())
 				}
 			}
 		}
@@ -341,7 +341,7 @@ func (s *gopkginSource) listVersions(ctx context.Context) ([]PairedVersion, erro
 		vlist[dbranch] = branchVersion{
 			name:      dbv.v.(branchVersion).name,
 			isDefault: true,
-		}.Is(dbv.r)
+		}.Pair(dbv.r)
 	}
 
 	return vlist, nil
@@ -386,13 +386,13 @@ func (s *bzrSource) listVersions(ctx context.Context) ([]PairedVersion, error) {
 		idx := bytes.IndexByte(line, 32) // space
 		v := NewVersion(string(line[:idx]))
 		r := Revision(bytes.TrimSpace(line[idx:]))
-		vlist = append(vlist, v.Is(r))
+		vlist = append(vlist, v.Pair(r))
 	}
 
 	// Last, add the default branch, hardcoding the visual representation of it
 	// that bzr uses when operating in the workflow mode we're using.
 	v := newDefaultBranch("(default)")
-	vlist = append(vlist, v.Is(Revision(string(branchrev))))
+	vlist = append(vlist, v.Pair(Revision(string(branchrev))))
 
 	return vlist, nil
 }
@@ -443,7 +443,7 @@ func (s *hgSource) listVersions(ctx context.Context) ([]PairedVersion, error) {
 		}
 
 		idx := bytes.IndexByte(pair[0], 32) // space
-		v := NewVersion(string(pair[0][:idx])).Is(Revision(pair[1])).(PairedVersion)
+		v := NewVersion(string(pair[0][:idx])).Pair(Revision(pair[1])).(PairedVersion)
 		vlist = append(vlist, v)
 	}
 
@@ -475,9 +475,9 @@ func (s *hgSource) listVersions(ctx context.Context) ([]PairedVersion, error) {
 			var v PairedVersion
 			if str == "@" {
 				magicAt = true
-				v = newDefaultBranch(str).Is(Revision(pair[1])).(PairedVersion)
+				v = newDefaultBranch(str).Pair(Revision(pair[1])).(PairedVersion)
 			} else {
-				v = NewBranch(str).Is(Revision(pair[1])).(PairedVersion)
+				v = NewBranch(str).Pair(Revision(pair[1])).(PairedVersion)
 			}
 			vlist = append(vlist, v)
 		}
@@ -504,9 +504,9 @@ func (s *hgSource) listVersions(ctx context.Context) ([]PairedVersion, error) {
 		// "default" branch, then mark it as default branch
 		var v PairedVersion
 		if !magicAt && str == "default" {
-			v = newDefaultBranch(str).Is(Revision(pair[1])).(PairedVersion)
+			v = newDefaultBranch(str).Pair(Revision(pair[1])).(PairedVersion)
 		} else {
-			v = NewBranch(str).Is(Revision(pair[1])).(PairedVersion)
+			v = NewBranch(str).Pair(Revision(pair[1])).(PairedVersion)
 		}
 		vlist = append(vlist, v)
 	}

--- a/internal/gps/vcs_source_test.go
+++ b/internal/gps/vcs_source_test.go
@@ -193,7 +193,7 @@ func testGopkginSourceInteractions(t *testing.T) {
 		}
 
 		// check that an expected rev is present
-		rev := evl[0].(PairedVersion).Underlying()
+		rev := evl[0].(PairedVersion).Revision()
 		is, err := src.revisionPresentIn(rev)
 		if err != nil {
 			t.Errorf("Unexpected error while checking revision presence: %s", err)

--- a/internal/gps/vcs_source_test.go
+++ b/internal/gps/vcs_source_test.go
@@ -105,13 +105,13 @@ func testGitSourceInteractions(t *testing.T) {
 	} else {
 		SortForUpgrade(vlist)
 		evl := []Version{
-			NewVersion("v2.0.0").Is(Revision("4a54adf81c75375d26d376459c00d5ff9b703e5e")),
-			NewVersion("v1.1.0").Is(Revision("b2cb48dda625f6640b34d9ffb664533359ac8b91")),
-			NewVersion("v1.0.0").Is(Revision("bf85021c0405edbc4f3648b0603818d641674f72")),
-			newDefaultBranch("master").Is(Revision("bf85021c0405edbc4f3648b0603818d641674f72")),
-			NewBranch("v1").Is(Revision("e3777f683305eafca223aefe56b4e8ecf103f467")),
-			NewBranch("v1.1").Is(Revision("f1fbc520489a98306eb28c235204e39fa8a89c84")),
-			NewBranch("v3").Is(Revision("4a54adf81c75375d26d376459c00d5ff9b703e5e")),
+			NewVersion("v2.0.0").Pair(Revision("4a54adf81c75375d26d376459c00d5ff9b703e5e")),
+			NewVersion("v1.1.0").Pair(Revision("b2cb48dda625f6640b34d9ffb664533359ac8b91")),
+			NewVersion("v1.0.0").Pair(Revision("bf85021c0405edbc4f3648b0603818d641674f72")),
+			newDefaultBranch("master").Pair(Revision("bf85021c0405edbc4f3648b0603818d641674f72")),
+			NewBranch("v1").Pair(Revision("e3777f683305eafca223aefe56b4e8ecf103f467")),
+			NewBranch("v1.1").Pair(Revision("f1fbc520489a98306eb28c235204e39fa8a89c84")),
+			NewBranch("v3").Pair(Revision("4a54adf81c75375d26d376459c00d5ff9b703e5e")),
 		}
 		if !reflect.DeepEqual(vlist, evl) {
 			t.Errorf("Version list was not what we expected:\n\t(GOT): %s\n\t(WNT): %s", vlist, evl)
@@ -246,31 +246,31 @@ func testGopkginSourceInteractions(t *testing.T) {
 	wg.Add(4)
 	go func() {
 		tfunc("gopkg.in/sdboyer/gpkt.v1", "github.com/sdboyer/gpkt", 1, []Version{
-			NewVersion("v1.1.0").Is(Revision("b2cb48dda625f6640b34d9ffb664533359ac8b91")),
-			NewVersion("v1.0.0").Is(Revision("bf85021c0405edbc4f3648b0603818d641674f72")),
-			newDefaultBranch("v1.1").Is(Revision("f1fbc520489a98306eb28c235204e39fa8a89c84")),
-			NewBranch("v1").Is(Revision("e3777f683305eafca223aefe56b4e8ecf103f467")),
+			NewVersion("v1.1.0").Pair(Revision("b2cb48dda625f6640b34d9ffb664533359ac8b91")),
+			NewVersion("v1.0.0").Pair(Revision("bf85021c0405edbc4f3648b0603818d641674f72")),
+			newDefaultBranch("v1.1").Pair(Revision("f1fbc520489a98306eb28c235204e39fa8a89c84")),
+			NewBranch("v1").Pair(Revision("e3777f683305eafca223aefe56b4e8ecf103f467")),
 		})
 		wg.Done()
 	}()
 
 	go func() {
 		tfunc("gopkg.in/sdboyer/gpkt.v2", "github.com/sdboyer/gpkt", 2, []Version{
-			NewVersion("v2.0.0").Is(Revision("4a54adf81c75375d26d376459c00d5ff9b703e5e")),
+			NewVersion("v2.0.0").Pair(Revision("4a54adf81c75375d26d376459c00d5ff9b703e5e")),
 		})
 		wg.Done()
 	}()
 
 	go func() {
 		tfunc("gopkg.in/sdboyer/gpkt.v3", "github.com/sdboyer/gpkt", 3, []Version{
-			newDefaultBranch("v3").Is(Revision("4a54adf81c75375d26d376459c00d5ff9b703e5e")),
+			newDefaultBranch("v3").Pair(Revision("4a54adf81c75375d26d376459c00d5ff9b703e5e")),
 		})
 		wg.Done()
 	}()
 
 	go func() {
 		tfunc("github.com/sdboyer/gpkt2.v1-unstable", "github.com/sdboyer/gpkt2", 1, []Version{
-			newDefaultBranch("v1-unstable").Is(Revision("24de0be8f4a0b8a44321562117749b257bfcef69")),
+			newDefaultBranch("v1-unstable").Pair(Revision("24de0be8f4a0b8a44321562117749b257bfcef69")),
 		})
 		wg.Done()
 	}()
@@ -336,8 +336,8 @@ func testBzrSourceInteractions(t *testing.T) {
 		t.Errorf("Expected %s as source URL, got %s", un, src.upstreamURL())
 	}
 	evl := []Version{
-		NewVersion("1.0.0").Is(Revision("matt@mattfarina.com-20150731135137-pbphasfppmygpl68")),
-		newDefaultBranch("(default)").Is(Revision("matt@mattfarina.com-20150731135137-pbphasfppmygpl68")),
+		NewVersion("1.0.0").Pair(Revision("matt@mattfarina.com-20150731135137-pbphasfppmygpl68")),
+		newDefaultBranch("(default)").Pair(Revision("matt@mattfarina.com-20150731135137-pbphasfppmygpl68")),
 	}
 
 	// check that an expected rev is present
@@ -501,20 +501,20 @@ func testHgSourceInteractions(t *testing.T) {
 	donech := make(chan struct{})
 	go func() {
 		tfunc("bitbucket.org/sdboyer/withbm", []Version{
-			NewVersion("v1.0.0").Is(Revision("aa110802a0c64195d0a6c375c9f66668827c90b4")),
-			newDefaultBranch("@").Is(Revision("b10d05d581e5401f383e48ccfeb84b48fde99d06")),
-			NewBranch("another").Is(Revision("b10d05d581e5401f383e48ccfeb84b48fde99d06")),
-			NewBranch("default").Is(Revision("3d466f437f6616da594bbab6446cc1cb4328d1bb")),
-			NewBranch("newbranch").Is(Revision("5e2a01be9aee942098e44590ae545c7143da9675")),
+			NewVersion("v1.0.0").Pair(Revision("aa110802a0c64195d0a6c375c9f66668827c90b4")),
+			newDefaultBranch("@").Pair(Revision("b10d05d581e5401f383e48ccfeb84b48fde99d06")),
+			NewBranch("another").Pair(Revision("b10d05d581e5401f383e48ccfeb84b48fde99d06")),
+			NewBranch("default").Pair(Revision("3d466f437f6616da594bbab6446cc1cb4328d1bb")),
+			NewBranch("newbranch").Pair(Revision("5e2a01be9aee942098e44590ae545c7143da9675")),
 		})
 		close(donech)
 	}()
 
 	tfunc("bitbucket.org/sdboyer/nobm", []Version{
-		NewVersion("v1.0.0").Is(Revision("aa110802a0c64195d0a6c375c9f66668827c90b4")),
-		newDefaultBranch("default").Is(Revision("3d466f437f6616da594bbab6446cc1cb4328d1bb")),
-		NewBranch("another").Is(Revision("b10d05d581e5401f383e48ccfeb84b48fde99d06")),
-		NewBranch("newbranch").Is(Revision("5e2a01be9aee942098e44590ae545c7143da9675")),
+		NewVersion("v1.0.0").Pair(Revision("aa110802a0c64195d0a6c375c9f66668827c90b4")),
+		newDefaultBranch("default").Pair(Revision("3d466f437f6616da594bbab6446cc1cb4328d1bb")),
+		NewBranch("another").Pair(Revision("b10d05d581e5401f383e48ccfeb84b48fde99d06")),
+		NewBranch("newbranch").Pair(Revision("5e2a01be9aee942098e44590ae545c7143da9675")),
 	})
 
 	<-donech

--- a/internal/gps/version.go
+++ b/internal/gps/version.go
@@ -47,8 +47,8 @@ type Version interface {
 type PairedVersion interface {
 	Version
 
-	// Underlying returns the immutable Revision that identifies this Version.
-	Underlying() Revision
+	// Revision returns the immutable Revision that identifies this Version.
+	Revision() Revision
 
 	// Unpair returns the surface-level UnpairedVersion that half of the pair.
 	//
@@ -460,14 +460,14 @@ func (v versionPair) ImpliedCaretString() string {
 }
 
 func (v versionPair) typedString() string {
-	return fmt.Sprintf("%s-%s", v.Unpair().typedString(), v.Underlying().typedString())
+	return fmt.Sprintf("%s-%s", v.Unpair().typedString(), v.Revision().typedString())
 }
 
 func (v versionPair) Type() VersionType {
 	return v.v.Type()
 }
 
-func (v versionPair) Underlying() Revision {
+func (v versionPair) Revision() Revision {
 	return v.r
 }
 
@@ -786,7 +786,7 @@ func VersionComponentStrings(v Version) (revision string, branch string, version
 	case Revision:
 		revision = tv.String()
 	case PairedVersion:
-		revision = tv.Underlying().String()
+		revision = tv.Revision().String()
 	}
 
 	switch v.Type() {

--- a/internal/gps/version.go
+++ b/internal/gps/version.go
@@ -64,9 +64,9 @@ type PairedVersion interface {
 // VersionPair by indicating the version's corresponding, underlying Revision.
 type UnpairedVersion interface {
 	Version
-	// Is takes the underlying Revision that this UnpairedVersion corresponds
+	// Pair takes the underlying Revision that this UnpairedVersion corresponds
 	// to and unites them into a PairedVersion.
-	Is(Revision) PairedVersion
+	Pair(Revision) PairedVersion
 	// Ensures it is impossible to be both a PairedVersion and an
 	// UnpairedVersion
 	_pair(bool)
@@ -267,7 +267,7 @@ func (v branchVersion) Intersect(c Constraint) Constraint {
 	return none
 }
 
-func (v branchVersion) Is(r Revision) PairedVersion {
+func (v branchVersion) Pair(r Revision) PairedVersion {
 	return versionPair{
 		v: v,
 		r: r,
@@ -348,7 +348,7 @@ func (v plainVersion) Intersect(c Constraint) Constraint {
 	return none
 }
 
-func (v plainVersion) Is(r Revision) PairedVersion {
+func (v plainVersion) Pair(r Revision) PairedVersion {
 	return versionPair{
 		v: v,
 		r: r,
@@ -439,7 +439,7 @@ func (v semVersion) Intersect(c Constraint) Constraint {
 	return none
 }
 
-func (v semVersion) Is(r Revision) PairedVersion {
+func (v semVersion) Pair(r Revision) PairedVersion {
 	return versionPair{
 		v: v,
 		r: r,

--- a/internal/gps/version_queue_test.go
+++ b/internal/gps/version_queue_test.go
@@ -16,11 +16,11 @@ type fakeBridge struct {
 }
 
 var fakevl = []Version{
-	NewVersion("v2.0.0").Is("200rev"),
-	NewVersion("v1.1.1").Is("111rev"),
-	NewVersion("v1.1.0").Is("110rev"),
-	NewVersion("v1.0.0").Is("100rev"),
-	NewBranch("master").Is("masterrev"),
+	NewVersion("v2.0.0").Pair("200rev"),
+	NewVersion("v1.1.1").Pair("111rev"),
+	NewVersion("v1.1.0").Pair("110rev"),
+	NewVersion("v1.0.0").Pair("100rev"),
+	NewBranch("master").Pair("masterrev"),
 }
 
 func init() {

--- a/internal/gps/version_test.go
+++ b/internal/gps/version_test.go
@@ -8,16 +8,16 @@ import "testing"
 
 func TestVersionSorts(t *testing.T) {
 	rev := Revision("flooboofoobooo")
-	v1 := NewBranch("master").Is(rev)
-	v2 := NewBranch("test").Is(rev)
-	v3 := NewVersion("1.0.0").Is(rev)
-	v4 := NewVersion("1.0.1").Is(rev)
-	v5 := NewVersion("v2.0.5").Is(rev)
-	v6 := NewVersion("2.0.5.2").Is(rev)
-	v7 := newDefaultBranch("unwrapped").Is(rev)
-	v8 := NewVersion("20.0.5.2").Is(rev)
-	v9 := NewVersion("v1.5.5-beta.4").Is(rev)
-	v10 := NewVersion("v3.0.1-alpha.1").Is(rev)
+	v1 := NewBranch("master").Pair(rev)
+	v2 := NewBranch("test").Pair(rev)
+	v3 := NewVersion("1.0.0").Pair(rev)
+	v4 := NewVersion("1.0.1").Pair(rev)
+	v5 := NewVersion("v2.0.5").Pair(rev)
+	v6 := NewVersion("2.0.5.2").Pair(rev)
+	v7 := newDefaultBranch("unwrapped").Pair(rev)
+	v8 := NewVersion("20.0.5.2").Pair(rev)
+	v9 := NewVersion("v1.5.5-beta.4").Pair(rev)
+	v10 := NewVersion("v3.0.1-alpha.1").Pair(rev)
 
 	start := []Version{
 		v1,

--- a/internal/gps/version_unifier.go
+++ b/internal/gps/version_unifier.go
@@ -146,14 +146,14 @@ func (vu versionUnifier) createTypeUnion(id ProjectIdentifier, v Version) versio
 	case Revision:
 		return versionTypeUnion(vu.pairRevision(id, tv))
 	case PairedVersion:
-		return versionTypeUnion(vu.pairRevision(id, tv.Underlying()))
+		return versionTypeUnion(vu.pairRevision(id, tv.Revision()))
 	case UnpairedVersion:
 		pv := vu.pairVersion(id, tv)
 		if pv == nil {
 			return versionTypeUnion{tv}
 		}
 
-		return versionTypeUnion(vu.pairRevision(id, pv.Underlying()))
+		return versionTypeUnion(vu.pairRevision(id, pv.Revision()))
 	}
 
 	return nil

--- a/internal/gps/version_unifier_test.go
+++ b/internal/gps/version_unifier_test.go
@@ -20,16 +20,16 @@ func init() {
 	rev3 := Revision("revision-three")
 
 	lvfb1 = lvFixBridge{
-		NewBranch("master").Is(rev1),
-		NewBranch("test").Is(rev2),
-		NewVersion("1.0.0").Is(rev1),
-		NewVersion("1.0.1").Is("other1"),
-		NewVersion("v2.0.5").Is(rev3),
-		NewVersion("2.0.5.2").Is(rev3),
-		newDefaultBranch("unwrapped").Is(rev3),
-		NewVersion("20.0.5.2").Is(rev1),
-		NewVersion("v1.5.5-beta.4").Is("other2"),
-		NewVersion("v3.0.1-alpha.1").Is(rev2),
+		NewBranch("master").Pair(rev1),
+		NewBranch("test").Pair(rev2),
+		NewVersion("1.0.0").Pair(rev1),
+		NewVersion("1.0.1").Pair("other1"),
+		NewVersion("v2.0.5").Pair(rev3),
+		NewVersion("2.0.5.2").Pair(rev3),
+		newDefaultBranch("unwrapped").Pair(rev3),
+		NewVersion("20.0.5.2").Pair(rev1),
+		NewVersion("v1.5.5-beta.4").Pair("other2"),
+		NewVersion("v3.0.1-alpha.1").Pair(rev2),
 	}
 }
 
@@ -96,7 +96,7 @@ func TestTypeUnionIntersect(t *testing.T) {
 	}
 
 	gotc = vu.intersect(id, c, rev3)
-	if gotc != NewVersion("v2.0.5").Is(rev3) {
+	if gotc != NewVersion("v2.0.5").Pair(rev3) {
 		t.Fatalf("wanted v2.0.5, got %s from intersect", gotc.typedString())
 	}
 }

--- a/lock.go
+++ b/lock.go
@@ -95,9 +95,9 @@ func fromRawLock(raw rawLock) (*Lock, error) {
 			if ld.Branch != "" {
 				return nil, errors.Errorf("lock file specified both a branch (%s) and version (%s) for %s", ld.Branch, ld.Version, ld.Name)
 			}
-			v = gps.NewVersion(ld.Version).Is(r)
+			v = gps.NewVersion(ld.Version).Pair(r)
 		} else if ld.Branch != "" {
-			v = gps.NewBranch(ld.Branch).Is(r)
+			v = gps.NewBranch(ld.Branch).Pair(r)
 		} else if r == "" {
 			return nil, errors.Errorf("lock file has entry for %s, but specifies no branch or version", ld.Name)
 		}

--- a/lock_test.go
+++ b/lock_test.go
@@ -34,7 +34,7 @@ func TestReadLock(t *testing.T) {
 		P: []gps.LockedProject{
 			gps.NewLockedProject(
 				gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot("github.com/golang/dep/internal/gps")},
-				gps.NewBranch("master").Is(gps.Revision("d05d5aca9f895d19e9265839bffeadd74a2d2ecb")),
+				gps.NewBranch("master").Pair(gps.Revision("d05d5aca9f895d19e9265839bffeadd74a2d2ecb")),
 				[]string{"."},
 			),
 		},
@@ -60,7 +60,7 @@ func TestReadLock(t *testing.T) {
 		P: []gps.LockedProject{
 			gps.NewLockedProject(
 				gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot("github.com/golang/dep/internal/gps")},
-				gps.NewVersion("0.12.2").Is(gps.Revision("d05d5aca9f895d19e9265839bffeadd74a2d2ecb")),
+				gps.NewVersion("0.12.2").Pair(gps.Revision("d05d5aca9f895d19e9265839bffeadd74a2d2ecb")),
 				[]string{"."},
 			),
 		},
@@ -85,7 +85,7 @@ func TestWriteLock(t *testing.T) {
 		P: []gps.LockedProject{
 			gps.NewLockedProject(
 				gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot("github.com/golang/dep/internal/gps")},
-				gps.NewBranch("master").Is(gps.Revision("d05d5aca9f895d19e9265839bffeadd74a2d2ecb")),
+				gps.NewBranch("master").Pair(gps.Revision("d05d5aca9f895d19e9265839bffeadd74a2d2ecb")),
 				[]string{"."},
 			),
 		},
@@ -116,7 +116,7 @@ func TestWriteLock(t *testing.T) {
 		P: []gps.LockedProject{
 			gps.NewLockedProject(
 				gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot("github.com/golang/dep/internal/gps")},
-				gps.NewVersion("0.12.2").Is(gps.Revision("d05d5aca9f895d19e9265839bffeadd74a2d2ecb")),
+				gps.NewVersion("0.12.2").Pair(gps.Revision("d05d5aca9f895d19e9265839bffeadd74a2d2ecb")),
 				[]string{"."},
 			),
 		},


### PR DESCRIPTION
### What does this do / why do we need it?

This PR proposes name changes for two gps version interface methods, primarily for the sake of readability (based on my experience working towards #431).
1) The `UnpairedVersion` interface method `Is`:
Old: `Is(Revision) PairedVersion`
New: `Pair(Revision) PairedVersion`
2) The `PairedVersion` interface method `Underlying`:
Old: `Underlying() Revision`
New: `Revision() Revision`
[Jump to interface declarations](https://github.com/golang/dep/pull/750/files#diff-4d0ad66ea351a55090725da9672b6c4e)

### What should your reviewer look out for in this PR?

Reasons not to do this, or more idiomatic name alternatives.

### Which issue(s) does this PR fix?

Related to #672 and #431
