### PR TITLE
Remove trailing spaces from generated Gopkg.toml

### DIFF
--- a/cmd/dep/testdata/harness_tests/ensure/empty/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/ensure/empty/case1/final/Gopkg.toml
@@ -6,16 +6,16 @@
 #
 # required = ["github.com/user/thing/cmd/thing"]
 # ignored = ["github.com/user/project/pkgX", "bitbucket.org/user/project/pkgA/pkgY"]
-# 
+#
 # [[constraint]]
 #   name = "github.com/user/project"
 #   version = "1.0.0"
-# 
+#
 # [[constraint]]
 #   name = "github.com/user/project2"
 #   branch = "dev"
 #   source = "github.com/myfork/project2"
-# 
+#
 # [[override]]
 #  name = "github.com/x/y"
 #  version = "2.4.0"

--- a/cmd/dep/testdata/harness_tests/ensure/override/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/ensure/override/case1/final/Gopkg.toml
@@ -6,16 +6,16 @@
 #
 # required = ["github.com/user/thing/cmd/thing"]
 # ignored = ["github.com/user/project/pkgX", "bitbucket.org/user/project/pkgA/pkgY"]
-# 
+#
 # [[constraint]]
 #   name = "github.com/user/project"
 #   version = "1.0.0"
-# 
+#
 # [[constraint]]
 #   name = "github.com/user/project2"
 #   branch = "dev"
 #   source = "github.com/myfork/project2"
-# 
+#
 # [[override]]
 #  name = "github.com/x/y"
 #  version = "2.4.0"

--- a/testdata/txn_writer/expected_manifest.toml
+++ b/testdata/txn_writer/expected_manifest.toml
@@ -6,16 +6,16 @@
 #
 # required = ["github.com/user/thing/cmd/thing"]
 # ignored = ["github.com/user/project/pkgX", "bitbucket.org/user/project/pkgA/pkgY"]
-# 
+#
 # [[constraint]]
 #   name = "github.com/user/project"
 #   version = "1.0.0"
-# 
+#
 # [[constraint]]
 #   name = "github.com/user/project2"
 #   branch = "dev"
 #   source = "github.com/myfork/project2"
-# 
+#
 # [[override]]
 #  name = "github.com/x/y"
 #  version = "2.4.0"

--- a/txn_writer.go
+++ b/txn_writer.go
@@ -31,16 +31,16 @@ var exampleTOML = []byte(`
 #
 # required = ["github.com/user/thing/cmd/thing"]
 # ignored = ["github.com/user/project/pkgX", "bitbucket.org/user/project/pkgA/pkgY"]
-# 
+#
 # [[constraint]]
 #   name = "github.com/user/project"
 #   version = "1.0.0"
-# 
+#
 # [[constraint]]
 #   name = "github.com/user/project2"
 #   branch = "dev"
 #   source = "github.com/myfork/project2"
-# 
+#
 # [[override]]
 #  name = "github.com/x/y"
 #  version = "2.4.0"


### PR DESCRIPTION
Sometimes IDE/editor removes trailing spaces automatically. It causes ridiculous git diff...