### PR TITLE
Fix build on master

### DIFF
--- a/internal/feedback/feedback.go
+++ b/internal/feedback/feedback.go
@@ -58,7 +58,7 @@ func NewLockedProjectFeedback(lp gps.LockedProject, depType string) *ConstraintF
 	switch vt := lp.Version().(type) {
 	case gps.PairedVersion:
 		cf.LockedVersion = vt.String()
-		cf.Revision = vt.Underlying().String()
+		cf.Revision = vt.Revision().String()
 	case gps.UnpairedVersion: // Logically this should never occur, but handle for completeness sake
 		cf.LockedVersion = vt.String()
 	case gps.Revision:

--- a/internal/feedback/feedback_test.go
+++ b/internal/feedback/feedback_test.go
@@ -52,8 +52,8 @@ func TestFeedback_Constraint(t *testing.T) {
 }
 
 func TestFeedback_LockedProject(t *testing.T) {
-	v := gps.NewVersion("v1.1.4").Is("bc29b4f")
-	b := gps.NewBranch("master").Is("436f39d")
+	v := gps.NewVersion("v1.1.4").Pair("bc29b4f")
+	b := gps.NewBranch("master").Pair("436f39d")
 	pi := gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot("github.com/foo/bar")}
 
 	cases := []struct {


### PR DESCRIPTION
A few PRs collided in the last merge, this fixes the rename from `Underlying()` to `Revision()`, and `Is()` to `Pair()`.