### PR TITLE
Consolidate direct deps by root project

### DIFF
--- a/cmd/dep/init_test.go
+++ b/cmd/dep/init_test.go
@@ -1,0 +1,41 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"testing"
+
+	"path/filepath"
+
+	"github.com/golang/dep"
+	"github.com/golang/dep/internal/gps"
+	"github.com/golang/dep/internal/test"
+)
+
+func TestGetDirectDependencies_ConsolidatesRootProjects(t *testing.T) {
+	h := test.NewHelper(t)
+	defer h.Cleanup()
+
+	ctx := newTestContext(h)
+	sm, err := ctx.SourceManager()
+	h.Must(err)
+	defer sm.Release()
+
+	testprj := "directdepstest"
+	testdir := filepath.Join("src", testprj)
+	h.TempDir(testdir)
+	h.TempCopy(filepath.Join(testdir, "main.go"), "init/directdeps/main.go")
+
+	testpath := h.Path(testdir)
+	prj := &dep.Project{AbsRoot: testpath, ResolvedAbsRoot: testpath, ImportRoot: gps.ProjectRoot(testprj)}
+
+	_, dd, err := getDirectDependencies(sm, prj)
+	h.Must(err)
+
+	wantpr := "github.com/carolynvs/deptest-subpkg"
+	if _, has := dd[wantpr]; !has {
+		t.Fatalf("Expected direct dependencies to contain %s, got %v", wantpr, dd)
+	}
+}

--- a/cmd/dep/testdata/init/directdeps/main.go
+++ b/cmd/dep/testdata/init/directdeps/main.go
@@ -1,0 +1,9 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import _ "github.com/carolynvs/deptest-subpkg/subby"
+
+func main() {}


### PR DESCRIPTION
At the end of `dep init`, the `rootAnalyzer` [removes any constraints that are not direct dependencies](https://github.com/golang/dep/blob/6c5ebb93c4e32614ba61fed6acb962a272ad4b8a/cmd/dep/root_analyzer.go#L94). If only a subpackage was imported, never the root package from the dependency, then it (incorrectly) removes the constraint for the dependency.  The direct dep was added to the map as a full subpackage, when the constraint is only the root package.

This fixes `getDirectDependencies` to return only root packages. Now when we lookup constrains in the directdeps map, we are comparing root projects to root projects.