### PR TITLE
Check error returned from deduceConstraint

### DIFF
--- a/cmd/dep/glide_importer.go
+++ b/cmd/dep/glide_importer.go
@@ -207,6 +207,9 @@ func (g *glideImporter) buildProjectConstraint(pkg glidePackage) (pc gps.Project
 
 	pc.Ident = gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot(pkg.Name), Source: pkg.Repository}
 	pc.Constraint, err = deduceConstraint(pkg.Reference, pc.Ident, g.sm)
+	if err != nil {
+		return
+	}
 
 	f := fb.NewConstraintFeedback(pc, fb.DepTypeImported)
 	f.LogFeedback(g.logger)

--- a/cmd/dep/godep_importer.go
+++ b/cmd/dep/godep_importer.go
@@ -159,6 +159,9 @@ func (g *godepImporter) convert(pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock, e
 func (g *godepImporter) buildProjectConstraint(pkg godepPackage) (pc gps.ProjectConstraint, err error) {
 	pc.Ident = gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot(pkg.ImportPath)}
 	pc.Constraint, err = deduceConstraint(pkg.Comment, pc.Ident, g.sm)
+	if err != nil {
+		return
+	}
 
 	f := fb.NewConstraintFeedback(pc, fb.DepTypeImported)
 	f.LogFeedback(g.logger)


### PR DESCRIPTION
Add checks for error returned from deduceConstraint to avoid panic due to
passing nil constraint to feedback.

### What does this do / why do we need it?

Avoids panicking when `deduceConstraint()` fails to deduce a valid constraint.
