### PR TITLE
move deduceConstraint to SourceManager

### DIFF
--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -296,7 +296,7 @@ func getProjectConstraint(arg string, sm gps.SourceManager) (gps.ProjectConstrai
 	}
 
 	pi := gps.ProjectIdentifier{ProjectRoot: pr, Source: source}
-	c, err := sm.DeduceConstraint(versionStr, pi)
+	c, err := sm.InferConstraint(versionStr, pi)
 	if err != nil {
 		return emptyPC, err
 	}

--- a/cmd/dep/ensure_test.go
+++ b/cmd/dep/ensure_test.go
@@ -38,7 +38,7 @@ func TestDeduceConstraint(t *testing.T) {
 
 	pi := gps.ProjectIdentifier{ProjectRoot: "github.com/sdboyer/deptest"}
 	for str, want := range constraints {
-		got, err := sm.DeduceConstraint(str, pi)
+		got, err := sm.InferConstraint(str, pi)
 		h.Must(err)
 
 		wantT := reflect.TypeOf(want)
@@ -68,7 +68,7 @@ func TestDeduceConstraint_InvalidInput(t *testing.T) {
 
 	pi := gps.ProjectIdentifier{ProjectRoot: "github.com/sdboyer/deptest"}
 	for _, str := range constraints {
-		_, err := sm.DeduceConstraint(str, pi)
+		_, err := sm.InferConstraint(str, pi)
 		if err == nil {
 			t.Errorf("expected %s to produce an error", str)
 		}

--- a/cmd/dep/ensure_test.go
+++ b/cmd/dep/ensure_test.go
@@ -38,7 +38,7 @@ func TestDeduceConstraint(t *testing.T) {
 
 	pi := gps.ProjectIdentifier{ProjectRoot: "github.com/sdboyer/deptest"}
 	for str, want := range constraints {
-		got, err := deduceConstraint(str, pi, sm)
+		got, err := sm.DeduceConstraint(str, pi)
 		h.Must(err)
 
 		wantT := reflect.TypeOf(want)
@@ -68,7 +68,7 @@ func TestDeduceConstraint_InvalidInput(t *testing.T) {
 
 	pi := gps.ProjectIdentifier{ProjectRoot: "github.com/sdboyer/deptest"}
 	for _, str := range constraints {
-		_, err := deduceConstraint(str, pi, sm)
+		_, err := sm.DeduceConstraint(str, pi)
 		if err == nil {
 			t.Errorf("expected %s to produce an error", str)
 		}

--- a/cmd/dep/glide_importer.go
+++ b/cmd/dep/glide_importer.go
@@ -206,10 +206,10 @@ func (g *glideImporter) buildProjectConstraint(pkg glidePackage) (pc gps.Project
 	}
 
 	pc.Ident = gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot(pkg.Name), Source: pkg.Repository}
-	pc.Constraint, err = deduceConstraint(pkg.Reference, pc.Ident, g.sm)
-	if err != nil {
-		return
-	}
+	pc.Constraint, err = g.sm.DeduceConstraint(pkg.Reference, pc.Ident)
+    if err != nil {
+        return
+    }
 
 	f := fb.NewConstraintFeedback(pc, fb.DepTypeImported)
 	f.LogFeedback(g.logger)

--- a/cmd/dep/glide_importer.go
+++ b/cmd/dep/glide_importer.go
@@ -206,10 +206,10 @@ func (g *glideImporter) buildProjectConstraint(pkg glidePackage) (pc gps.Project
 	}
 
 	pc.Ident = gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot(pkg.Name), Source: pkg.Repository}
-	pc.Constraint, err = g.sm.DeduceConstraint(pkg.Reference, pc.Ident)
-    if err != nil {
-        return
-    }
+	pc.Constraint, err = g.sm.InferConstraint(pkg.Reference, pc.Ident)
+	if err != nil {
+		return
+	}
 
 	f := fb.NewConstraintFeedback(pc, fb.DepTypeImported)
 	f.LogFeedback(g.logger)

--- a/cmd/dep/godep_importer.go
+++ b/cmd/dep/godep_importer.go
@@ -158,10 +158,10 @@ func (g *godepImporter) convert(pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock, e
 // create a project constraint
 func (g *godepImporter) buildProjectConstraint(pkg godepPackage) (pc gps.ProjectConstraint, err error) {
 	pc.Ident = gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot(pkg.ImportPath)}
-	pc.Constraint, err = deduceConstraint(pkg.Comment, pc.Ident, g.sm)
-	if err != nil {
-		return
-	}
+	pc.Constraint, err = g.sm.DeduceConstraint(pkg.Comment, pc.Ident)
+    if err != nil {
+        return
+    }
 
 	f := fb.NewConstraintFeedback(pc, fb.DepTypeImported)
 	f.LogFeedback(g.logger)

--- a/cmd/dep/godep_importer.go
+++ b/cmd/dep/godep_importer.go
@@ -158,10 +158,10 @@ func (g *godepImporter) convert(pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock, e
 // create a project constraint
 func (g *godepImporter) buildProjectConstraint(pkg godepPackage) (pc gps.ProjectConstraint, err error) {
 	pc.Ident = gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot(pkg.ImportPath)}
-	pc.Constraint, err = g.sm.DeduceConstraint(pkg.Comment, pc.Ident)
-    if err != nil {
-        return
-    }
+	pc.Constraint, err = g.sm.InferConstraint(pkg.Comment, pc.Ident)
+	if err != nil {
+		return
+	}
 
 	f := fb.NewConstraintFeedback(pc, fb.DepTypeImported)
 	f.LogFeedback(g.logger)

--- a/internal/gps/solve_basic_test.go
+++ b/internal/gps/solve_basic_test.go
@@ -5,12 +5,15 @@
 package gps
 
 import (
+	"encoding/hex"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/Masterminds/semver"
 	"github.com/golang/dep/internal/gps/pkgtree"
+	"github.com/pkg/errors"
 )
 
 var regfrom = regexp.MustCompile(`^(\w*) from (\w*) ([0-9\.\*]*)`)
@@ -1492,6 +1495,72 @@ func (sm *depspecSourceManager) allSpecs() []depspec {
 
 func (sm *depspecSourceManager) ignore() map[string]bool {
 	return sm.ig
+}
+
+// DeduceConstraint tries to puzzle out what kind of version is given in a string -
+// semver, a revision, or as a fallback, a plain tag
+func (sm *depspecSourceManager) DeduceConstraint(s string, pi ProjectIdentifier) (Constraint, error) {
+	if s == "" {
+		// Find the default branch
+		versions, err := sm.ListVersions(pi)
+		if err != nil {
+			return nil, errors.Wrapf(err, "list versions for %s(%s)", pi.ProjectRoot, pi.Source) // means repo does not exist
+		}
+
+		SortPairedForUpgrade(versions)
+		for _, v := range versions {
+			if v.Type() == IsBranch {
+				return v.Unpair(), nil
+			}
+		}
+	}
+
+	// always semver if we can
+	c, err := NewSemverConstraintIC(s)
+	if err == nil {
+		return c, nil
+	}
+
+	slen := len(s)
+	if slen == 40 {
+		if _, err = hex.DecodeString(s); err == nil {
+			// Whether or not it's intended to be a SHA1 digest, this is a
+			// valid byte sequence for that, so go with Revision. This
+			// covers git and hg
+			return Revision(s), nil
+		}
+	}
+	// Next, try for bzr, which has a three-component GUID separated by
+	// dashes. There should be two, but the email part could contain
+	// internal dashes
+	if strings.Count(s, "-") >= 2 {
+		// Work from the back to avoid potential confusion from the email
+		i3 := strings.LastIndex(s, "-")
+		// Skip if - is last char, otherwise this would panic on bounds err
+		if slen == i3+1 {
+			return NewVersion(s), nil
+		}
+
+		i2 := strings.LastIndex(s[:i3], "-")
+		if _, err = strconv.ParseUint(s[i2+1:i3], 10, 64); err == nil {
+			// Getting this far means it'd pretty much be nuts if it's not a
+			// bzr rev, so don't bother parsing the email.
+			return Revision(s), nil
+		}
+	}
+
+	// call out to network and get the package's versions
+	versions, err := sm.ListVersions(pi)
+	if err != nil {
+		return nil, errors.Wrapf(err, "list versions for %s(%s)", pi.ProjectRoot, pi.Source) // means repo does not exist
+	}
+
+	for _, version := range versions {
+		if s == version.String() {
+			return version.Unpair(), nil
+		}
+	}
+	return nil, errors.Errorf("%s is not a valid version for the package %s(%s)", s, pi.ProjectRoot, pi.Source)
 }
 
 type depspecBridge struct {

--- a/internal/gps/source_manager.go
+++ b/internal/gps/source_manager.go
@@ -6,17 +6,20 @@ package gps
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/golang/dep/internal/gps/pkgtree"
+	"github.com/pkg/errors"
 	"github.com/sdboyer/constext"
 )
 
@@ -72,6 +75,10 @@ type SourceManager interface {
 	// no longer safe to call methods against it; all method calls will
 	// immediately result in errors.
 	Release()
+
+	// DeduceConstraint tries to puzzle out what kind of version is given in a string -
+	// semver, a revision, or as a fallback, a plain tag
+	DeduceConstraint(s string, pi ProjectIdentifier) (Constraint, error)
 }
 
 // A ProjectAnalyzer is responsible for analyzing a given path for Manifest and
@@ -453,6 +460,72 @@ func (sm *SourceMgr) DeduceProjectRoot(ip string) (ProjectRoot, error) {
 
 	pd, err := sm.deduceCoord.deduceRootPath(context.TODO(), ip)
 	return ProjectRoot(pd.root), err
+}
+
+// DeduceConstraint tries to puzzle out what kind of version is given in a string -
+// semver, a revision, or as a fallback, a plain tag
+func (sm *SourceMgr) DeduceConstraint(s string, pi ProjectIdentifier) (Constraint, error) {
+	if s == "" {
+		// Find the default branch
+		versions, err := sm.ListVersions(pi)
+		if err != nil {
+			return nil, errors.Wrapf(err, "list versions for %s(%s)", pi.ProjectRoot, pi.Source) // means repo does not exist
+		}
+
+		SortPairedForUpgrade(versions)
+		for _, v := range versions {
+			if v.Type() == IsBranch {
+				return v.Unpair(), nil
+			}
+		}
+	}
+
+	// always semver if we can
+	c, err := NewSemverConstraintIC(s)
+	if err == nil {
+		return c, nil
+	}
+
+	slen := len(s)
+	if slen == 40 {
+		if _, err = hex.DecodeString(s); err == nil {
+			// Whether or not it's intended to be a SHA1 digest, this is a
+			// valid byte sequence for that, so go with Revision. This
+			// covers git and hg
+			return Revision(s), nil
+		}
+	}
+	// Next, try for bzr, which has a three-component GUID separated by
+	// dashes. There should be two, but the email part could contain
+	// internal dashes
+	if strings.Count(s, "-") >= 2 {
+		// Work from the back to avoid potential confusion from the email
+		i3 := strings.LastIndex(s, "-")
+		// Skip if - is last char, otherwise this would panic on bounds err
+		if slen == i3+1 {
+			return NewVersion(s), nil
+		}
+
+		i2 := strings.LastIndex(s[:i3], "-")
+		if _, err = strconv.ParseUint(s[i2+1:i3], 10, 64); err == nil {
+			// Getting this far means it'd pretty much be nuts if it's not a
+			// bzr rev, so don't bother parsing the email.
+			return Revision(s), nil
+		}
+	}
+
+	// call out to network and get the package's versions
+	versions, err := sm.ListVersions(pi)
+	if err != nil {
+		return nil, errors.Wrapf(err, "list versions for %s(%s)", pi.ProjectRoot, pi.Source) // means repo does not exist
+	}
+
+	for _, version := range versions {
+		if s == version.String() {
+			return version.Unpair(), nil
+		}
+	}
+	return nil, errors.Errorf("%s is not a valid version for the package %s(%s)", s, pi.ProjectRoot, pi.Source)
 }
 
 type timeCount struct {

--- a/internal/gps/source_manager.go
+++ b/internal/gps/source_manager.go
@@ -76,9 +76,9 @@ type SourceManager interface {
 	// immediately result in errors.
 	Release()
 
-	// DeduceConstraint tries to puzzle out what kind of version is given in a string -
+	// InferConstraint tries to puzzle out what kind of version is given in a string -
 	// semver, a revision, or as a fallback, a plain tag
-	DeduceConstraint(s string, pi ProjectIdentifier) (Constraint, error)
+	InferConstraint(s string, pi ProjectIdentifier) (Constraint, error)
 }
 
 // A ProjectAnalyzer is responsible for analyzing a given path for Manifest and
@@ -462,9 +462,9 @@ func (sm *SourceMgr) DeduceProjectRoot(ip string) (ProjectRoot, error) {
 	return ProjectRoot(pd.root), err
 }
 
-// DeduceConstraint tries to puzzle out what kind of version is given in a string -
+// InferConstraint tries to puzzle out what kind of version is given in a string -
 // semver, a revision, or as a fallback, a plain tag
-func (sm *SourceMgr) DeduceConstraint(s string, pi ProjectIdentifier) (Constraint, error) {
+func (sm *SourceMgr) InferConstraint(s string, pi ProjectIdentifier) (Constraint, error) {
 	if s == "" {
 		// Find the default branch
 		versions, err := sm.ListVersions(pi)


### PR DESCRIPTION
### What does this do / why do we need it?
Moves the function `deduceConstraint` to the SourceManager interface. 

### What should your reviewer look out for in this PR?
I think the `DeduceConstraint` implementation for `depspecSourceManager` could be simpler, since it's a mock implementation? not sure

### Do you need help or clarification on anything?
natm

### Which issue(s) does this PR fix?
https://github.com/golang/dep/issues/654
