### PR TITLE
add jmank88 to MAINTAINERS and CODEOWNERS for gps caching

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,3 +22,6 @@
 /cmd/dep/status*                          @darkowlzz
 /cmd/dep/testdata/harness_tests/status**  @darkowlzz
 /cmd/dep/graphviz*                        @darkowlzz
+
+# gps caching
+/internal/gps/source_cache* @jmank88

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -12,6 +12,6 @@ General maintainers:
   * source manager: (vacant)
   * root deduction: (vacant)
   * source/vcs interaction: (vacant)
-  * caching: (vacant)
+  * caching: Jordan Krage (@jmank88)
   * pkgtree: (vacant)
   * versions and constraints: (vacant)


### PR DESCRIPTION
### What does this do / why do we need it?

Adds myself to MAINTAINERS and CODEOWNERS for gps caching.

Related #629