### PR TITLE
Address mixup between bzr revisions and semver suffixes

### DIFF
--- a/internal/gps/source_manager.go
+++ b/internal/gps/source_manager.go
@@ -462,9 +462,9 @@ func (sm *SourceMgr) DeduceProjectRoot(ip string) (ProjectRoot, error) {
 	return ProjectRoot(pd.root), err
 }
 
-// InferConstraint tries to puzzle out what kind of version is given in a string.
-// Preference is given first for revisions, then branches, then semver constraints,
-// and then plain tags.
+// InferConstraint tries to puzzle out what kind of version is given in a
+// string. Preference is given first for revisions, then branches, then semver
+// constraints, and then plain tags.
 func (sm *SourceMgr) InferConstraint(s string, pi ProjectIdentifier) (Constraint, error) {
 	slen := len(s)
 	if slen == 40 {

--- a/internal/gps/source_manager.go
+++ b/internal/gps/source_manager.go
@@ -479,7 +479,7 @@ func (sm *SourceMgr) InferConstraint(s string, pi ProjectIdentifier) (Constraint
 	// Next, try for bzr, which has a three-component GUID separated by
 	// dashes. There should be two, but the email part could contain
 	// internal dashes
-	if strings.Count(s, "-") >= 2 {
+	if strings.Contains(s, "@") && strings.Count(s, "-") >= 2 {
 		// Work from the back to avoid potential confusion from the email
 		i3 := strings.LastIndex(s, "-")
 		// Skip if - is last char, otherwise this would panic on bounds err

--- a/internal/gps/source_manager_test.go
+++ b/internal/gps/source_manager_test.go
@@ -24,7 +24,7 @@ func TestSourceManager_InferConstraint(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	svs, err := NewSemverConstraintIC(">=0.12.0, <=12.0.0-de4dcafe0")
+	svs, err := NewSemverConstraintIC("v0.12.0-12-de4dcafe0")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/gps/source_manager_test.go
+++ b/internal/gps/source_manager_test.go
@@ -24,10 +24,16 @@ func TestSourceManager_InferConstraint(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	svs, err := NewSemverConstraintIC(">=0.12.0, <=12.0.0-de4dcafe0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	constraints := map[string]Constraint{
 		"v0.8.1": sv,
 		"v2":     NewBranch("v2"),
-		"master": NewBranch("master"),
+		"v0.12.0-12-de4dcafe0": svs,
+		"master":               NewBranch("master"),
 		"5b3352dc16517996fb951394bcbbe913a2a616e3": Revision("5b3352dc16517996fb951394bcbbe913a2a616e3"),
 
 		// valid bzr rev


### PR DESCRIPTION
### What does this do / why do we need it?

This PR handles the case in the `godep_importer` where the imported dependency is referencing a semantic version with a suffix. E.g. 

```
{
	"ImportPath": "github.com/Shopify/sarama",
	"Comment": "v1.12.0-12-g2fd980e",
	"Rev": "2fd980e23bdcbb8edeb78fc704de0c39a6567ffc"
},
```

Will now become:

```
[[constraint]]
  name = "github.com/Shopify/sarama"
  version = ">=1.12.0, <=12.0.0-g2fd980e"
```

### What should your reviewer look out for in this PR?

As per my understanding it is fine to assume that `bzr` revisions contain `@` symbols. But I'm not a `bzr` user so I'm half guessing (with some reading on the Internet) that it's valid.

### Do you need help or clarification on anything?

I think I've gotten what I needed in #827.

There was a comment in the code that I modified that was a bit too long. I have wrapped it. Don't know if you'd like to keep such things out of the PR. Let me know and I can drop that commit, no biggie 😄 .

### Which issue(s) does this PR fix?

fixes #827