### PR TITLE
[WIP]: internal/fs: add EquivalentPaths function

### DIFF
--- a/cmd/dep/gopath_scanner.go
+++ b/cmd/dep/gopath_scanner.go
@@ -134,7 +134,7 @@ func (g *gopathScanner) overlay(rootM *dep.Manifest, rootL *dep.Lock) {
 }
 
 func trimPathPrefix(p1, p2 string) string {
-	if fs.HasFilepathPrefix(p1, p2) {
+	if isPrefix, _ := fs.HasFilepathPrefix(p1, p2); isPrefix {
 		return p1[len(p2):]
 	}
 	return p1

--- a/context.go
+++ b/context.go
@@ -179,7 +179,7 @@ func (c *Ctx) DetectProjectGOPATH(p *Project) (string, error) {
 	pGOPATH, perr := c.detectGOPATH(p.AbsRoot)
 
 	// If p.AbsRoot is a not symlink, attempt to detect GOPATH for p.AbsRoot only.
-	if equal, _ := fs.EqualPaths(p.AbsRoot, p.ResolvedAbsRoot); equal {
+	if equal, _ := fs.EquivalentPaths(p.AbsRoot, p.ResolvedAbsRoot); equal {
 		return pGOPATH, perr
 	}
 
@@ -191,7 +191,7 @@ func (c *Ctx) DetectProjectGOPATH(p *Project) (string, error) {
 	}
 
 	// If pGOPATH equals rGOPATH, then both are within the same GOPATH.
-	if equal, _ := fs.EqualPaths(pGOPATH, rGOPATH); equal {
+	if equal, _ := fs.EquivalentPaths(pGOPATH, rGOPATH); equal {
 		return "", errors.Errorf("both %s and %s are in the same GOPATH %s", p.AbsRoot, p.ResolvedAbsRoot, pGOPATH)
 	}
 

--- a/context.go
+++ b/context.go
@@ -210,7 +210,11 @@ func (c *Ctx) DetectProjectGOPATH(p *Project) (string, error) {
 // detectGOPATH detects the GOPATH for a given path from ctx.GOPATHs.
 func (c *Ctx) detectGOPATH(path string) (string, error) {
 	for _, gp := range c.GOPATHs {
-		if fs.HasFilepathPrefix(path, gp) {
+		isPrefix, err := fs.HasFilepathPrefix(path, gp)
+		if err != nil {
+			return "", errors.Wrap(err, "failed to detect GOPATH")
+		}
+		if isPrefix {
 			return gp, nil
 		}
 	}
@@ -221,7 +225,11 @@ func (c *Ctx) detectGOPATH(path string) (string, error) {
 // `$GOPATH/src/` prefix.  Returns an error for paths equal to, or without this prefix.
 func (c *Ctx) ImportForAbs(path string) (string, error) {
 	srcprefix := filepath.Join(c.GOPATH, "src") + string(filepath.Separator)
-	if fs.HasFilepathPrefix(path, srcprefix) {
+	isPrefix, err := fs.HasFilepathPrefix(path, srcprefix)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to find import path")
+	}
+	if isPrefix {
 		if len(path) <= len(srcprefix) {
 			return "", errors.New("dep does not currently support using GOPATH/src as the project root")
 		}

--- a/context.go
+++ b/context.go
@@ -179,7 +179,7 @@ func (c *Ctx) DetectProjectGOPATH(p *Project) (string, error) {
 	pGOPATH, perr := c.detectGOPATH(p.AbsRoot)
 
 	// If p.AbsRoot is a not symlink, attempt to detect GOPATH for p.AbsRoot only.
-	if p.AbsRoot == p.ResolvedAbsRoot {
+	if equal, _ := fs.EqualPaths(p.AbsRoot, p.ResolvedAbsRoot); equal {
 		return pGOPATH, perr
 	}
 
@@ -191,7 +191,7 @@ func (c *Ctx) DetectProjectGOPATH(p *Project) (string, error) {
 	}
 
 	// If pGOPATH equals rGOPATH, then both are within the same GOPATH.
-	if pGOPATH == rGOPATH {
+	if equal, _ := fs.EqualPaths(pGOPATH, rGOPATH); equal {
 		return "", errors.Errorf("both %s and %s are in the same GOPATH %s", p.AbsRoot, p.ResolvedAbsRoot, pGOPATH)
 	}
 

--- a/context_test.go
+++ b/context_test.go
@@ -314,22 +314,15 @@ func TestDetectProjectGOPATH(t *testing.T) {
 	h := test.NewHelper(t)
 	defer h.Cleanup()
 
-	h.TempDir("go")
-	h.TempDir("go-two")
+	h.TempDir(filepath.Join("sym", "symlink"))
+	h.TempDir(filepath.Join("go", "src", "sym", "path"))
+	h.TempDir(filepath.Join("go", "src", "real", "path"))
+	h.TempDir(filepath.Join("go-two", "src", "real", "path"))
+	h.TempDir(filepath.Join("go-two", "src", "sym"))
 
 	ctx := &Ctx{
 		GOPATHs: []string{h.Path("go"), h.Path("go-two")},
 	}
-
-	h.TempDir("go/src/real/path")
-
-	// Another directory used as a GOPATH
-	h.TempDir("go-two/src/sym")
-
-	h.TempDir(filepath.Join(".", "sym/symlink")) // Directory for symlinks
-	h.TempDir(filepath.Join("go", "src", "sym", "path"))
-	h.TempDir(filepath.Join("go", "src", " real", "path"))
-	h.TempDir(filepath.Join("go-two", "src", "real", "path"))
 
 	testcases := []struct {
 		name         string
@@ -383,7 +376,7 @@ func TestDetectProjectGOPATH(t *testing.T) {
 		{
 			name:         "AbsRoot-is-a-symlink-to-ResolvedAbsRoot",
 			root:         filepath.Join(h.Path("."), "sym", "symlink"),
-			resolvedRoot: filepath.Join(ctx.GOPATHs[0], "src", " real", "path"),
+			resolvedRoot: filepath.Join(ctx.GOPATHs[0], "src", "real", "path"),
 			GOPATH:       ctx.GOPATHs[0],
 		},
 	}
@@ -412,36 +405,33 @@ func TestDetectGOPATH(t *testing.T) {
 	th := test.NewHelper(t)
 	defer th.Cleanup()
 
-	th.TempDir("go")
-	th.TempDir("gotwo")
+	th.TempDir(filepath.Join("code", "src", "github.com", "username", "package"))
+	th.TempDir(filepath.Join("go", "src", "github.com", "username", "package"))
+	th.TempDir(filepath.Join("gotwo", "src", "github.com", "username", "package"))
 
 	ctx := &Ctx{GOPATHs: []string{
 		th.Path("go"),
 		th.Path("gotwo"),
 	}}
 
-	th.TempDir(filepath.Join("code", "src", "github.com", "username", "package"))
-	th.TempDir(filepath.Join("go", "src", "github.com", "username", "package"))
-	th.TempDir(filepath.Join("gotwo", "src", "github.com", "username", "package"))
-
 	testcases := []struct {
 		GOPATH string
 		path   string
 		err    bool
 	}{
-		{th.Path("go"), filepath.Join(th.Path("go"), "src/github.com/username/package"), false},
-		{th.Path("go"), filepath.Join(th.Path("go"), "src/github.com/username/package"), false},
-		{th.Path("gotwo"), filepath.Join(th.Path("gotwo"), "src/github.com/username/package"), false},
-		{"", filepath.Join(th.Path("."), "code/src/github.com/username/package"), true},
+		{th.Path("go"), th.Path(filepath.Join("go", "src", "github.com", "username", "package")), false},
+		{th.Path("go"), th.Path(filepath.Join("go", "src", "github.com", "username", "package")), false},
+		{th.Path("gotwo"), th.Path(filepath.Join("gotwo", "src", "github.com", "username", "package")), false},
+		{"", th.Path(filepath.Join("code", "src", "github.com", "username", "package")), true},
 	}
 
 	for _, tc := range testcases {
 		GOPATH, err := ctx.detectGOPATH(tc.path)
 		if tc.err && err == nil {
-			t.Error("Expected error but got none")
+			t.Error("expected error but got none")
 		}
 		if GOPATH != tc.GOPATH {
-			t.Errorf("Expected GOPATH to be %s, got %s", GOPATH, tc.GOPATH)
+			t.Errorf("expected GOPATH to be %s, got %s", GOPATH, tc.GOPATH)
 		}
 	}
 }

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -102,8 +102,8 @@ func HasFilepathPrefix(path, prefix string) bool {
 	return true
 }
 
-// EquivalentPaths compares the paths passed to check if the are equivalent.
-// It respects the case-sensitivity of the underlaying filesysyems.
+// EquivalentPaths compares the paths passed to check if they are equivalent.
+// It respects the case-sensitivity of the underlying filesysyems.
 func EquivalentPaths(p1, p2 string) (bool, error) {
 	p1 = filepath.Clean(p1)
 	p2 = filepath.Clean(p2)

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -102,9 +102,9 @@ func HasFilepathPrefix(path, prefix string) bool {
 	return true
 }
 
-// EqualPaths compares the paths passed to check if the are equivalent.
+// EquivalentPaths compares the paths passed to check if the are equivalent.
 // It respects the case-sensitivity of the underlaying filesysyems.
-func EqualPaths(p1, p2 string) (bool, error) {
+func EquivalentPaths(p1, p2 string) (bool, error) {
 	p1 = filepath.Clean(p1)
 	p2 = filepath.Clean(p2)
 

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -75,7 +75,11 @@ func TestHasFilepathPrefix(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if got := HasFilepathPrefix(c.path, c.prefix); c.want != got {
+		got, err := HasFilepathPrefix(c.path, c.prefix)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if c.want != got {
 			t.Fatalf("dir: %q, prefix: %q, expected: %v, got: %v", c.path, c.prefix, c.want, got)
 		}
 	}
@@ -122,13 +126,18 @@ func TestHasFilepathPrefix_Files(t *testing.T) {
 		path   string
 		prefix string
 		want   bool
+		err    bool
 	}{
-		{existingFile, filepath.Join(dir2), true},
-		{nonExistingFile, filepath.Join(dir2), false},
+		{existingFile, filepath.Join(dir2), true, false},
+		{nonExistingFile, filepath.Join(dir2), false, true},
 	}
 
 	for _, c := range cases {
-		if got := HasFilepathPrefix(c.path, c.prefix); c.want != got {
+		got, err := HasFilepathPrefix(c.path, c.prefix)
+		if err != nil && !c.err {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if c.want != got {
 			t.Fatalf("dir: %q, prefix: %q, expected: %v, got: %v", c.path, c.prefix, c.want, got)
 		}
 	}

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -134,7 +134,7 @@ func TestHasFilepathPrefix_Files(t *testing.T) {
 	}
 }
 
-func TestEqualPaths(t *testing.T) {
+func TestEquivalentPaths(t *testing.T) {
 	h := test.NewHelper(t)
 	h.TempDir("dir")
 	h.TempDir("dir2")
@@ -166,17 +166,17 @@ func TestEqualPaths(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		got, err := EqualPaths(tc.p1, tc.p2)
+		got, err := EquivalentPaths(tc.p1, tc.p2)
 		if err != nil && !tc.err {
 			t.Error("unexpected error:", err)
 		}
 		if caseSensitive {
 			if tc.caseSensitiveEquivalent != got {
-				t.Errorf("expected EqualPaths(%q, %q) to be %t on case-sensitive filesystem, got %t", tc.p1, tc.p2, tc.caseSensitiveEquivalent, got)
+				t.Errorf("expected EquivalentPaths(%q, %q) to be %t on case-sensitive filesystem, got %t", tc.p1, tc.p2, tc.caseSensitiveEquivalent, got)
 			}
 		} else {
 			if tc.caseInensitiveEquivalent != got {
-				t.Errorf("expected EqualPaths(%q, %q) to be %t on case-insensitive filesystem, got %t", tc.p1, tc.p2, tc.caseInensitiveEquivalent, got)
+				t.Errorf("expected EquivalentPaths(%q, %q) to be %t on case-insensitive filesystem, got %t", tc.p1, tc.p2, tc.caseInensitiveEquivalent, got)
 			}
 		}
 	}


### PR DESCRIPTION
### What does this do / why do we need it?

Add a new method to `internal/fs` to check for path equivalence.

### What should your reviewer look out for in this PR?

Does this work as expected?

### Which issue(s) does this PR fix?

fixes #772
fixes #805