### PR TITLE
Try to fix stale lock file problems mentioned in bug #820.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,6 +26,12 @@
   revision = "cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/nightlyone/lockfile"
+  packages = ["."]
+  revision = "e83dc5e7bba095e8d32fb2124714bf41f2a30cb5"
+
+[[projects]]
   name = "github.com/pelletier/go-buffruneio"
   packages = ["."]
   revision = "c37440a7cf42ac63b919c752ca73a85067e05992"
@@ -52,6 +58,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "1096dfb111cbe243aa24ea824ea3e1db7bb178c01d5565107c6d9290d225d722"
+  inputs-digest = "48b2f69d59b2f321b14ee11547f4ac94468ac91bb99aad48337d42b75b791975"
   solver-name = "gps-cdcl"
   solver-version = 1


### PR DESCRIPTION
### What does this do / why do we need it?

This addresses the case where there is a stale lock file, or if there is multiple dep instances running. Each subsequent dep instance will now wait until the previous dep instances finish. The lock file will be removed if it is stale; it keeps track of which PIDs are active, and checks to see if the pid exists if it's busy.

It also should give better error messages if there is a problem.

### What should your reviewer look out for in this PR?

Anything disastrous?

### Do you need help or clarification on anything?

### Which issue(s) does this PR fix?

fixes #820 
