### PR TITLE
fix(gps): support source urls that point directly to go.googlesource.com

### DIFF
--- a/internal/gps/deduce.go
+++ b/internal/gps/deduce.go
@@ -72,6 +72,7 @@ var (
 	//gcRegex      = regexp.MustCompile(`^(?P<root>code\.google\.com/[pr]/(?P<project>[a-z0-9\-]+)(\.(?P<subrepo>[a-z0-9\-]+))?)(/[A-Za-z0-9_.\-]+)*$`)
 	jazzRegex         = regexp.MustCompile(`^(?P<root>hub\.jazz\.net(/git/[a-z0-9]+/[A-Za-z0-9_.\-]+))((?:/[A-Za-z0-9_.\-]+)*)$`)
 	apacheRegex       = regexp.MustCompile(`^(?P<root>git\.apache\.org(/[a-z0-9_.\-]+\.git))((?:/[A-Za-z0-9_.\-]+)*)$`)
+	goSourceRegex     = regexp.MustCompile(`^(?P<root>go\.googlesource\.com(/[A-Za-z0-9-._]+))((?:/[A-Za-z0-9_.\-]+)*)$`)
 	vcsExtensionRegex = regexp.MustCompile(`^(?P<root>([a-z0-9.\-]+\.)+[a-z0-9.\-]+(:[0-9]+)?/[A-Za-z0-9_.\-/~]*?\.(?P<vcs>bzr|git|hg|svn))((?:/[A-Za-z0-9_.\-]+)*)$`)
 )
 
@@ -91,6 +92,7 @@ func pathDeducerTrie() *deducerTrie {
 	dxt.Insert("git.launchpad.net/", launchpadGitDeducer{regexp: glpRegex})
 	dxt.Insert("hub.jazz.net/", jazzDeducer{regexp: jazzRegex})
 	dxt.Insert("git.apache.org/", apacheDeducer{regexp: apacheRegex})
+	dxt.Insert("go.googlesource.com/", goSourceDeducer{regexp: goSourceRegex})
 
 	return dxt
 }
@@ -461,6 +463,39 @@ func (m apacheDeducer) deduceSource(path string, u *url.URL) (maybeSource, error
 	}
 
 	return mb, nil
