### PR TITLE
ensure: always write vendor even if not empty

### DIFF
--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -10,11 +10,9 @@ import (
 	"fmt"
 	"go/build"
 	"log"
-	"path/filepath"
 	"strings"
 
 	"github.com/golang/dep"
-	"github.com/golang/dep/internal/fs"
 	"github.com/golang/dep/internal/gps"
 	"github.com/golang/dep/internal/gps/pkgtree"
 	"github.com/pkg/errors"
@@ -151,19 +149,8 @@ func (cmd *ensureCommand) Run(ctx *dep.Ctx, args []string) error {
 		return errors.Wrap(err, "ensure Solve()")
 	}
 
-	// check if vendor exists, because if the locks are the same but
-	// vendor does not exist we should write vendor
-	vendorExists, err := fs.IsNonEmptyDir(filepath.Join(p.AbsRoot, "vendor"))
-	if err != nil {
-		return errors.Wrap(err, "ensure vendor is a directory")
-	}
-	writeV := dep.VendorOnChanged
-	if !vendorExists && solution != nil {
-		writeV = dep.VendorAlways
-	}
-
 	newLock := dep.LockFromSolution(solution)
-	sw, err := dep.NewSafeWriter(nil, p.Lock, newLock, writeV)
+	sw, err := dep.NewSafeWriter(nil, p.Lock, newLock, dep.VendorAlways)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### What does this do / why do we need it?

If the vendor directory already exists, and the lock file hasn't
changed, even though a project may be missing from the vendor
directory, dep ensure would not add the dependency to the vendor
folder.

If the project is in the vendor folder, but it has been modified
(no longer in sync with lock file), ensure would not replace the
dependency in the vendor folder.

This change causes dep ensure to run anytime there's a solution,
regardless of the state vendor folder is in, erring on the side
of replacing vendor without checking existing state which is the
most correct behaviour given the ensure intention.

Future optimisations may want to check and verify the contents of
the vendor folder before blinding replacing it.

### What should your reviewer look out for in this PR?

Check the original issue #883, and then my initial proposal PR in #884, sdboyer then gave this solution a tentative OK in https://github.com/golang/dep/issues/883#issuecomment-317288684

### Do you need help or clarification on anything?

Edge cases, or any thoughts where this might be a bad idea. Such as if we've ever recommended doing in place edits to vendor directory.

No tests are included, as this is pretty critical behaviour, I presume an integration test or similar would be in order?

### Which issue(s) does this PR fix?

Fixes #883.
