### PR TITLE
Remove duplicate root projects when importing from glide

### DIFF
--- a/cmd/dep/glide_importer.go
+++ b/cmd/dep/glide_importer.go
@@ -145,14 +145,7 @@ func (g *glideImporter) convert(pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock, e
 		Constraints: make(gps.ProjectConstraints),
 	}
 
-	for _, pkg := range g.yaml.Imports {
-		pc, err := g.buildProjectConstraint(pkg)
-		if err != nil {
-			return nil, nil, err
-		}
-		manifest.Constraints[pc.Ident.ProjectRoot] = gps.ProjectProperties{Source: pc.Ident.Source, Constraint: pc.Constraint}
-	}
-	for _, pkg := range g.yaml.TestImports {
+	for _, pkg := range append(g.yaml.Imports, g.yaml.TestImports...) {
 		pc, err := g.buildProjectConstraint(pkg)
 		if err != nil {
 			return nil, nil, err
@@ -177,11 +170,7 @@ func (g *glideImporter) convert(pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock, e
 	if g.lock != nil {
 		lock = &dep.Lock{}
 
-		for _, pkg := range g.lock.Imports {
-			lp := g.buildLockedProject(pkg, manifest)
-			lock.P = append(lock.P, lp)
-		}
-		for _, pkg := range g.lock.TestImports {
+		for _, pkg := range append(g.lock.Imports, g.lock.TestImports...) {
 			lp := g.buildLockedProject(pkg, manifest)
 			lock.P = append(lock.P, lp)
 		}

--- a/cmd/dep/godep_importer.go
+++ b/cmd/dep/godep_importer.go
@@ -108,7 +108,7 @@ func (g *godepImporter) convert(pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock, e
 		pkg.ImportPath = string(ip)
 
 		// Check if it already existing in locked projects
-		if projectExistsInLock(lock, pkg.ImportPath) {
+		if projectExistsInLock(lock, ip) {
 			continue
 		}
 
@@ -186,16 +186,4 @@ func (g *godepImporter) buildLockedProject(pkg godepPackage, manifest *dep.Manif
 	f.LogFeedback(g.logger)
 
 	return lp
-}
-
-// projectExistsInLock checks if the given import path already existing in
-// locked projects.
-func projectExistsInLock(l *dep.Lock, ip string) bool {
-	for _, lp := range l.P {
-		if ip == string(lp.Ident().ProjectRoot) {
-			return true
-		}
-	}
-
-	return false
 }

--- a/cmd/dep/godep_importer_test.go
+++ b/cmd/dep/godep_importer_test.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/golang/dep"
 	"github.com/golang/dep/internal/gps"
 	"github.com/golang/dep/internal/test"
 	"github.com/pkg/errors"
@@ -274,35 +273,6 @@ func TestGodepConfig_JsonLoad(t *testing.T) {
 
 	if !equalImports(g.json.Imports, wantJSON.Imports) {
 		t.Fatalf("Expected imports to be equal. \n\t(GOT): %v\n\t(WNT): %v", g.json.Imports, wantJSON.Imports)
-	}
-}
-
-func TestGodepConfig_ProjectExistsInLock(t *testing.T) {
-	lock := &dep.Lock{}
-	pi := gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot("github.com/sdboyer/deptest")}
-	ver := gps.NewVersion("v1.0.0")
-	lock.P = append(lock.P, gps.NewLockedProject(pi, ver, nil))
-
-	cases := []struct {
-		importPath string
-		want       bool
-	}{
-		{
-			importPath: "github.com/sdboyer/deptest",
-			want:       true,
-		},
-		{
-			importPath: "github.com/golang/notexist",
-			want:       false,
-		},
-	}
-
-	for _, c := range cases {
-		result := projectExistsInLock(lock, c.importPath)
-
-		if result != c.want {
-			t.Fatalf("projectExistsInLock result is not as want: \n\t(GOT) %v \n\t(WNT) %v", result, c.want)
-		}
 	}
 }
 

--- a/cmd/dep/root_analyzer.go
+++ b/cmd/dep/root_analyzer.go
@@ -211,3 +211,15 @@ func lookupVersionForLockedProject(pi gps.ProjectIdentifier, c gps.Constraint, r
 	// Give up and lock only to a revision
 	return rev, nil
 }
+
+// projectExistsInLock checks if the given project already exists in
+// a lockfile.
+func projectExistsInLock(l *dep.Lock, pr gps.ProjectRoot) bool {
+	for _, lp := range l.P {
+		if pr == lp.Ident().ProjectRoot {
+			return true
+		}
+	}
+
+	return false
+}

--- a/cmd/dep/testdata/harness_tests/init/glide/case1/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/init/glide/case1/final/Gopkg.lock
@@ -2,6 +2,11 @@
 
 
 [[projects]]
+  name = "github.com/carolynvs/deptest-subpkg"
+  packages = ["subby"]
+  revision = "6c41d90f78bb1015696a2ad591debfa8971512d5"
+
+[[projects]]
   name = "github.com/sdboyer/deptest"
   packages = ["."]
   revision = "ff2948a2ac8f538c4ecd55962e919d1e13e74baf"
@@ -16,6 +21,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c53803413bd0160505cce903e1cba743e0b964088f8cc42a6123f6fe1a0ae9d3"
+  inputs-digest = "7efcfca7f138c3579d22b4ef788294649c734ea630124fb8fbb47acf8770b086"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/dep/testdata/harness_tests/init/glide/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/glide/case1/final/Gopkg.toml
@@ -1,5 +1,8 @@
 ignored = ["github.com/sdboyer/dep-test","github.com/golang/notexist/samples"]
 
 [[constraint]]
+  name = "github.com/carolynvs/deptest-subpkg"
+
+[[constraint]]
   name = "github.com/sdboyer/deptestdos"
   version = "2.0.0"

--- a/cmd/dep/testdata/harness_tests/init/glide/case1/initial/glide.lock
+++ b/cmd/dep/testdata/harness_tests/init/glide/case1/initial/glide.lock
@@ -7,6 +7,8 @@ imports:
   version: ff2948a2ac8f538c4ecd55962e919d1e13e74baf
 - name: github.com/sdboyer/deptestdos
   version: 5c607206be5decd28e6263ffffdcee067266015e
+- name: github.com/carolynvs/deptest-subpkg/subby
+  version: 6c41d90f78bb1015696a2ad591debfa8971512d5
 testImports:
 - name: github.com/golang/lint
   version: cb00e5669539f047b2f4c53a421a01b0c8e172c6

--- a/cmd/dep/testdata/harness_tests/init/glide/case1/initial/glide.yaml
+++ b/cmd/dep/testdata/harness_tests/init/glide/case1/initial/glide.yaml
@@ -16,5 +16,6 @@ import:
   version: v1.0.0
 - package: github.com/sdboyer/deptestdos
   version: v2.0.0
+- package: github.com/carolynvs/deptest-subpkg/subby
 testImport:
 - package: github.com/golang/lint

--- a/cmd/dep/testdata/harness_tests/init/glide/case1/initial/main.go
+++ b/cmd/dep/testdata/harness_tests/init/glide/case1/initial/main.go
@@ -7,6 +7,7 @@ package main
 import (
 	"fmt"
 
+	_ "github.com/carolynvs/deptest-subpkg/subby"
 	"github.com/sdboyer/deptestdos"
 )
 

--- a/cmd/dep/testdata/harness_tests/init/glide/case1/testcase.json
+++ b/cmd/dep/testdata/harness_tests/init/glide/case1/testcase.json
@@ -8,6 +8,7 @@
     "github.com/sdboyer/deptestdos": "5c607206be5decd28e6263ffffdcee067266015e"
   },
   "vendor-final": [
+    "github.com/carolynvs/deptest-subpkg",
     "github.com/sdboyer/deptest",
     "github.com/sdboyer/deptestdos"
   ]


### PR DESCRIPTION
I (naively) assumed that since glide supports listing the subpackages used, that it people's glide.yaml/lock wouldn't have multiple entries for the same root package...

The glide importer now checks for duplicate root projects. I've introduced a cache of the resolution from import path to root project, because it's guaranteed that paths will be double resolved (for glide and any other future importer that uses a config + lock).