### PR TITLE
fs.isDir return error when directory is not found

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -38,6 +38,7 @@ func TestCtx_ProjectImport(t *testing.T) {
 
 	for _, want := range importPaths {
 		fullpath := filepath.Join(depCtx.GOPATH, "src", want)
+		h.TempDir(filepath.Join("src", want))
 		got, err := depCtx.ImportForAbs(fullpath)
 		if err != nil {
 			t.Fatal(err)
@@ -345,6 +346,7 @@ func TestCaseInsentitiveGOPATH(t *testing.T) {
 
 	ip := "github.com/pkg/errors"
 	fullpath := filepath.Join(depCtx.GOPATH, "src", ip)
+	h.TempDir(filepath.Join("src", ip))
 	pr, err := depCtx.ImportForAbs(fullpath)
 	if err != nil {
 		t.Fatal(err)
@@ -366,13 +368,14 @@ func TestDetectProjectGOPATH(t *testing.T) {
 	}
 
 	h.TempDir("go/src/real/path")
-	h.TempDir("go/src/sym")
 
 	// Another directory used as a GOPATH
-	h.TempDir("go-two/src/real/path")
 	h.TempDir("go-two/src/sym")
 
-	h.TempDir("sym") // Directory for symlinks
+	h.TempDir(filepath.Join(".", "sym/symlink")) // Directory for symlinks
+	h.TempDir(filepath.Join("go", "src", "sym", "path"))
+	h.TempDir(filepath.Join("go", "src", " real", "path"))
+	h.TempDir(filepath.Join("go-two", "src", "real", "path"))
 
 	testcases := []struct {
 		name         string
@@ -462,6 +465,10 @@ func TestDetectGOPATH(t *testing.T) {
 		th.Path("go"),
 		th.Path("gotwo"),
 	}}
+
+	th.TempDir(filepath.Join("code", "src", "github.com", "username", "package"))
+	th.TempDir(filepath.Join("go", "src", "github.com", "username", "package"))
+	th.TempDir(filepath.Join("gotwo", "src", "github.com", "username", "package"))
 
 	testcases := []struct {
 		GOPATH string

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -334,9 +334,6 @@ func copySymlink(src, dst string) error {
 func IsDir(name string) (bool, error) {
 	// TODO: lstat?
 	fi, err := os.Stat(name)
-	if os.IsNotExist(err) {
-		return false, nil
-	}
 	if err != nil {
 		return false, err
 	}
@@ -349,8 +346,10 @@ func IsDir(name string) (bool, error) {
 // IsNonEmptyDir determines if the path given is a non-empty directory or not.
 func IsNonEmptyDir(name string) (bool, error) {
 	isDir, err := IsDir(name)
-	if !isDir || err != nil {
+	if err != nil && !os.IsNotExist(err) {
 		return false, err
+	} else if !isDir {
+		return false, nil
 	}
 
 	// Get file descriptor

--- a/project.go
+++ b/project.go
@@ -87,7 +87,7 @@ func (p *Project) MakeParams() gps.SolveParameters {
 func BackupVendor(vpath, suffix string) (string, error) {
 	// Check if there's a non-empty vendor directory
 	vendorExists, err := fs.IsNonEmptyDir(vpath)
-	if err != nil {
+	if err != nil && !os.IsNotExist(err) {
 		return "", err
 	}
 	if vendorExists {

--- a/txn_writer.go
+++ b/txn_writer.go
@@ -235,7 +235,7 @@ func (sw SafeWriter) validate(root string, sm gps.SourceManager) error {
 		return errors.New("root path must be non-empty")
 	}
 	if is, err := fs.IsDir(root); !is {
-		if err != nil {
+		if err != nil && !os.IsNotExist(err) {
 			return err
 		}
 		return errors.Errorf("root path %q does not exist", root)


### PR DESCRIPTION

### What does this do / why do we need it?
As the issue states `fs.isDir` should always return an error and not just false if the directory is not found.

### What should your reviewer look out for in this PR?
Altering of `fs.isDir` returned error. The unit tests have been adjusted accordingly but the integration tests are still having issues.

### Do you need help or clarification on anything?
Yes. It seems the integration tests have a `testcase.json` where expected errors are listed. However since `fs.isDir` now potentially returns large, complex errors from `os.Stat` simple error matching on the strings will not be possible. If the change to the code is what the issue is calling for then I would need some help/clarification on how to handle the new integration test expectancies. 

The test case ion question:
`go/src/github.com/golang/dep/cmd/dep/testdata/init_path_tests/relative_path/testcase.json`

### Which issue(s) does this PR fix?
fixes #642 
