### PR TITLE
document lock mismatch state for ensure

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ for one or more dependencies, do the following:
 
 ### Checking the status of dependencies
 
+Run `dep status` to see the current status of all your dependencies.
+
 ```sh
 $ dep status
 PROJECT                             CONSTRAINT     VERSION        REVISION  LATEST
@@ -116,6 +118,20 @@ github.com/Masterminds/semver       branch 2.x     branch 2.x     139cc09   c2e7
 github.com/Masterminds/vcs          ^1.11.0        v1.11.1        3084677   3084677
 github.com/armon/go-radix           *              branch master  4239b77   4239b77
 ```
+
+On top of that, if you have added new imports to your project or modified the manifest file without running `dep ensure` again, `dep status` will tell you there is a mismatch between the lock file and the current status of the project.
+
+```sh
+$ dep status
+Lock inputs-digest mismatch due to the following packages missing from the lock:
+
+PROJECT                         MISSING PACKAGES
+github.com/Masterminds/goutils  [github.com/Masterminds/goutils]
+
+This happens when a new import is added. Run `dep ensure` to install the missing packages.
+```
+
+As `dep status` suggests, run `dep ensure` to update your lockfile. Then run `dep status` again, and the lock mismatch should go away.
 
 ### Updating dependencies
 


### PR DESCRIPTION
### What does this do / why do we need it?

It adds documentation to the readme regarding the mismatch lock state in `dep status`

### What should your reviewer look out for in this PR?

### Do you need help or clarification on anything?

@carolynvs mentioned in the issue that modifying the `Gopkg.toml` should also generate the same message when you run `dep ensure`, but I tried and I did not get such message. Only when I added the import. Should I report it as a bug?

### Which issue(s) does this PR fix?

Fixes #876 
