### PR TITLE
Better error reporting from dep ensure when packages have errors

### DIFF
--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -304,7 +304,8 @@ func getProjectConstraint(arg string, sm gps.SourceManager) (gps.ProjectConstrai
 }
 
 func checkErrors(m map[string]pkgtree.PackageOrErr) error {
-	buildErrors, noGoErrors := []string{}, []string{}
+	var buildErrors, noGoErrors []string
+
 	for importPath, poe := range m {
 		if poe.Err != nil {
 			switch poe.Err.(type) {

--- a/cmd/dep/ensure_test.go
+++ b/cmd/dep/ensure_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"errors"
+	"go/build"
+	"testing"
+
+	"github.com/golang/dep/internal/gps/pkgtree"
+)
+
+func TestCheckErrors(t *testing.T) {
+	tt := []struct {
+		name        string
+		hasErrs     bool
+		pkgOrErrMap map[string]pkgtree.PackageOrErr
+	}{
+		{
+			name:    "noErrors",
+			hasErrs: false,
+			pkgOrErrMap: map[string]pkgtree.PackageOrErr{
+				"mypkg": {
+					P: pkgtree.Package{},
+				},
+			},
+		},
+		{
+			name:    "hasErrors",
+			hasErrs: true,
+			pkgOrErrMap: map[string]pkgtree.PackageOrErr{
+				"github.com/me/pkg": {
+					Err: &build.NoGoError{},
+				},
+				"github.com/someone/pkg": {
+					Err: errors.New("code is busted"),
+				},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			if hasErrs := checkErrors(tc.pkgOrErrMap) != nil; hasErrs != tc.hasErrs {
+				t.Fail()
+			}
+		})
+	}
+}

--- a/cmd/dep/testdata/harness_tests/ensure/pkg-errors/case1/testcase.json
+++ b/cmd/dep/testdata/harness_tests/ensure/pkg-errors/case1/testcase.json
@@ -3,6 +3,6 @@
     ["init", "-no-examples", "-skip-tools"],
     ["ensure", "-update"]
   ],
-  "error-expected": "all dirs lacked any go code",
+  "error-expected": "Found 1 errors:\n\ngithub.com/golang/notexist: no go code",
   "vendor-final": []
 }


### PR DESCRIPTION
### What does this do / why do we need it?

Running dep ensure would generate unhelpful output when directories had code with errors or no go code. This prints the import path of the package with either "no go code" or the build error message. This gives us output like:

```
Found 3 errors:

λ dep ensure
Found 97 errors:

/Users/grepory/go/src/github.com/golang/dep/internal/gps/_testdata/src/bad/bad.go:6:43: expected 'package', found 'EOF'
import path github.com/golang/dep/internal/gps/_testdata/src/relimport/dotdotslash had a local import: "../github.com/golang/dep/internal/gps"
import path github.com/golang/dep/internal/gps/_testdata/src/relimport/dotslash had a local import: "./simple"
import path github.com/golang/dep/internal/gps/_testdata/src/relimport/dotdot had a local import: ".."
github.com/golang/dep/cmd/dep/testdata/harness_tests/init/glide/case2: no go code
github.com/golang/dep/internal/gps/_testdata/src/github.com: no go code
...
```

### What should your reviewer look out for in this PR?

The easiest thing to do to sort the errors was to use append and consolidate our error types into a single array (`buildErrors`) preferring actual build errors to `no go code`. I couldn't think of a better way to do this.

### Do you need help or clarification on anything?

Should running dep ensure here generate 97 errors? 😿 

### Which issue(s) does this PR fix?

fixes #814 
