### PR TITLE
Update feedback to support revision without version

### DIFF
--- a/internal/feedback/feedback.go
+++ b/internal/feedback/feedback.go
@@ -73,7 +73,7 @@ func (cf ConstraintFeedback) LogFeedback(logger *log.Logger) {
 	if cf.Constraint != "" {
 		logger.Printf("  %v", GetUsingFeedback(cf.Constraint, cf.ConstraintType, cf.DependencyType, cf.ProjectPath))
 	}
-	if cf.LockedVersion != "" && cf.Revision != "" {
+	if cf.Revision != "" {
 		logger.Printf("  %v", GetLockingFeedback(cf.LockedVersion, cf.Revision, cf.DependencyType, cf.ProjectPath))
 	}
 }
@@ -104,7 +104,11 @@ func GetLockingFeedback(version, revision, depType, projectPath string) string {
 	}
 
 	if depType == DepTypeImported {
-		return fmt.Sprintf("Trying %s (%s) as initial lock for %s %s", version, revision, depType, projectPath)
+		if version != "" {
+			return fmt.Sprintf("Trying %s (%s) as initial lock for %s %s", version, revision, depType, projectPath)
+		}
+		return fmt.Sprintf("Trying * (%s) as initial lock for %s %s", revision, depType, projectPath)
+
 	}
 	return fmt.Sprintf("Locking in %s (%s) for %s %s", version, revision, depType, projectPath)
 }

--- a/internal/feedback/feedback.go
+++ b/internal/feedback/feedback.go
@@ -104,11 +104,10 @@ func GetLockingFeedback(version, revision, depType, projectPath string) string {
 	}
 
 	if depType == DepTypeImported {
-		if version != "" {
-			return fmt.Sprintf("Trying %s (%s) as initial lock for %s %s", version, revision, depType, projectPath)
+		if version == "" {
+			version = "*"
 		}
-		return fmt.Sprintf("Trying * (%s) as initial lock for %s %s", revision, depType, projectPath)
-
+		return fmt.Sprintf("Trying %s (%s) as initial lock for %s %s", version, revision, depType, projectPath)
 	}
 	return fmt.Sprintf("Locking in %s (%s) for %s %s", version, revision, depType, projectPath)
 }

--- a/internal/feedback/feedback_test.go
+++ b/internal/feedback/feedback_test.go
@@ -31,6 +31,10 @@ func TestFeedback_Constraint(t *testing.T) {
 			want:     "Using ^1.0.0 as initial constraint for imported dep github.com/foo/bar",
 		},
 		{
+			feedback: NewConstraintFeedback(gps.ProjectConstraint{Constraint: gps.Any(), Ident: pi}, DepTypeImported),
+			want:     "Using * as initial constraint for imported dep github.com/foo/bar",
+		},
+		{
 			feedback: NewConstraintFeedback(gps.ProjectConstraint{Constraint: rev, Ident: pi}, DepTypeDirect),
 			want:     "Using 1b8edb3 as hint for direct dep github.com/foo/bar",
 		},
@@ -67,6 +71,10 @@ func TestFeedback_LockedProject(t *testing.T) {
 		{
 			feedback: NewLockedProjectFeedback(gps.NewLockedProject(pi, v, nil), DepTypeImported),
 			want:     "Trying v1.1.4 (bc29b4f) as initial lock for imported dep github.com/foo/bar",
+		},
+		{
+			feedback: NewLockedProjectFeedback(gps.NewLockedProject(pi, gps.NewVersion("").Pair("bc29b4f"), nil), DepTypeImported),
+			want:     "Trying * (bc29b4f) as initial lock for imported dep github.com/foo/bar",
 		},
 		{
 			feedback: NewLockedProjectFeedback(gps.NewLockedProject(pi, b, nil), DepTypeTransitive),


### PR DESCRIPTION

### What does this do / why do we need it?
Update feedback to support revision without version. 

Doing this so we can get feedback for the detached head
use case that govendor frequently has.

Without this change we won't get any feedback for locks that have a revision, but no version.  This can happen if we are using `gps.Any()` for the constraint.

Without this fix you might see something like the following: 

```
Using * as initial constraint for imported dep github.com/sdboyer/deptest
```

After this fix you should see something like : 

```
Using * as initial constraint for imported dep github.com/sdboyer/deptest
Trying * (c575196) as initial lock for imported dep github.com/sdboyer/deptest
```

### What should your reviewer look out for in this PR?


### Do you need help or clarification on anything?
No.

### Which issue(s) does this PR fix?
None