### PR TITLE
Default an empty constraint as any, not latest

### DIFF
--- a/cmd/dep/testdata/glide/golden.txt
+++ b/cmd/dep/testdata/glide/golden.txt
@@ -2,7 +2,7 @@ Detected glide configuration files...
 Converting from glide.yaml and glide.lock...
   Using master as initial constraint for imported dep github.com/sdboyer/deptest
   Using ^2.0.0 as initial constraint for imported dep github.com/sdboyer/deptestdos
-  Using master as initial constraint for imported dep github.com/golang/lint
+  Using * as initial constraint for imported dep github.com/golang/lint
   Trying v0.8.1 (3f4c3be) as initial lock for imported dep github.com/sdboyer/deptest
   Trying v2.0.0 (5c60720) as initial lock for imported dep github.com/sdboyer/deptestdos
-  Trying master (cb00e56) as initial lock for imported dep github.com/golang/lint
+  Trying * (cb00e56) as initial lock for imported dep github.com/golang/lint

--- a/internal/gps/source_manager.go
+++ b/internal/gps/source_manager.go
@@ -502,6 +502,10 @@ func (sm *SourceMgr) DeduceProjectRoot(ip string) (ProjectRoot, error) {
 // string. Preference is given first for revisions, then branches, then semver
 // constraints, and then plain tags.
 func (sm *SourceMgr) InferConstraint(s string, pi ProjectIdentifier) (Constraint, error) {
+	if s == "" {
+		return Any(), nil
+	}
+
 	slen := len(s)
 	if slen == 40 {
 		if _, err := hex.DecodeString(s); err == nil {
@@ -539,8 +543,7 @@ func (sm *SourceMgr) InferConstraint(s string, pi ProjectIdentifier) (Constraint
 	}
 	SortPairedForUpgrade(versions)
 	for _, v := range versions {
-		// Pick the default branch if no constraint is given
-		if s == "" || s == v.String() {
+		if s == v.String() {
 			version = v
 			break
 		}

--- a/internal/gps/source_manager_test.go
+++ b/internal/gps/source_manager_test.go
@@ -30,6 +30,7 @@ func TestSourceManager_InferConstraint(t *testing.T) {
 	}
 
 	constraints := map[string]Constraint{
+		"":       Any(),
 		"v0.8.1": sv,
 		"v2":     NewBranch("v2"),
 		"v0.12.0-12-de4dcafe0": svs,


### PR DESCRIPTION
When a package is specified without any restrictions, default the constraint to `gps.Any()`, not latest from the default branch.

Work in pending pull requests for the importers has made it clear that this change is universally needed and shouldn't be done one-off in each importer.