+}
+
+type goSourceDeducer struct {
+	regexp *regexp.Regexp
+}
+
+func (m goSourceDeducer) deduceRoot(path string) (string, error) {
+	v := m.regexp.FindStringSubmatch(path)
+	if v == nil {
+		return "", fmt.Errorf("%s is not a valid path for a source on go.googlesource.com", path)
+	}
+
+	return "go.googlesource.com" + v[2], nil
+}
+
+func (m goSourceDeducer) deduceSource(path string, u *url.URL) (maybeSource, error) {
+	v := m.regexp.FindStringSubmatch(path)
+	if v == nil {
+		return nil, fmt.Errorf("%s is not a valid path for a source on go.googlesource.com", path)
+	}
+
+	u.Host = "go.googlesource.com"
+	u.Path = v[2]
+
+	switch u.Scheme {
+	case "":
+		u.Scheme = "https"
+		fallthrough
+	case "https":
+		return maybeGitSource{url: u}, nil
+	default:
+		return nil, fmt.Errorf("go.googlesource.com only supports https, %s is not allowed", u.String())
+	}
 }
 
 type vcsExtensionDeducer struct {

--- a/internal/gps/deduce.go
+++ b/internal/gps/deduce.go
@@ -72,7 +72,7 @@ var (
 	//gcRegex      = regexp.MustCompile(`^(?P<root>code\.google\.com/[pr]/(?P<project>[a-z0-9\-]+)(\.(?P<subrepo>[a-z0-9\-]+))?)(/[A-Za-z0-9_.\-]+)*$`)
 	jazzRegex         = regexp.MustCompile(`^(?P<root>hub\.jazz\.net(/git/[a-z0-9]+/[A-Za-z0-9_.\-]+))((?:/[A-Za-z0-9_.\-]+)*)$`)
 	apacheRegex       = regexp.MustCompile(`^(?P<root>git\.apache\.org(/[a-z0-9_.\-]+\.git))((?:/[A-Za-z0-9_.\-]+)*)$`)
-	goSourceRegex     = regexp.MustCompile(`^(?P<root>go\.googlesource\.com(/[A-Za-z0-9-._]+))((?:/[A-Za-z0-9_.\-]+)*)$`)
+	googlesourceRegex = regexp.MustCompile(`^(?P<root>go\.googlesource\.com(/[A-Za-z0-9-._]+))((?:/[A-Za-z0-9_.\-]+)*)$`)
 	vcsExtensionRegex = regexp.MustCompile(`^(?P<root>([a-z0-9.\-]+\.)+[a-z0-9.\-]+(:[0-9]+)?/[A-Za-z0-9_.\-/~]*?\.(?P<vcs>bzr|git|hg|svn))((?:/[A-Za-z0-9_.\-]+)*)$`)
 )
 
@@ -92,7 +92,7 @@ func pathDeducerTrie() *deducerTrie {
 	dxt.Insert("git.launchpad.net/", launchpadGitDeducer{regexp: glpRegex})
 	dxt.Insert("hub.jazz.net/", jazzDeducer{regexp: jazzRegex})
 	dxt.Insert("git.apache.org/", apacheDeducer{regexp: apacheRegex})
-	dxt.Insert("go.googlesource.com/", goSourceDeducer{regexp: goSourceRegex})
+	dxt.Insert("go.googlesource.com/", googlesourceDeducer{regexp: googlesourceRegex})
 
 	return dxt
 }
@@ -465,11 +465,11 @@ func (m apacheDeducer) deduceSource(path string, u *url.URL) (maybeSource, error
 	return mb, nil
 }
 
-type goSourceDeducer struct {
+type googlesourceDeducer struct {
 	regexp *regexp.Regexp
 }
 
-func (m goSourceDeducer) deduceRoot(path string) (string, error) {
+func (m googlesourceDeducer) deduceRoot(path string) (string, error) {
 	v := m.regexp.FindStringSubmatch(path)
 	if v == nil {
 		return "", fmt.Errorf("%s is not a valid path for a source on go.googlesource.com", path)
@@ -478,7 +478,7 @@ func (m goSourceDeducer) deduceRoot(path string) (string, error) {
 	return "go.googlesource.com" + v[2], nil
 }
 
-func (m goSourceDeducer) deduceSource(path string, u *url.URL) (maybeSource, error) {
+func (m googlesourceDeducer) deduceSource(path string, u *url.URL) (maybeSource, error) {
 	v := m.regexp.FindStringSubmatch(path)
 	if v == nil {
 		return nil, fmt.Errorf("%s is not a valid path for a source on go.googlesource.com", path)

--- a/internal/gps/deduce_test.go
+++ b/internal/gps/deduce_test.go
@@ -385,7 +385,7 @@ var pathDeductionFixtures = map[string][]pathDeductionFixture{
 			},
 		},
 	},
-	"gosource": {
+	"googlesource": {
 		// Official go repositories hosted on go.googlesource.com
 		{
 			in:   "go.googlesource.com/crypto",
@@ -529,8 +529,8 @@ func TestDeduceFromPath(t *testing.T) {
 				deducer = launchpadGitDeducer{regexp: glpRegex}
 			case "apache":
 				deducer = apacheDeducer{regexp: apacheRegex}
-			case "gosource":
-				deducer = goSourceDeducer{regexp: goSourceRegex}
+			case "googlesource":
+				deducer = googlesourceDeducer{regexp: googlesourceRegex}
 			case "vcsext":
 				deducer = vcsExtensionDeducer{regexp: vcsExtensionRegex}
 			default:

--- a/internal/gps/deduce_test.go
+++ b/internal/gps/deduce_test.go
@@ -385,6 +385,30 @@ var pathDeductionFixtures = map[string][]pathDeductionFixture{
 			},
 		},
 	},
+	"gosource": {
+		// Official go repositories hosted on go.googlesource.com
+		{
+			in:   "go.googlesource.com/crypto",
+			root: "go.googlesource.com/crypto",
+			mb:   maybeGitSource{url: mkurl("https://go.googlesource.com/crypto")},
+		},
+		{
+			in:   "go.googlesource.com/crypto/ssh",
+			root: "go.googlesource.com/crypto",
+			mb:   maybeGitSource{url: mkurl("https://go.googlesource.com/crypto")},
+		},
+		// Spaces are not valid in package names
+		{
+			in:   "go.googlesource.com/cry pto",
+			rerr: errors.New("go.googlesource.com/cry pto is not a valid path for a source on go.googlesource.com"),
+		},
+		// Non https schemes are not valid
+		{
+			in:     "gopher://go.googlesource.com/crypto",
+			root:   "go.googlesource.com/crypto",
+			srcerr: errors.New("go.googlesource.com only supports https, gopher://go.googlesource.com/crypto is not allowed"),
+		},
+	},
 	"vcsext": {
 		// VCS extension-based syntax
 		{
@@ -505,6 +529,8 @@ func TestDeduceFromPath(t *testing.T) {
 				deducer = launchpadGitDeducer{regexp: glpRegex}
 			case "apache":
 				deducer = apacheDeducer{regexp: apacheRegex}
+			case "gosource":
+				deducer = goSourceDeducer{regexp: goSourceRegex}
 			case "vcsext":
 				deducer = vcsExtensionDeducer{regexp: vcsExtensionRegex}
 			default:


### PR DESCRIPTION
This fixes a bug which can be reproduced simply:

```
$ dep ensure golang.org/x/crypto:go.googlesource.com/crypto
list versions for golang.org/x/crypto(https://go.googlesource.com/crypto): unable to deduce repository and source type for "https://go.googlesource.com/crypto": unable to read metadata: go-import metadata not found
```

The problem comes up because there was no deducer for
go.googlesource.com, and go.googlesource.com itself does not have any
metatags that can be used to deduce the vcs.

Generally speaking, this bug would not come up because most users would
target golang.org/x/crypto, which *does* have all of the required
metadata, but it's a bug all the same.

I encountered the bug (and @sdboyer confirmed it) while working on #818.