### PR TITLE
GOPATH detection now works when GOPATH is a symlink

### DIFF
--- a/context.go
+++ b/context.go
@@ -212,6 +212,11 @@ func (c *Ctx) DetectProjectGOPATH(p *Project) (string, error) {
 // detectGOPATH detects the GOPATH for a given path from ctx.GOPATHs.
 func (c *Ctx) detectGOPATH(path string) (string, error) {
 	for _, gp := range c.GOPATHs {
+		// Evaluate symlinks in case the user's GOPATH contains a symlink.
+		gp, err := filepath.EvalSymlinks(gp)
+		if err != nil {
+			return "", errors.New("failed to evaluate symlinks on GOPATH")
+		}
 		if fs.HasFilepathPrefix(path, gp) {
 			return gp, nil
 		}


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].
-->

### What does this do / why do we need it?

Currently, `dep init` fails with `ctx.DetectProjectGOPATH: /Users/nkatsaros/some/symlinked/src/project is not within a known GOPATH` if your GOPATH is a symlink. Note that the GOPATH is the symlink, not the project path.

Given that the standard Go toolchain works with this situation, dep should likely work too.

### What should your reviewer look out for in this PR?
Nope.

### Do you need help or clarification on anything?
The tests in `TestDetectProjectGOPATH` are a little strange, the function likely needs some clean up. They work, but I'm not 100% sure they are correct.

### Which issue(s) does this PR fix?
None.
<!--

fixes #
fixes #

-->
