### PR TITLE
Include context in the vcs error message

### DIFF
--- a/vendor/github.com/Masterminds/vcs/errors.go
+++ b/vendor/github.com/Masterminds/vcs/errors.go
@@ -1,6 +1,9 @@
 package vcs
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 // The vcs package provides ways to work with errors that hide the underlying
 // implementation details but make them accessible if needed. For basic errors
@@ -93,7 +96,7 @@ type vcsError struct {
 
 // Error implements the Error interface
 func (e *vcsError) Error() string {
-	return e.s
+	return fmt.Sprintf("%s: %v", e.s, e.e)
 }
 
 // Original retrieves the underlying implementation specific error.


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].
-->

### What does this do / why do we need it?
Adds more context to vcs errors

### What should your reviewer look out for in this PR?
When vcs fails, more information is shown.  For example if you run dep init -v and a vcs command times out (like #832), more information is shown.
`unable to update repository:` becomes `unable to update repository: command killed after 2m of no activity`

### Do you need help or clarification on anything?

### Which issue(s) does this PR fix?
This doesn't fully fix, but it's related to #832.

<!--

fixes #
fixes #

-->
