### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,24 @@
+# init
+/cmd/dep/init*                          @carolynvs
+/cmd/dep/gopath_scanner*                @carolynvs
+/cmd/dep/root_analyzer*                 @carolynvs
+/cmd/dep/*_importer*                    @carolynvs
+/cmd/dep/testdata/glide                 @carolynvs
+/cmd/dep/testdata/godep                 @carolynvs
+/cmd/dep/testdata/harness_tests/init    @carolynvs
+/cmd/dep/testdata/init**                @carolynvs
+/analyzer*                              @carolynvs
+/testdata/analyzer                      @carolynvs
+/internal/feedback                      @carolynvs
+
+# ensure
+/cmd/dep/ensure*                          @ibrasho
+/cmd/dep/testdata/harness_tests/ensure**  @ibrasho
+
+# status
+/cmd/dep/status*                          @darkowlzz
+/cmd/dep/testdata/harness_tests/status**  @darkowlzz
+/cmd/dep/graphviz*                        @darkowlzz
+
+# gps
+/internal/gps   @sdboyer


### PR DESCRIPTION
Flag well-known components with their assigned maintainer. A review will automatically be requested from them, though it isn't required unless we flip a setting in the repo.

https://github.com/blog/2392-introducing-code-owners

NOTE: I purposefully didn't mark files that people have worked on in the past, e.g. me and the lockdiff, just components of which we are explicit maintainers.