### PR TITLE
Fixes #429. Removed Manifest.TestDependencyConstraints() and all usage.

### DIFF
--- a/internal/gps/manifest_test.go
+++ b/internal/gps/manifest_test.go
@@ -15,28 +15,15 @@ func TestPrepManifest(t *testing.T) {
 				Source: "whatever",
 			},
 		},
-		TestDeps: ProjectConstraints{
-			ProjectRoot("baz"): ProjectProperties{},
-			ProjectRoot("qux"): ProjectProperties{
-				Source: "whatever",
-			},
-		},
 	}
 
 	prepped := prepManifest(m)
 	d := prepped.DependencyConstraints()
-	td := prepped.TestDependencyConstraints()
 	if len(d) != 1 {
 		t.Error("prepManifest did not eliminate empty ProjectProperties from deps map")
-	}
-	if len(td) != 1 {
-		t.Error("prepManifest did not eliminate empty ProjectProperties from test deps map")
 	}
 
 	if d[ProjectRoot("bar")].Constraint != any {
 		t.Error("prepManifest did not normalize nil constraint to anyConstraint in deps map")
-	}
-	if td[ProjectRoot("qux")].Constraint != any {
-		t.Error("prepManifest did not normalize nil constraint to anyConstraint in test deps map")
 	}
 }

--- a/internal/gps/rootdata.go
+++ b/internal/gps/rootdata.go
@@ -81,7 +81,7 @@ func (rd rootdata) externalImportList(stdLibFn func(string) bool) []string {
 
 func (rd rootdata) getApplicableConstraints(stdLibFn func(string) bool) []workingConstraint {
 	// Merge the normal and test constraints together
-	pc := rd.rm.DependencyConstraints().merge(rd.rm.TestDependencyConstraints())
+	pc := rd.rm.DependencyConstraints()
 
 	// Ensure that overrides which aren't in the combined pc map already make it
 	// in. Doing so makes input hashes equal in more useful cases.
@@ -139,7 +139,7 @@ func (rd rootdata) getApplicableConstraints(stdLibFn func(string) bool) []workin
 }
 
 func (rd rootdata) combineConstraints() []workingConstraint {
-	return rd.ovr.overrideAll(rd.rm.DependencyConstraints().merge(rd.rm.TestDependencyConstraints()))
+	return rd.ovr.overrideAll(rd.rm.DependencyConstraints())
 }
 
 // needVersionListFor indicates whether we need a version list for a given

--- a/internal/gps/rootdata.go
+++ b/internal/gps/rootdata.go
@@ -80,7 +80,6 @@ func (rd rootdata) externalImportList(stdLibFn func(string) bool) []string {
 }
 
 func (rd rootdata) getApplicableConstraints(stdLibFn func(string) bool) []workingConstraint {
-	// Merge the normal and test constraints together
 	pc := rd.rm.DependencyConstraints()
 
 	// Ensure that overrides which aren't in the combined pc map already make it

--- a/internal/gps/solve_basic_test.go
+++ b/internal/gps/solve_basic_test.go
@@ -893,38 +893,6 @@ var basicFixtures = map[string]basicFixture{
 			"foo ptaggerino oldrev",
 		),
 	},
-	// "includes root package's dev dependencies": {
-	// 	ds: []depspec{
-	// 		mkDepspec("root 1.0.0", "(dev) foo 1.0.0", "(dev) bar 1.0.0"),
-	// 		mkDepspec("foo 1.0.0"),
-	// 		mkDepspec("bar 1.0.0"),
-	// 	},
-	// 	r: mksolution(
-	// 		"foo 1.0.0",
-	// 		"bar 1.0.0",
-	// 	),
-	// },
-	// "includes dev dependency's transitive dependencies": {
-	// 	ds: []depspec{
-	// 		mkDepspec("root 1.0.0", "(dev) foo 1.0.0"),
-	// 		mkDepspec("foo 1.0.0", "bar 1.0.0"),
-	// 		mkDepspec("bar 1.0.0"),
-	// 	},
-	// 	r: mksolution(
-	// 		"foo 1.0.0",
-	// 		"bar 1.0.0",
-	// 	),
-	// },
-	// "ignores transitive dependency's dev dependencies": {
-	// 	ds: []depspec{
-	// 		mkDepspec("root 1.0.0", "(dev) foo 1.0.0"),
-	// 		mkDepspec("foo 1.0.0", "(dev) bar 1.0.0"),
-	// 		mkDepspec("bar 1.0.0"),
-	// 	},
-	// 	r: mksolution(
-	// 		"foo 1.0.0",
-	// 	),
-	// },
 	"no version that matches requirement": {
 		ds: []depspec{
 			mkDepspec("root 0.0.0", "foo ^1.0.0"),

--- a/internal/gps/solve_bimodal_test.go
+++ b/internal/gps/solve_bimodal_test.go
@@ -1087,7 +1087,6 @@ func (f bimodalFixture) solution() map[ProjectIdentifier]LockedProject {
 func (f bimodalFixture) rootmanifest() RootManifest {
 	m := simpleRootManifest{
 		c:   pcSliceToMap(f.ds[0].deps),
-		tc:  pcSliceToMap(f.ds[0].devdeps),
 		ovr: f.ovr,
 		ig:  make(map[string]bool),
 		req: make(map[string]bool),

--- a/manifest.go
+++ b/manifest.go
@@ -316,12 +316,6 @@ func (m *Manifest) DependencyConstraints() gps.ProjectConstraints {
 	return m.Constraints
 }
 
-// TestDependencyConstraints remains unimplemented by returning nil for now.
-func (m *Manifest) TestDependencyConstraints() gps.ProjectConstraints {
-	// TODO decide whether we're going to incorporate this or not
-	return nil
-}
-
 // Overrides returns a list of project-level override constraints.
 func (m *Manifest) Overrides() gps.ProjectConstraints {
 	return m.Ovr


### PR DESCRIPTION
Fixes #429. Removed Manifest.TestDependencyConstraints() and all usage.

As per the issue description, speficying dependency now does not imply
requirement. Therefore, there is no point in differentiating normal
and test dependencies.

Issue also talks about removing pcSliceToMap. This function converts few slices to a map and works for non-test dependencies. So unless I am missing something, I don't think it can be removed.

