### PR TITLE
Simplify temp dir creation in tests

### DIFF
--- a/internal/test/integration_testproj.go
+++ b/internal/test/integration_testproj.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -274,9 +275,11 @@ func (p *IntegrationTestProject) makeRootTempDir() {
 		p.tempdir, err = ioutil.TempDir("", "gotest")
 		p.Must(err)
 
-		// Fox for OSX where the tempdir is a symlink:
-		p.tempdir, err = filepath.EvalSymlinks(p.tempdir)
-		p.Must(err)
+		// Fix for OSX where the tempdir is a symlink:
+		if runtime.GOOS == "darwin" {
+			p.tempdir, err = filepath.EvalSymlinks(p.tempdir)
+			p.Must(err)
+		}
 	}
 }
 

--- a/internal/test/integration_testproj.go
+++ b/internal/test/integration_testproj.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -50,16 +49,7 @@ func NewTestProject(t *testing.T, initPath, wd string, externalProc bool, run Ru
 	new.TempDir(ProjectRoot, "vendor")
 	new.CopyTree(initPath)
 
-	// Note that the Travis darwin platform, directories with certain roots such
-	// as /var are actually links to a dirtree under /private.  Without the patch
-	// below the wd, and therefore the GOPATH, is recorded as "/var/..." but the
-	// actual process runs in "/private/var/..." and dies due to not being in the
-	// GOPATH because the roots don't line up.
-	if externalProc && runtime.GOOS == "darwin" && needsPrivateLeader(new.tempdir) {
-		new.Setenv("GOPATH", filepath.Join("/private", new.tempdir))
-	} else {
-		new.Setenv("GOPATH", new.tempdir)
-	}
+	new.Setenv("GOPATH", new.tempdir)
 
 	return new
 }
@@ -283,6 +273,10 @@ func (p *IntegrationTestProject) makeRootTempDir() {
 		var err error
 		p.tempdir, err = ioutil.TempDir("", "gotest")
 		p.Must(err)
+
+		// Fox for OSX where the tempdir is a symlink:
+		p.tempdir, err = filepath.EvalSymlinks(p.tempdir)
+		p.Must(err)
 	}
 }
 
@@ -297,16 +291,4 @@ func (p *IntegrationTestProject) Must(err error) {
 	if err != nil {
 		p.t.Fatalf("%+v", err)
 	}
-}
-
-// Checks for filepath beginnings that result in the "/private" leader
-// on Mac platforms
-func needsPrivateLeader(path string) bool {
-	var roots = []string{"/var", "/tmp", "/etc"}
-	for _, root := range roots {
-		if strings.HasPrefix(path, root) {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
If the tempdir is evaluated on creation, there is no need for special
handling of "darwin" (OSX) in NewTestProject()

### What does this do / why do we need it?

It simplifies the code in `NewTestProject()` (`internal/test/integration_testproj.go`) by removing special handling when `runtime.GOOS == "darwin"`. 

The problem is that tempfiles[1] on OSX are symlinks and it's just simpler to EvalSymlinks when the test directory is created than having special handling for `"darwin"` later.

[1] An example temp directory on OSX:

    tmpDir: /var/folders/np/f6xzpfd94217nvgdpmwt_qbr0000gn/T/gotest259673386
    ...it symlinks to: /private/var/folders/np/f6xzpfd94217nvgdpmwt_qbr0000gn/T/gotest259673386