### PR TITLE
Skip missing vcs tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,28 @@ information on using pull requests.
 
 [GitHub Help]: https://help.github.com/articles/about-pull-requests/
 
+### Running tests
+On go 1.9, run all the tests with the following command:
+
+```
+go test ./...
+```
+
+On older version of go, run all the tests (excluding tests in vendor/) with the following command:
+
+```
+go test -race $(go list ./... | grep -v vendor)
+```
+
+The following test flags are defined:
+* `-skip-missing-bin`: Some tests require that software is installed on your machine
+   such as git, svn, hg, and bzr. Use this flag to skip those tests,
+   e.g. `go test ./... -skip-missing-bin`.
+* `-update`: Our tests use the [golden file pattern](https://github.com/golang/dep/issues/204)
+   where expected output is saved in files in this repo, instead of embedded in tests.
+   Use this flag when the expected output of a test has changed, and the golden
+   files will be rewritten during the test run, e.g. `go test ./... -update`.
+
 ## Contributor License Agreement
 
 Contributions to this project must be accompanied by a Contributor License

--- a/internal/feedback/feedback_test.go
+++ b/internal/feedback/feedback_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/golang/dep/internal/gps"
+	_ "github.com/golang/dep/internal/test" // Define test flags globally
 )
 
 func TestFeedback_Constraint(t *testing.T) {

--- a/internal/gps/paths/paths_test.go
+++ b/internal/gps/paths/paths_test.go
@@ -4,7 +4,11 @@
 
 package paths
 
-import "testing"
+import (
+	"testing"
+
+	_ "github.com/golang/dep/internal/test" // Define test flags globally
+)
 
 func TestIsStandardImportPath(t *testing.T) {
 	fix := []struct {

--- a/internal/gps/pkgtree/pkgtree_test.go
+++ b/internal/gps/pkgtree/pkgtree_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/golang/dep/internal/fs"
 	"github.com/golang/dep/internal/gps/paths"
+	_ "github.com/golang/dep/internal/test" // Define test flags globally
 )
 
 // PackageTree.ToReachMap() uses an easily separable algorithm, wmToReach(),

--- a/internal/gps/vcs_repo_test.go
+++ b/internal/gps/vcs_repo_test.go
@@ -125,6 +125,7 @@ func testSvnRepo(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
 	}
+	requiresBins(t, "svn")
 
 	ctx := context.Background()
 	tempDir, err := ioutil.TempDir("", "go-vcs-svn-tests")
@@ -218,6 +219,7 @@ func testHgRepo(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
 	}
+	requiresBins(t, "hg")
 
 	ctx := context.Background()
 	tempDir, err := ioutil.TempDir("", "go-vcs-hg-tests")
@@ -278,6 +280,7 @@ func testGitRepo(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
 	}
+	requiresBins(t, "git")
 
 	ctx := context.Background()
 	tempDir, err := ioutil.TempDir("", "go-vcs-git-tests")
@@ -355,6 +358,7 @@ func testBzrRepo(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
 	}
+	requiresBins(t, "bzr")
 
 	ctx := context.Background()
 	tempDir, err := ioutil.TempDir("", "go-vcs-bzr-tests")

--- a/internal/gps/vcs_source_test.go
+++ b/internal/gps/vcs_source_test.go
@@ -21,8 +21,7 @@ func TestSlowVcs(t *testing.T) {
 	t.Run("source-gateway", testSourceGateway)
 	t.Run("bzr-repo", testBzrRepo)
 	t.Run("bzr-source", testBzrSourceInteractions)
-	// TODO(kris-nova) re-enable syn-repo after gps is merged into dep
-	//t.Run("svn-repo", testSvnRepo)
+	t.Run("svn-repo", testSvnRepo)
 	// TODO(sdboyer) svn-source
 	t.Run("hg-repo", testHgRepo)
 	t.Run("hg-source", testHgSourceInteractions)

--- a/internal/gps/vcs_source_test.go
+++ b/internal/gps/vcs_source_test.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/golang/dep/internal/test"
 )
 
 // Parent test that executes all the slow vcs interaction tests in parallel.
@@ -524,7 +526,11 @@ func requiresBins(t *testing.T, bins ...string) {
 	for _, b := range bins {
 		_, err := exec.LookPath(b)
 		if err != nil {
-			t.Fatalf("%s is not installed", b)
+			if *test.SkipMissingBinTests {
+				t.Skipf("Skipping: %s is not installed", b)
+			} else {
+				t.Fatalf("%s is not installed. Rerun with the -skip-missing-bin flag to skip this test instead.", b)
+			}
 		}
 	}
 }

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -24,9 +24,10 @@ import (
 )
 
 var (
-	ExeSuffix string // ".exe" on Windows
-	mu        sync.Mutex
-	PrintLogs *bool = flag.Bool("logs", false, "log stdin/stdout of test commands")
+	ExeSuffix           string // ".exe" on Windows
+	mu                  sync.Mutex
+	PrintLogs           *bool = flag.Bool("logs", false, "log stdin/stdout of test commands")
+	SkipMissingBinTests *bool = flag.Bool("skip-missing-bin", false, "Skip tests when a required binary is missing, instead of failing")
 )
 
 const (

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -248,7 +248,11 @@ func NeedsExternalNetwork(t *testing.T) {
 // git binary is not available.
 func NeedsGit(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
-		t.Skip("skipping because git binary not found")
+		if *SkipMissingBinTests {
+			t.Skip("Skipping: git is not installed")
+		} else {
+			t.Fatal("git is not installed. Rerun with the -skip-missing-bin flag to skip this test instead.")
+		}
 	}
 }
 


### PR DESCRIPTION
I don't have bzr, svn or hg installed and am guessing that I'm not the only one. It would be nice if contributors didn't have to install a bunch of rando stuff just to run the test suite. Or have them ignore those tests when they inevitably fail.

I am looking for a way that when a contributor runs the straightforward `go test ./...` that those tests are skipped if the binary is missing. I have that part working in this PR.

I am looking for feedback on how to get the travis job to enforce that those tests aren't skipped though. I added a `-strict` flag to those tests, only to realize that prints a lot of crud because other test packages don't have that flag defined. So running `go test ./... -strict` yields a lot of `flag provided but not defined: -strict` warnings.

Do you think there's a way we could make this happen?