### PR TITLE
dep: update calculatePrune to not assume "/" as file separator

### DIFF
--- a/txn_writer.go
+++ b/txn_writer.go
@@ -530,6 +530,7 @@ fail:
 	return failerr
 }
 
+// calculatePrune returns the paths of the packages to be deleted from vendorDir.
 func calculatePrune(vendorDir string, keep []string, logger *log.Logger) ([]string, error) {
 	if logger != nil {
 		logger.Println("Calculating prune. Checking the following packages:")
@@ -547,7 +548,7 @@ func calculatePrune(vendorDir string, keep []string, logger *log.Logger) ([]stri
 			return nil
 		}
 
-		name := strings.TrimPrefix(path, vendorDir+"/")
+		name := strings.TrimPrefix(path, vendorDir+string(filepath.Separator))
 		if logger != nil {
 			logger.Printf("  %s", name)
 		}

--- a/txn_writer_test.go
+++ b/txn_writer_test.go
@@ -577,11 +577,12 @@ func TestCalculatePrune(t *testing.T) {
 
 	vendorDir := "vendor"
 	h.TempDir(vendorDir)
-	h.TempDir(filepath.Join(vendorDir, "github.com", "prune", "package"))
-	h.TempDir(filepath.Join(vendorDir, "github.com", "keep", "package"))
+	h.TempDir(filepath.Join(vendorDir, "github.com/keep/pkg/sub"))
+	h.TempDir(filepath.Join(vendorDir, "github.com/prune/pkg/sub"))
 
 	toKeep := []string{
-		"github.com/keep/package",
+		filepath.FromSlash("github.com/keep/pkg"),
+		filepath.FromSlash("github.com/keep/pkg/sub"),
 	}
 
 	got, err := calculatePrune(h.Path(vendorDir), toKeep, nil)
@@ -591,16 +592,13 @@ func TestCalculatePrune(t *testing.T) {
 
 	sort.Sort(byLen(got))
 
-	if len(got) != 2 {
-		t.Fatalf("expected 2 directories, got %v", len(got))
-	}
-
 	want := []string{
-		h.Path(filepath.Join(vendorDir, "github.com", "prune", "package")),
-		h.Path(filepath.Join(vendorDir, "github.com", "prune")),
+		h.Path(filepath.Join(vendorDir, "github.com/prune/pkg/sub")),
+		h.Path(filepath.Join(vendorDir, "github.com/prune/pkg")),
+		h.Path(filepath.Join(vendorDir, "github.com/prune")),
 	}
 
 	if !reflect.DeepEqual(want, got) {
-		t.Fatalf("expect %s, got %s", want, got)
+		t.Fatalf("calculated prune paths are not as expected.\n(WNT) %s\n(GOT) %s", want, got)
 	}
 }


### PR DESCRIPTION
### What does this do / why do we need it?
As reported in #775 , `dep prune` deletes all directories in `vendor`. After digging in, the culpirt seems to be `calculatePrune` in `txn_writer.go`.

[This line](https://github.com/golang/dep/blob/master/txn_writer.go#L550) assume all paths use `/` as a separator. And therefore, causes [this check](https://github.com/golang/dep/blob/master/txn_writer.go#L557) to be always `true` (on filesystems that don't use `/`) thus adding all directories to the `toDelete` slice.

### What should your reviewer look out for in this PR?
Generic review.

### Which issue(s) does this PR fix?

fixes #775