### PR TITLE
documentation improvements for new users

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Keep an eye on the [Roadmap](https://github.com/golang/dep/wiki/Roadmap) for a s
 
 ## Filing issues
 
-Please check the existing issues and [FAQ](FAQ.md) to see if your feedback has already been reported.
+Please check the existing issues and [FAQ](docs/FAQ.md) to see if your feedback has already been reported.
 
 When [filing an issue](https://github.com/golang/dep/issues/new), make sure to answer these five questions:
 

--- a/README.md
+++ b/README.md
@@ -41,10 +41,9 @@ To start managing dependencies using dep, run the following from your project ro
 
 ```sh
 $ dep init
-$ dep ensure -update
 ```
 
-`dep init` will do the following:
+This does the following:
 
 1. Look for [existing dependency management files](docs/FAQ.md#what-external-tools-are-supported) to convert
 1. Check if your dependencies use dep
@@ -57,10 +56,13 @@ $ dep ensure -update
 
 ## Usage
 
-There is one main subcommand you will use: `dep ensure`. `ensure` synchronizes
-your dependencies in `vendor/` to make sure they match what's in your `import`s
-and `Gopkg.toml`. `dep ensure` is safe to run early and often. See the help text
-for more detailed usage instructions.
+There is one main subcommand you will use: `dep ensure`. `ensure` first makes
+sure `Gopkg.lock` is consistent with your `import`s and `Gopkg.toml`. If any
+changes are detected, it then populates `vendor/` with exactly what's described
+in `Gopkg.lock`.
+
+`dep ensure` is safe to run early and often. See the help text for more detailed
+usage instructions.
 
 ```sh
 $ dep help ensure
@@ -69,6 +71,8 @@ $ dep help ensure
 ### Installing dependencies
 
 (if your `vendor/` directory isn't [checked in with your code](](docs/FAQ.md#should-i-commit-my-vendor-directory)))
+
+<!-- may change with https://github.com/golang/dep/pull/489 -->
 
 ```sh
 $ dep ensure
@@ -80,8 +84,8 @@ matches the constraints from the manifest. If the dependency is missing from
 
 ### Adding a dependency
 
-1. Add the `import` in your source code file(s).
-1. Download via dep.
+1. `import` the package in your `*.go` source code file(s).
+1. Run the following command to update your `Gopkg.lock` and populate `vendor/` with the new dependency.
 
     ```sh
     $ dep ensure
@@ -156,7 +160,11 @@ Don't run `dep ensure` until you're done. `dep ensure` will reinstall the
 dependency into `vendor/` based on your manifest, as if you were installing from
 scratch.
 
-To test out code that is pushed, see [changing dependencies](#changing-dependencies).
+This solution works for short-term use, but for something long-term, take a look
+at [virtualgo](https://github.com/GetStream/vg).
+
+To test out code that has been pushed as a new version, or to a branch or fork,
+see [changing dependencies](#changing-dependencies).
 
 ## Feedback
 

--- a/README.md
+++ b/README.md
@@ -49,9 +49,13 @@ $ dep ensure -update
 `dep init` will do the following:
 
 1. Look for [existing dependency management files](docs/FAQ.md#what-external-tools-are-supported) to convert
-1. Back up your existing `vendor/` directory to
+1. Check if your dependencies use dep
+1. Identify your dependencies
+1. Back up your existing `vendor/` directory (if you have one) to
 `_vendor-TIMESTAMP/`
+1. Pick the highest compatible version for each dependency
 1. Generate [`Gopkg.toml`](Gopkg.toml.md) ("manifest") and `Gopkg.lock` files
+1. Install the dependencies in `vendor/`
 
 ### Day-to-day workflows
 
@@ -65,6 +69,8 @@ $ dep help ensure
 ```
 
 #### Installing dependencies
+
+(if your `vendor/` directory isn't [checked in with your code](](docs/FAQ.md#should-i-commit-my-vendor-directory)))
 
 ```sh
 $ dep ensure
@@ -85,12 +91,12 @@ matches the constraints from the manifest. If the dependency is missing from
 
 #### Changing dependencies
 
-When you want to do the following for one or more dependencies:
+If you want to:
 
 * Change the allowed `version`/`branch`/`revision`
 * Switch to using a fork
 
-do the following:
+for one or more dependencies, do the following:
 
 1. Modify your `Gopkg.toml`.
 1. Run
@@ -99,6 +105,16 @@ do the following:
     $ dep ensure
     ```
 
+#### Checking the status of dependencies
+
+```sh
+$ dep status
+PROJECT                             CONSTRAINT     VERSION        REVISION  LATEST
+github.com/Masterminds/semver       branch 2.x     branch 2.x     139cc09   c2e7f6c
+github.com/Masterminds/vcs          ^1.11.0        v1.11.1        3084677   3084677
+github.com/armon/go-radix           *              branch master  4239b77   4239b77
+```
+
 #### Updating dependencies
 
 (to the latest version allowed by the manifest)
@@ -106,6 +122,43 @@ do the following:
 ```sh
 $ dep ensure -update
 ```
+
+#### Removing dependencies
+
+1. Remove the `import`s and all usage from your code.
+1. Run
+
+    ```sh
+    $ dep ensure
+    ```
+
+1. Remove from `Gopkg.toml`, if it was in there.
+
+#### Testing changes to a dependency
+
+Making changes in your `vendor/` directory directly is not recommended, as dep
+will overwrite any changes. Instead:
+
+1. Delete the dependency from the `vendor/` directory.
+
+    ```sh
+    rm -rf vendor/<dependency>
+    ```
+
+1. Add that dependency to your `GOPATH`, if it isn't already.
+
+    ```sh
+    $ go get <dependency>
+    ```
+
+1. Modify the dependency in `$GOPATH/src/<dependency>`.
+1. Test, build, etc.
+
+Don't run `dep ensure` until you're done. `dep ensure` will reinstall the
+dependency into `vendor/` based on your manifest, as if you were installing from
+scratch.
+
+To test out code that is pushed, see [changing dependencies](#changing-dependencies).
 
 ## Feedback
 

--- a/README.md
+++ b/README.md
@@ -51,23 +51,60 @@ $ dep ensure -update
 1. Look for [existing dependency management files](docs/FAQ.md#what-external-tools-are-supported) to convert
 1. Back up your existing `vendor/` directory to
 `_vendor-TIMESTAMP/`
-1. Generate [`Gopkg.toml`](Gopkg.toml.md) and `Gopkg.lock` files
+1. Generate [`Gopkg.toml`](Gopkg.toml.md) ("manifest") and `Gopkg.lock` files
 
-### Day-to-day workflow
+### Day-to-day workflows
 
-When you or a collaborator add/remove/change dependencies by modifying
-your `import`s or `Gopkg.toml`, run
+There is one main subcommand you will use: `dep ensure`. `ensure` synchronizes
+your dependencies in `vendor/` to make sure they match what's in your `import`s
+and `Gopkg.toml`. `dep ensure` is safe to run early and often. See the help text
+for more detailed usage instructions.
+
+```sh
+$ dep help ensure
+```
+
+#### Installing dependencies
 
 ```sh
 $ dep ensure
 ```
 
-This will synchronize your dependencies in `vendor/` to make sure they match
-what's in your `import`s and `Gopkg.toml`. `dep ensure` is safe to run early and
-often. See the help text for more detailed usage instructions.
+If a dependency already exists in your `vendor/` folder, dep will ensure it
+matches the constraints from the manifest. If the dependency is missing from
+`vendor/`, the latest version allowed by your manifest will be installed.
+
+#### Adding a dependency
+
+1. Add the `import` in your source code file(s).
+1. Download via dep.
+
+    ```sh
+    $ dep ensure
+    ```
+
+#### Changing dependencies
+
+When you want to do the following for one or more dependencies:
+
+* Change the allowed `version`/`branch`/`revision`
+* Switch to using a fork
+
+do the following:
+
+1. Modify your `Gopkg.toml`.
+1. Run
+
+    ```sh
+    $ dep ensure
+    ```
+
+#### Updating dependencies
+
+(to the latest version allowed by the manifest)
 
 ```sh
-$ dep help ensure
+$ dep ensure -update
 ```
 
 ## Feedback

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ That said, keep in mind the following:
   - [User Stories](https://docs.google.com/document/d/1wT8e8wBHMrSRHY4UF_60GCgyWGqvYye4THvaDARPySs/edit)
   - [Features](https://docs.google.com/document/d/1JNP6DgSK-c6KqveIhQk-n_HAw3hsZkL-okoleM43NgA/edit)
   - [Design Space](https://docs.google.com/document/d/1TpQlQYovCoX9FkpgsoxzdvZplghudHAiQOame30A-v8/edit)
-- [Frequently Asked Questions](FAQ.md)
+- [Frequently Asked Questions](docs/FAQ.md)
 
 ## Usage
 
@@ -58,7 +58,7 @@ Feedback is greatly appreciated.
 At this stage, the maintainers are most interested in feedback centered on the user experience (UX) of the tool.
 Do you have workflows that the tool supports well, or doesn't support at all?
 Do any of the commands have surprising effects, output, or results?
-Please check the existing issues and [FAQ](FAQ.md) to see if your feedback has already been reported.
+Please check the existing issues and [FAQ](docs/FAQ.md) to see if your feedback has already been reported.
 If not, please file an issue, describing what you did or wanted to do, what you expected to happen, and what actually happened.
 
 ## Contributing
@@ -68,4 +68,3 @@ The maintainers actively manage the issues list, and try to highlight issues sui
 The project follows the typical GitHub pull request model.
 See [CONTRIBUTING.md](CONTRIBUTING.md) for more details.
 Before starting any work, please either comment on an existing issue, or file a new one.
-

--- a/README.md
+++ b/README.md
@@ -31,20 +31,42 @@ That said, keep in mind the following:
 
 ## Usage
 
+### Initial setup
+
 Get the tool via
 
 ```sh
 $ go get -u github.com/golang/dep/cmd/dep
 ```
 
-Typical usage - either on a new project or converting an existing one - is
+To set up Dep on a project, run the following from your project root directory:
 
 ```sh
 $ dep init
 $ dep ensure -update
 ```
 
-If your project was already using a `vendor/` directory, it was backed up to `_vendor-TIMESTAMP/`.
+`dep init` will do the following:
+
+1. Look for [existing dependency management
+files](docs/FAQ.md#what-external-tools-are-supported) to convert
+1. Back up your existing `vendor/` directory to
+`_vendor-TIMESTAMP/`
+1. Generate [`Gopkg.toml`](Gopkg.toml.md) and `Gopkg.lock` files
+
+### Day-to-day workflow
+
+When you or a collaborator add/remove/change dependencies, run
+
+```sh
+$ dep ensure
+```
+
+This will synchronize your dependencies in `vendor/` to make sure they match
+what's in your `import`s and `Gopkg.toml`. `dep ensure` is safe to run early and
+often.
+
+#### Updating a specific dependency
 
 To update a dependency to a new version, you might run
 
@@ -56,6 +78,7 @@ See the help text for more detailed usage instructions.
 
 ```sh
 $ dep help ensure
+$ dep ensure -examples
 ```
 
 ## Feedback

--- a/README.md
+++ b/README.md
@@ -37,12 +37,14 @@ Get the tool via
 $ go get -u github.com/golang/dep/cmd/dep
 ```
 
-Typical usage on a new repo might be
+Typical usage - either on a new project or converting an existing one - is
 
 ```sh
 $ dep init
 $ dep ensure -update
 ```
+
+If your project was already using a `vendor/` directory, it was backed up to `_vendor-TIMESTAMP/`.
 
 To update a dependency to a new version, you might run
 
@@ -51,6 +53,10 @@ $ dep ensure github.com/pkg/errors@^0.8.0
 ```
 
 See the help text for more detailed usage instructions.
+
+```sh
+$ dep help ensure
+```
 
 ## Feedback
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Get the tool via
 $ go get -u github.com/golang/dep/cmd/dep
 ```
 
-To set up Dep on a project, run the following from your project root directory:
+To start managing dependencies using dep, run the following from your project root directory:
 
 ```sh
 $ dep init
@@ -48,8 +48,7 @@ $ dep ensure -update
 
 `dep init` will do the following:
 
-1. Look for [existing dependency management
-files](docs/FAQ.md#what-external-tools-are-supported) to convert
+1. Look for [existing dependency management files](docs/FAQ.md#what-external-tools-are-supported) to convert
 1. Back up your existing `vendor/` directory to
 `_vendor-TIMESTAMP/`
 1. Generate [`Gopkg.toml`](Gopkg.toml.md) and `Gopkg.lock` files

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ files](docs/FAQ.md#what-external-tools-are-supported) to convert
 
 ### Day-to-day workflow
 
-When you or a collaborator add/remove/change dependencies, run
+When you or a collaborator add/remove/change dependencies by modifying
+your `import`s or `Gopkg.toml`, run
 
 ```sh
 $ dep ensure
@@ -64,21 +65,10 @@ $ dep ensure
 
 This will synchronize your dependencies in `vendor/` to make sure they match
 what's in your `import`s and `Gopkg.toml`. `dep ensure` is safe to run early and
-often.
-
-#### Updating a specific dependency
-
-To update a dependency to a new version, you might run
-
-```sh
-$ dep ensure github.com/pkg/errors@^0.8.0
-```
-
-See the help text for more detailed usage instructions.
+often. See the help text for more detailed usage instructions.
 
 ```sh
 $ dep help ensure
-$ dep ensure -examples
 ```
 
 ## Feedback

--- a/README.md
+++ b/README.md
@@ -29,9 +29,7 @@ That said, keep in mind the following:
   - [Design Space](https://docs.google.com/document/d/1TpQlQYovCoX9FkpgsoxzdvZplghudHAiQOame30A-v8/edit)
 - [Frequently Asked Questions](docs/FAQ.md)
 
-## Usage
-
-### Initial setup
+## Setup
 
 Get the tool via
 
@@ -57,7 +55,7 @@ $ dep ensure -update
 1. Generate [`Gopkg.toml`](Gopkg.toml.md) ("manifest") and `Gopkg.lock` files
 1. Install the dependencies in `vendor/`
 
-### Day-to-day workflows
+## Usage
 
 There is one main subcommand you will use: `dep ensure`. `ensure` synchronizes
 your dependencies in `vendor/` to make sure they match what's in your `import`s
@@ -68,7 +66,7 @@ for more detailed usage instructions.
 $ dep help ensure
 ```
 
-#### Installing dependencies
+### Installing dependencies
 
 (if your `vendor/` directory isn't [checked in with your code](](docs/FAQ.md#should-i-commit-my-vendor-directory)))
 
@@ -80,7 +78,7 @@ If a dependency already exists in your `vendor/` folder, dep will ensure it
 matches the constraints from the manifest. If the dependency is missing from
 `vendor/`, the latest version allowed by your manifest will be installed.
 
-#### Adding a dependency
+### Adding a dependency
 
 1. Add the `import` in your source code file(s).
 1. Download via dep.
@@ -89,7 +87,7 @@ matches the constraints from the manifest. If the dependency is missing from
     $ dep ensure
     ```
 
-#### Changing dependencies
+### Changing dependencies
 
 If you want to:
 
@@ -105,7 +103,7 @@ for one or more dependencies, do the following:
     $ dep ensure
     ```
 
-#### Checking the status of dependencies
+### Checking the status of dependencies
 
 ```sh
 $ dep status
@@ -115,7 +113,7 @@ github.com/Masterminds/vcs          ^1.11.0        v1.11.1        3084677   3084
 github.com/armon/go-radix           *              branch master  4239b77   4239b77
 ```
 
-#### Updating dependencies
+### Updating dependencies
 
 (to the latest version allowed by the manifest)
 
@@ -123,7 +121,7 @@ github.com/armon/go-radix           *              branch master  4239b77   4239
 $ dep ensure -update
 ```
 
-#### Removing dependencies
+### Removing dependencies
 
 1. Remove the `import`s and all usage from your code.
 1. Run
@@ -134,7 +132,7 @@ $ dep ensure -update
 
 1. Remove from `Gopkg.toml`, if it was in there.
 
-#### Testing changes to a dependency
+### Testing changes to a dependency
 
 Making changes in your `vendor/` directory directly is not recommended, as dep
 will overwrite any changes. Instead:

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -82,7 +82,7 @@ Here are some suggestions for when you could use `dep` or `go get`:
 * Use `required` to explicitly add a dependency that is not imported directly or transitively, for example a development package used for code generation.
 * Use `ignored` to ignore a package and any of that package's unique dependencies.
 
-Refer [Gopkg.toml](https://github.com/golang/dep/blob/master/docs/Gopkg.toml.md)
+Refer to the [Gopkg.toml documentation](Gopkg.toml.md)
 for detailed definitions of the above terms.
 
 ## How do I constrain a transitive dependency's version?

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -13,7 +13,6 @@ Summarize the question and quote the reply, linking back to the original comment
 
 ## Configuration
 * [What is the difference between Gopkg.toml (the "manifest") and Gopkg.lock (the "lock")?](#what-is-the-difference-between-gopkgtoml-the-manifest-and-gopkglock-the-lock)
-* [When should I use `constraint`, `override` `required`, or `ignored` in the Gopkg.toml?](#when-should-i-use-constraint-override-required-or-ignored-in-gopkgtoml)
 * [How do I constrain a transitive dependency's version?](#how-do-i-constrain-a-transitive-dependencys-version)
 * [Can I put the manifest and lock in the vendor directory?](#can-i-put-the-manifest-and-lock-in-the-vendor-directory)
 * [How do I get `dep` to authenticate to a `git` repo?](#how-do-i-get-dep-to-authenticate-to-a-git-repo)
@@ -72,16 +71,6 @@ Here are some suggestions for when you could use `dep` or `go get`:
 >
 > This flexibility is important because it allows us to provide easy commands (e.g. `dep ensure -update`) that can manage an update process for you, within the constraints you specify, AND because it allows your project, when imported by someone else, to collaboratively specify the constraints for your own dependencies.
 -[@sdboyer in #281](https://github.com/golang/dep/issues/281#issuecomment-284118314)
-
-### When should I use `constraint`, `override`, `required`, or `ignored` in `Gopkg.toml`?
-
-* Use `constraint` to constrain a [direct dependency](#what-is-a-direct-or-transitive-dependency) to a specific branch, version range, revision, or specify an alternate source such as a fork.
-* Use `override` to constrain a [transitive dependency](#what-is-a-direct-or-transitive-dependency). See [How do I constrain a transitive dependency's version?](#how-do-i-constrain-a-transitive-dependencys-version) for more details on how overrides differ from constraints. Overrides should be used cautiously, sparingly, and temporarily.
-* Use `required` to explicitly add a dependency that is not imported directly or transitively, for example a development package used for code generation.
-* Use `ignored` to ignore a package and any of that package's unique dependencies.
-
-Refer to the [Gopkg.toml documentation](Gopkg.toml.md)
-for detailed definitions of the above terms.
 
 ## How do I constrain a transitive dependency's version?
 First, if you're wondering about this because you're trying to keep the version

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -25,7 +25,6 @@ Summarize the question and quote the reply, linking back to the original comment
 * [Why did `dep` use a different revision for package X instead of the revision in the lock file?](#why-did-dep-use-a-different-revision-for-package-x-instead-of-the-revision-in-the-lock-file)
 * [Why is `dep` slow?](#why-is-dep-slow)
 * [How does `dep` handle symbolic links?](#how-does-dep-handle-symbolic-links)
-* [`dep` deleted my files in the vendor directory!](#dep-deleted-my-files-in-the-vendor-directory)
 
 ## Best Practices
 * [Should I commit my vendor directory?](#should-i-commit-my-vendor-directory)
@@ -291,13 +290,6 @@ When `dep` is invoked with a project root that is a symlink, it will be resolved
 
 This is the only symbolic link support that `dep` really intends to provide. In keeping with the general practices of the `go` tool, `dep` tends to either ignore symlinks (when walking) or copy the symlink itself, depending on the filesystem operation being performed.
 
-## `dep` deleted my files in the vendor directory!
-If you just ran `dep init`, there should be a copy of your original vendor directory named `_vendor-TIMESTAMP` in your project root. The other commands do not make a backup before modifying the vendor directory.
-
-> dep assumes complete control of vendor/, and may indeed blow things away if it feels like it.
--[@peterbourgon in #206](https://github.com/golang/dep/issues/206#issuecomment-277139419)
-
-
 ## Best Practices
 ### Should I commit my vendor directory?
 
@@ -318,7 +310,7 @@ It's up to you:
 >  I would recommend against ever working in your vendor directory since dep will overwrite any changes. It’s too easy to lose work that way.
 -[@carolynvs in #706](https://github.com/golang/dep/issues/706#issuecomment-305807261)
 
-If you have a fork, add a `[[constraint]]` entry for the project in `Gopkg.toml` and set `source` to the fork source. This will ensure that `dep` will fetch the project from the fork instead of the original source. 
+If you have a fork, add a `[[constraint]]` entry for the project in `Gopkg.toml` and set `source` to the fork source. This will ensure that `dep` will fetch the project from the fork instead of the original source.
 Otherwise, if you want to test changes locally, you can delete the package from `vendor/` and make changes directly in `GOPATH/src/*package*` so that your changes are picked up by the go tool chain.
 
 ## How do I roll releases that `dep` will be able to use?

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -28,7 +28,6 @@ Summarize the question and quote the reply, linking back to the original comment
 
 ## Best Practices
 * [Should I commit my vendor directory?](#should-i-commit-my-vendor-directory)
-* [How can I test changes to a dependency?](#how-can-i-test-changes-to-a-dependency)
 * [How do I roll releases that `dep` will be able to use?](#how-do-i-roll-releases-that-dep-will-be-able-to-use)
 * [What semver version should I use?](#what-semver-version-should-i-use)
 * [Is it OK to make backwards-incompatible changes now?](#is-it-ok-to-make-backwards-incompatible-changes-now)
@@ -304,14 +303,6 @@ It's up to you:
 
 - your repo will be bigger, potentially a lot bigger
 - PR diffs are more annoying
-
-## How can I test changes to a dependency?
-
->  I would recommend against ever working in your vendor directory since dep will overwrite any changes. It’s too easy to lose work that way.
--[@carolynvs in #706](https://github.com/golang/dep/issues/706#issuecomment-305807261)
-
-If you have a fork, add a `[[constraint]]` entry for the project in `Gopkg.toml` and set `source` to the fork source. This will ensure that `dep` will fetch the project from the fork instead of the original source.
-Otherwise, if you want to test changes locally, you can delete the package from `vendor/` and make changes directly in `GOPATH/src/*package*` so that your changes are picked up by the go tool chain.
 
 ## How do I roll releases that `dep` will be able to use?
 

--- a/docs/Gopkg.toml.md
+++ b/docs/Gopkg.toml.md
@@ -13,7 +13,7 @@ ignored = ["github.com/user/project/badpkg"]
 ```
 
 ## `metadata`
-`metadata` can exist at the root as well as under `constraint` and `override` declarations. 
+`metadata` can exist at the root as well as under `constraint` and `override` declarations.
 
 `metadata` declarations are ignored by dep and are meant for usage by other independent systems.
 
@@ -26,8 +26,8 @@ system2-data = "value that is used by another system"
 ```
 
 ## `constraint`
-A `constraint` provides rules for how a [direct dependency]((https://github.com/golang/dep/blob/master/FAQ.md#what-is-a-direct-or-transitive-dependency)) may be incorporated into the 
-dependency graph. 
+A `constraint` provides rules for how a [direct dependency](FAQ.md#what-is-a-direct-or-transitive-dependency) may be incorporated into the
+dependency graph.
 They are respected by dep whether coming from the Gopkg.toml of the current project or a dependency.
 ```toml
 [[constraint]]
@@ -47,12 +47,12 @@ They are respected by dep whether coming from the Gopkg.toml of the current proj
   key1 = "value that convey data to other systems"
   system1-data = "value that is used by a system"
   system2-data = "value that is used by another system"
-  ```
+```
 
 ## `override`
 An `override` has the same structure as a `constraint` declaration, but supersede all `constraint` declarations from all projects. Only `override` declarations from the current project's are applied.
 
- [When should I use constraint, override, required, or ignored in Gopkg.toml?](https://github.com/golang/dep/blob/master/FAQ.md#when-should-i-use-constraint-override-required-or-ignored-in-gopkgtoml)
+[When should I use constraint, override, required, or ignored in Gopkg.toml?](FAQ.md#when-should-i-use-constraint-override-required-or-ignored-in-gopkgtoml)
 ```toml
 [[override]]
   # Required: the root import path of the project being constrained.
@@ -90,13 +90,13 @@ operator pins the left-most non-zero digit in the version. For example:
 
 To pin a version of direct dependency in manifest, prefix the version with `=`.
 For example:
-```
+```toml
 [[constraint]]
   name = "github.com/pkg/errors"
   version = "=0.8.0"
 ```
 
-[Why is dep ignoring a version constraint in the manifest?](https://github.com/golang/dep/blob/master/FAQ.md#why-is-dep-ignoring-a-version-constraint-in-the-manifest)
+[Why is dep ignoring a version constraint in the manifest?](FAQ.md#why-is-dep-ignoring-a-version-constraint-in-the-manifest)
 
 # Example
 

--- a/docs/Gopkg.toml.md
+++ b/docs/Gopkg.toml.md
@@ -1,16 +1,27 @@
 # Gopkg.toml
 
 ## `required`
-`required` lists a set of packages (not projects) that must be included in Gopkg.lock. This list is merged with the set of packages imported by the current project. Use it when your project needs a package it doesn't explicitly import - including "main" packages.
- ```toml
+`required` lists a set of packages (not projects) that must be included in
+Gopkg.lock. This list is merged with the set of packages imported by the current
+project.
+```toml
 required = ["github.com/user/thing/cmd/thing"]
 ```
+
+**Use this for:** linters, generators, and other development tools that
+
+* Are needed by your project
+* Aren't `import`ed by your project, [directly or transitively](FAQ.md#what-is-a-direct-or-transitive-dependency)
+* You don't want put in your `GOPATH`, and/or you want to lock the version
 
 ## `ignored`
 `ignored` lists a set of packages (not projects) that are ignored when dep statically analyzes source code. Ignored packages can be in this project, or in a dependency.
 ```toml
 ignored = ["github.com/user/project/badpkg"]
 ```
+
+**Use this for:** preventing a package and any of that package's unique
+dependencies from being installed.
 
 ## `metadata`
 `metadata` can exist at the root as well as under `constraint` and `override` declarations.
@@ -49,10 +60,13 @@ They are respected by dep whether coming from the Gopkg.toml of the current proj
   system2-data = "value that is used by another system"
 ```
 
+**Use this for:** having a [direct dependency](FAQ.md#what-is-a-direct-or-transitive-dependency)
+use a specific branch, version range, revision, or alternate source (such as a
+fork).
+
 ## `override`
 An `override` has the same structure as a `constraint` declaration, but supersede all `constraint` declarations from all projects. Only `override` declarations from the current project's are applied.
 
-[When should I use constraint, override, required, or ignored in Gopkg.toml?](FAQ.md#when-should-i-use-constraint-override-required-or-ignored-in-gopkgtoml)
 ```toml
 [[override]]
   # Required: the root import path of the project being constrained.
@@ -70,6 +84,12 @@ An `override` has the same structure as a `constraint` declaration, but supersed
   system1-data = "value that is used by a system"
   system2-data = "value that is used by another system"
 ```
+
+**Use this for:** all the same things as a [`constraint`](#constraint), but for
+[transitive dependencies](FAQ.md#what-is-a-direct-or-transitive-dependency).
+See [How do I constrain a transitive dependency's version?](FAQ.md#how-do-i-constrain-a-transitive-dependencys-version)
+for more details on how overrides differ from `constraint`s. _Overrides should
+be used cautiously, sparingly, and temporarily._
 
 ## `version`
 


### PR DESCRIPTION
Hello from Gophercon! I'm a new Dep user/contributor, so decided to work on the first-run experience in terms of documentation.

### What does this do / why do we need it?

See the commit messages for details (I tried to keep each one small/discrete), but the high-level overview is:

* Moved the FAQ under the `docs/` folder, to have one less file at the top level
    * This could probably be done with other files, but I didn't want to get too carried away.
* Split and expand the Usage information into initial setup and day-to-day interactions with Dep
* Don't encourage adding/changing of dependencies through the CLI directly
* Minor formatting fixes

### What should your reviewer look out for in this PR?

Whether the updated instructions are still recommended/accurate.

### Do you need help or clarification on anything?

I don't _think_ so, but I don't know what I don't know.

### Which issue(s) does this PR fix?

None.
