### PR TITLE
gps: add new ProjectAnalyzerInfo type to return from ProjectAnalyzer.Info

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -45,7 +45,10 @@ func (a Analyzer) DeriveManifestAndLock(path string, n gps.ProjectRoot) (gps.Man
 	return m, nil, nil
 }
 
-// Info returns the name and version of this ProjectAnalyzer.
-func (a Analyzer) Info() (string, int) {
-	return "dep", 1
+// Info returns Analyzer's name and version info.
+func (a Analyzer) Info() gps.ProjectAnalyzerInfo {
+	return gps.ProjectAnalyzerInfo{
+		Name:    "dep",
+		Version: 1,
+	}
 }

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -105,9 +105,9 @@ func TestAnalyzerDeriveManifestAndLockInvalidManifest(t *testing.T) {
 func TestAnalyzerInfo(t *testing.T) {
 	a := Analyzer{}
 
-	name, vers := a.Info()
+	info := a.Info()
 
-	if name != "dep" || vers != 1 {
-		t.Fatalf("expected name to be 'dep' and version to be 1: name -> %q vers -> %d", name, vers)
+	if info.Name != "dep" || info.Version != 1 {
+		t.Fatalf("expected name to be 'dep' and version to be 1: name -> %q vers -> %d", info.Name, info.Version)
 	}
 }

--- a/cmd/dep/root_analyzer.go
+++ b/cmd/dep/root_analyzer.go
@@ -141,13 +141,16 @@ func (a *rootAnalyzer) FinalizeRootManifestAndLock(m *dep.Manifest, l *dep.Lock)
 	}
 }
 
-func (a *rootAnalyzer) Info() (string, int) {
+func (a *rootAnalyzer) Info() gps.ProjectAnalyzerInfo {
 	name := "dep"
 	version := 1
 	if !a.skipTools {
 		name = "dep+import"
 	}
-	return name, version
+	return gps.ProjectAnalyzerInfo{
+		Name:    name,
+		Version: version,
+	}
 }
 
 func lookupVersionForRevision(rev gps.Revision, pi gps.ProjectIdentifier, sm gps.SourceManager) (gps.Version, error) {

--- a/cmd/dep/root_analyzer_test.go
+++ b/cmd/dep/root_analyzer_test.go
@@ -13,7 +13,7 @@ func TestRootAnalyzer_Info(t *testing.T) {
 	}
 	for skipTools, want := range testCases {
 		a := rootAnalyzer{skipTools: skipTools}
-		got, _ := a.Info()
+		got := a.Info().Name
 		if got != want {
 			t.Errorf("Expected the name of the importer with skipTools=%t to be '%s', got '%s'", skipTools, want, got)
 		}

--- a/internal/gps/example.go
+++ b/internal/gps/example.go
@@ -70,6 +70,9 @@ func (a NaiveAnalyzer) DeriveManifestAndLock(path string, n gps.ProjectRoot) (gp
 
 // Reports the name and version of the analyzer. This is used internally as part
 // of gps' hashing memoization scheme.
-func (a NaiveAnalyzer) Info() (name string, version int) {
-	return "example-analyzer", 1
+func (a NaiveAnalyzer) Info() gps.ProjectAnalyzerInfo {
+	return gps.ProjectAnalyzerInfo{
+		Name:    "example-analyzer",
+		Version: 1,
+	}
 }

--- a/internal/gps/hash.go
+++ b/internal/gps/hash.go
@@ -106,9 +106,9 @@ func (s *solver) writeHashingInputs(w io.Writer) {
 	}
 
 	writeString(hhAnalyzer)
-	an, av := s.rd.an.Info()
-	writeString(an)
-	writeString(strconv.Itoa(av))
+	ai := s.rd.an.Info()
+	writeString(ai.Name)
+	writeString(strconv.Itoa(ai.Version))
 }
 
 // bytes.Buffer wrapper that injects newlines after each call to Write().

--- a/internal/gps/manager_test.go
+++ b/internal/gps/manager_test.go
@@ -27,8 +27,11 @@ func (naiveAnalyzer) DeriveManifestAndLock(string, ProjectRoot) (Manifest, Lock,
 	return nil, nil, nil
 }
 
-func (a naiveAnalyzer) Info() (name string, version int) {
-	return "naive-analyzer", 1
+func (a naiveAnalyzer) Info() ProjectAnalyzerInfo {
+	return ProjectAnalyzerInfo{
+		Name:    "naive-analyzer",
+		Version: 1,
+	}
 }
 
 func mkNaiveSM(t *testing.T) (*SourceMgr, func()) {

--- a/internal/gps/result.go
+++ b/internal/gps/result.go
@@ -35,11 +35,8 @@ type solution struct {
 	// The hash digest of the input opts
 	hd []byte
 
-	// The analyzer name
-	analyzerName string
-
-	// The analyzer version
-	analyzerVersion int
+	// The analyzer info
+	analyzerInfo ProjectAnalyzerInfo
 
 	// The solver used in producing this solution
 	solv Solver
@@ -95,11 +92,11 @@ func (r solution) InputHash() []byte {
 }
 
 func (r solution) AnalyzerName() string {
-	return r.analyzerName
+	return r.analyzerInfo.Name
 }
 
 func (r solution) AnalyzerVersion() int {
-	return r.analyzerVersion
+	return r.analyzerInfo.Version
 }
 
 func (r solution) SolverName() string {

--- a/internal/gps/result_test.go
+++ b/internal/gps/result_test.go
@@ -34,7 +34,7 @@ func init() {
 			}, nil),
 		},
 	}
-	basicResult.analyzerName, basicResult.analyzerVersion = (naiveAnalyzer{}).Info()
+	basicResult.analyzerInfo = (naiveAnalyzer{}).Info()
 
 	// Just in case something needs punishing, kubernetes offers a complex,
 	// real-world set of dependencies, and this revision is known to work.

--- a/internal/gps/solver.go
+++ b/internal/gps/solver.go
@@ -405,7 +405,7 @@ func (s *solver) Solve() (Solution, error) {
 			att:  s.attempts,
 			solv: s,
 		}
-		soln.analyzerName, soln.analyzerVersion = s.rd.an.Info()
+		soln.analyzerInfo = s.rd.an.Info()
 		soln.hd = s.HashInputs()
 
 		// Convert ProjectAtoms into LockedProjects

--- a/internal/gps/source.go
+++ b/internal/gps/source.go
@@ -276,7 +276,7 @@ func (sg *sourceGateway) getManifestAndLock(ctx context.Context, pr ProjectRoot,
 		return nil, nil, err
 	}
 
-	m, l, has := sg.cache.getManifestAndLock(r, an)
+	m, l, has := sg.cache.getManifestAndLock(r, an.Info())
 	if has {
 		return m, l, nil
 	}
@@ -286,8 +286,7 @@ func (sg *sourceGateway) getManifestAndLock(ctx context.Context, pr ProjectRoot,
 		return nil, nil, err
 	}
 
-	name, vers := an.Info()
-	label := fmt.Sprintf("%s:%s.%v", sg.src.upstreamURL(), name, vers)
+	label := fmt.Sprintf("%s:%s", sg.src.upstreamURL(), an.Info())
 	err = sg.suprvsr.do(ctx, label, ctGetManifestAndLock, func(ctx context.Context) error {
 		m, l, err = sg.src.getManifestAndLock(ctx, pr, r, an)
 		return err
@@ -317,7 +316,7 @@ func (sg *sourceGateway) getManifestAndLock(ctx context.Context, pr ProjectRoot,
 		return nil, nil, err
 	}
 
-	sg.cache.setManifestAndLock(r, an, m, l)
+	sg.cache.setManifestAndLock(r, an.Info(), m, l)
 	return m, l, nil
 }
 

--- a/internal/gps/source_manager.go
+++ b/internal/gps/source_manager.go
@@ -87,8 +87,19 @@ type ProjectAnalyzer interface {
 	// expected files containing Manifest and Lock data are merely absent.
 	DeriveManifestAndLock(path string, importRoot ProjectRoot) (Manifest, Lock, error)
 
-	// Report the name and version of this ProjectAnalyzer.
-	Info() (name string, version int)
+	// Info reports this project analyzer's info.
+	Info() ProjectAnalyzerInfo
+}
+
+// ProjectAnalyzerInfo indicates a ProjectAnalyzer's name and version.
+type ProjectAnalyzerInfo struct {
+	Name    string
+	Version int
+}
+
+// String returns a string like: "<name>.<decimal version>"
+func (p ProjectAnalyzerInfo) String() string {
+	return fmt.Sprintf("%s.%d", p.Name, p.Version)
 }
 
 // SourceMgr is the default SourceManager for gps.


### PR DESCRIPTION
### What does this do / why do we need it?

This PR proposes a new simple struct type `ProjectAnalyzerInfo` to return from `ProjectAnalyzer.Info()`, and to use in place of `ProjectAnalyzer` in a few places which only called `Info()`. My working branch for #431 contains additional usages.

### What should your reviewer look out for in this PR?

Better name or documentation opportunities. More usages of `ProjectAnalyzer` which only need `ProjectAnalyzerInfo`.

### Which issue(s) does this PR fix?

Related #672 and #431.