### PR TITLE
Expand on what the required list does and doesn't do

### DIFF
--- a/docs/Gopkg.toml.md
+++ b/docs/Gopkg.toml.md
@@ -14,6 +14,15 @@ required = ["github.com/user/thing/cmd/thing"]
 * Aren't `import`ed by your project, [directly or transitively](FAQ.md#what-is-a-direct-or-transitive-dependency)
 * You don't want put in your `GOPATH`, and/or you want to lock the version
 
+Please note that this only pulls in the sources of these dependencies. It does not install or compile them. So, if you need the tool to be installed you should still run the following (manually or from a `Makefile`)  after each `dep ensure`:
+
+```bash
+cd vendor/pkg/to/install
+go install .
+```
+
+Another option is to use [virtualgo](https://github.com/GetStream/vg), which installs dependencies in the `required` list automatically.
+
 ## `ignored`
 `ignored` lists a set of packages (not projects) that are ignored when dep statically analyzes source code. Ignored packages can be in this project, or in a dependency.
 ```toml

--- a/docs/Gopkg.toml.md
+++ b/docs/Gopkg.toml.md
@@ -21,7 +21,14 @@ cd vendor/pkg/to/install
 go install .
 ```
 
-Another option is to use [virtualgo](https://github.com/GetStream/vg), which installs dependencies in the `required` list automatically.
+This only works reliably if this is the only project to install these executables. This is not enough if you want to be able to run a different version of the same executable depending on the project you're working. In that case you have to use a different `GOBIN` for each project, by doing something like this before running the above commands:
+
+```bash
+export GOBIN=$PWD/bin
+export PATH=$GOBIN:$PATH
+```
+
+You might also try [virtualgo](https://github.com/GetStream/vg), which installs dependencies in the `required` list automatically in a project specific `GOBIN`.
 
 ## `ignored`
 `ignored` lists a set of packages (not projects) that are ignored when dep statically analyzes source code. Ignored packages can be in this project, or in a dependency.


### PR DESCRIPTION
The current wording is not clear on the fact that it won't install the packages in the required list. This can be confusing, because usually this is what you expect for linters and generators.

I put in a link to [virtualgo](https://github.com/GetStream/vg) as well, because it solves the issue as well. If desired I can remove it, but I thought it would be alright because there's also one in the README.