### PR TITLE
Use gentler subprocess termination semantics

### DIFF
--- a/internal/gps/cmd.go
+++ b/internal/gps/cmd.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os/exec"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Masterminds/vcs"
@@ -25,6 +26,18 @@ type monitoredCmd struct {
 	stderr  *activityBuffer
 }
 
+// timeoutError indicates that the monitored process was terminated due to
+// exceeding activity timeouts.
+type timeoutError struct {
+	timeout time.Duration
+}
+
+// killCmdError indicates that an error occurred while sending a kill signal to
+// the monitored process.
+type killCmdError struct {
+	err error
+}
+
 func newMonitoredCmd(cmd *exec.Cmd, timeout time.Duration) *monitoredCmd {
 	stdout, stderr := newActivityBuffer(), newActivityBuffer()
 	cmd.Stdout, cmd.Stderr = stdout, stderr
@@ -37,8 +50,8 @@ func newMonitoredCmd(cmd *exec.Cmd, timeout time.Duration) *monitoredCmd {
 }
 
 // run will wait for the command to finish and return the error, if any. If the
-// command does not show any activity for more than the specified timeout the
-// process will be killed.
+// command does not show any progress, as indicated by writing to stdout or
+// stderr, for more than the specified timeout, the process will be killed.
 func (c *monitoredCmd) run(ctx context.Context) error {
 	// Check for cancellation before even starting
 	if ctx.Err() != nil {
@@ -52,31 +65,58 @@ func (c *monitoredCmd) run(ctx context.Context) error {
 
 	ticker := time.NewTicker(c.timeout)
 	defer ticker.Stop()
+
+	// Atomic marker to track proc exit state. Guards against bad channel
+	// select receive order, where a tick or context cancellation could come
+	// in at the same time as process completion, but one of the former are
+	// picked first; in such a case, cmd.Process could(?) be nil by the time we
+	// call signal methods on it.
+	var isDone *int32 = new(int32)
 	done := make(chan error, 1)
 
 	go func() {
+		// Wait() can only be called once, so this must act as the completion
+		// indicator for both normal *and* signal-induced termination.
 		done <- c.cmd.Wait()
+		atomic.CompareAndSwapInt32(isDone, 0, 1)
 	}()
 
+	var killerr error
+selloop:
 	for {
 		select {
-		case <-ticker.C:
-			if c.hasTimedOut() {
-				if err := killProcess(c.cmd); err != nil {
-					return &killCmdError{err}
-				}
-
-				return &timeoutError{c.timeout}
-			}
-		case <-ctx.Done():
-			if err := killProcess(c.cmd); err != nil {
-				return &killCmdError{err}
-			}
-			return ctx.Err()
 		case err := <-done:
 			return err
+		case <-ticker.C:
+			if !atomic.CompareAndSwapInt32(isDone, 1, 1) && c.hasTimedOut() {
+				if err := killProcess(c.cmd, isDone); err != nil {
+					killerr = &killCmdError{err}
+				} else {
+					killerr = &timeoutError{c.timeout}
+				}
+				break selloop
+			}
+		case <-ctx.Done():
+			if !atomic.CompareAndSwapInt32(isDone, 1, 1) {
+				if err := killProcess(c.cmd, isDone); err != nil {
+					killerr = &killCmdError{err}
+				} else {
+					killerr = ctx.Err()
+				}
+				break selloop
+			}
 		}
 	}
+
+	// This is only reachable on the signal-induced termination path, so block
+	// until a message comes through the channel indicating that the command has
+	// exited.
+	//
+	// TODO(sdboyer) if the signaling process errored (resulting in a
+	// killCmdError stored in killerr), is it possible that this receive could
+	// block forever on some kind of hung process?
+	<-done
+	return killerr
 }
 
 func (c *monitoredCmd) hasTimedOut() bool {
@@ -121,16 +161,8 @@ func (b *activityBuffer) lastActivity() time.Time {
 	return b.lastActivityStamp
 }
 
-type timeoutError struct {
-	timeout time.Duration
-}
-
 func (e timeoutError) Error() string {
 	return fmt.Sprintf("command killed after %s of no activity", e.timeout)
-}
-
-type killCmdError struct {
-	err error
 }
 
 func (e killCmdError) Error() string {

--- a/internal/gps/cmd.go
+++ b/internal/gps/cmd.go
@@ -26,9 +26,9 @@ type monitoredCmd struct {
 	stderr  *activityBuffer
 }
 
-// timeoutError indicates that the monitored process was terminated due to
-// exceeding activity timeouts.
-type timeoutError struct {
+// noProgressError indicates that the monitored process was terminated due to
+// exceeding exceeding the progress timeout.
+type noProgressError struct {
 	timeout time.Duration
 }
 
@@ -92,7 +92,7 @@ selloop:
 				if err := killProcess(c.cmd, isDone); err != nil {
 					killerr = &killCmdError{err}
 				} else {
-					killerr = &timeoutError{c.timeout}
+					killerr = &noProgressError{c.timeout}
 				}
 				break selloop
 			}
@@ -161,7 +161,7 @@ func (b *activityBuffer) lastActivity() time.Time {
 	return b.lastActivityStamp
 }
 
-func (e timeoutError) Error() string {
+func (e noProgressError) Error() string {
 	return fmt.Sprintf("command killed after %s of no activity", e.timeout)
 }
 

--- a/internal/gps/cmd_test.go
+++ b/internal/gps/cmd_test.go
@@ -16,7 +16,7 @@ import (
 func mkTestCmd(iterations int) *monitoredCmd {
 	return newMonitoredCmd(
 		exec.Command("./echosleep", "-n", fmt.Sprint(iterations)),
-		500*time.Millisecond,
+		490*time.Millisecond,
 	)
 }
 
@@ -49,7 +49,7 @@ func TestMonitoredCmd(t *testing.T) {
 		t.Error("Expected command to fail")
 	}
 
-	_, ok := err.(*timeoutError)
+	_, ok := err.(*noProgressError)
 	if !ok {
 		t.Errorf("Expected a timeout error, but got: %s", err)
 	}

--- a/internal/gps/cmd_unix.go
+++ b/internal/gps/cmd_unix.go
@@ -1,0 +1,53 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !windows
+
+package gps
+
+import (
+	"os"
+	"os/exec"
+	"time"
+)
+
+// killProcess manages the termination of subprocesses in a way that tries to be
+// gentle (via os.Interrupt), but resorts to Kill if needed.
+//
+//
+// TODO(sdboyer) should the return differentiate between whether gentle methods
+// succeeded vs. falling back to a hard kill?
+func killProcess(cmd *exec.Cmd) error {
+	if err := cmd.Process.Signal(os.Interrupt); err != nil {
+		// If an error comes back from attempting to signal, proceed immediately
+		// to hard kill.
+		return cmd.Process.Kill()
+	}
+
+	// If the process doesn't exit immediately, check every 50ms, up to 3s,
+	// after which send a hard kill.
+	//
+	// Cannot rely on cmd.ProcessState.Exited() here, as that is not set
+	// correctly when the process exits due to a signal. See
+	// https://github.com/golang/go/issues/19798
+	if cmd.ProcessState == nil || !cmd.ProcessState.Exited() {
+		to := time.NewTimer(3 * time.Second)
+		tick := time.NewTicker(50 * time.Millisecond)
+
+		defer to.Stop()
+		defer tick.Stop()
+
+		// Loop until the ProcessState shows up, indicating the proc has exited,
+		// or the timer expires and
+		for cmd.ProcessState != nil {
+			select {
+			case <-to.C:
+				return cmd.Process.Kill()
+			case <-tick.C:
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/gps/cmd_windows.go
+++ b/internal/gps/cmd_windows.go
@@ -1,0 +1,14 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+package gps
+
+import "os/exec"
+
+func killProcess(cmd *exec.Cmd) error {
+	// TODO it'd be great if this could be more sophisticated...
+	return cmd.Process.Kill()
+}

--- a/internal/gps/cmd_windows.go
+++ b/internal/gps/cmd_windows.go
@@ -8,7 +8,7 @@ package gps
 
 import "os/exec"
 
-func killProcess(cmd *exec.Cmd) error {
+func killProcess(cmd *exec.Cmd, isDone *int32) error {
 	// TODO it'd be great if this could be more sophisticated...
 	return cmd.Process.Kill()
 }


### PR DESCRIPTION
### What does this do / why do we need it?

This should help address the overwhelming majority of reports of cache corruption, which occur as a result of Ctrl-c causing git to exit abruptly and leaving a corrupted repository state on disk. Given how common it is for people to Ctrl-c during their first dep init while dep is cloning down bunches of repos, this could help a lot. As @natefinch put it in #823:

> Even though dep is actually doing something, it's a long process, and thus it looks like it is hanging. Because it looks hung, people hit ctrl-C, which then corrupts the dep cache, and screws up further dep init attempts.

### What should your reviewer look out for in this PR?

Note that this PR sidesteps the problem for Windows. I'm hoping one of our Windows folks might be able to do a follow-up on that side - @ChrisHines? @mattn? (I did see [this](https://github.com/mattn/goemon/blob/master/proc_windows.go))

### Do you need help or clarification on anything?

I really don't like checking `cmd.ProcessState != nil` as a way of determining if the process has exited, but that was the most obvious solution that jumped out at me.

If folks could give this a shot to see if their issues go away, that'd be great. Of course, proving there ISN'T an problem through empirical tests is not fully possible, so just best-effort would be fine.

### Which issue(s) does this PR fix?

fixes #469
fixes #790
fixes #409 
fixes #823 (well enough for now, at least)
