### PR TITLE
Fixes #623. LockDiff now ignores hash/solvemeta.

### DIFF
--- a/internal/gps/lockdiff.go
+++ b/internal/gps/lockdiff.go
@@ -5,7 +5,6 @@
 package gps
 
 import (
-	"encoding/hex"
 	"fmt"
 	"sort"
 	"strings"
@@ -44,10 +43,9 @@ func (diff *StringDiff) String() string {
 // LockDiff is the set of differences between an existing lock file and an updated lock file.
 // Fields are only populated when there is a difference, otherwise they are empty.
 type LockDiff struct {
-	HashDiff *StringDiff
-	Add      []LockedProjectDiff
-	Remove   []LockedProjectDiff
-	Modify   []LockedProjectDiff
+	Add    []LockedProjectDiff
+	Remove []LockedProjectDiff
+	Modify []LockedProjectDiff
 }
 
 // LockedProjectDiff contains the before and after snapshot of a project reference.
@@ -90,12 +88,6 @@ func DiffLocks(l1 Lock, l2 Lock) *LockDiff {
 	}
 
 	diff := LockDiff{}
-
-	h1 := hex.EncodeToString(l1.InputHash())
-	h2 := hex.EncodeToString(l2.InputHash())
-	if h1 != h2 {
-		diff.HashDiff = &StringDiff{Previous: h1, Current: h2}
-	}
 
 	var i2next int
 	for i1 := 0; i1 < len(p1); i1++ {
@@ -140,7 +132,7 @@ func DiffLocks(l1 Lock, l2 Lock) *LockDiff {
 		diff.Add = append(diff.Add, add)
 	}
 
-	if diff.HashDiff == nil && len(diff.Add) == 0 && len(diff.Remove) == 0 && len(diff.Modify) == 0 {
+	if len(diff.Add) == 0 && len(diff.Remove) == 0 && len(diff.Modify) == 0 {
 		return nil // The locks are the equivalent
 	}
 	return &diff

--- a/testdata/txn_writer/expected_diff_output.txt
+++ b/testdata/txn_writer/expected_diff_output.txt
@@ -1,5 +1,3 @@
-Memo: 595716d270828e763c811ef79c9c41f85b1d1bfbdfe85280036405c03772206c -> 2252a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e
-
 Add:
 [[projects]]
   name = "github.com/sdboyer/deptest"

--- a/txn_writer.go
+++ b/txn_writer.go
@@ -6,7 +6,6 @@ package dep
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -175,10 +174,6 @@ func toRawLockedProjectDiffs(diffs []gps.LockedProjectDiff) rawLockedProjectDiff
 
 func formatLockDiff(diff gps.LockDiff) (string, error) {
 	var buf bytes.Buffer
-
-	if diff.HashDiff != nil {
-		buf.WriteString(fmt.Sprintf("Memo: %s\n\n", diff.HashDiff))
-	}
 
 	writeDiffs := func(diffs []gps.LockedProjectDiff) error {
 		raw := toRawLockedProjectDiffs(diffs)


### PR DESCRIPTION
Fixes #623. LockDiff now uses only project dependencies to identify changes, thus ignoring any changes to the SolveMeta iformation. If required changes in the SolveMeta can still be seen using source diffs. Modified and added tests to check new behaviour.

The solution was suggested by @sdboyer in #623. The code change is simple. I am more looking for comments if you can think of any unintended consequences of not comparing hashes any more.