### PR TITLE
Add item on relative imports to FAQ

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -281,9 +281,10 @@ This is the only symbolic link support that `dep` really intends to provide. In 
 
 ## Does `dep` support relative imports?
 
-Dep doesn't allow relative imports. It's one of the few cases in which dep restricts what the Go toolchain allows (although the toolchain already frowns heavily on them, so tread carefully!)
-
-Dep doesn't support them because of the difficulty required trying to prove that a '../' import doesn't escape the tree of the project. 
+No.
+> dep simply doesn't allow relative imports. this is one of the few places where we restrict a case that the toolchain itself allows. we disallow them only because:
+>  i. the toolchain already frowns heavily on them
+> ii. it's worse for our case, as we start venturing into [dot dot hell](http://doc.cat-v.org/plan_9/4th_edition/papers/lexnames) territory when trying to prove that the import does not escape the tree of the project -[@sdboyer in #899](https://github.com/golang/dep/issues/899#issuecomment-317904001)
 
 ## Best Practices
 ### Should I commit my vendor directory?

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -286,6 +286,8 @@ No.
 >  i. the toolchain already frowns heavily on them<br>
 > ii. it's worse for our case, as we start venturing into [dot dot hell](http://doc.cat-v.org/plan_9/4th_edition/papers/lexnames) territory when trying to prove that the import does not escape the tree of the project -[@sdboyer in #899](https://github.com/golang/dep/issues/899#issuecomment-317904001)
 
+For a refresher on Go's recommended workspace organization, see https://golang.org/doc/code.html. Organizing your code this way gives you a unique import path for every package.
+
 ## Best Practices
 ### Should I commit my vendor directory?
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -24,6 +24,7 @@ Summarize the question and quote the reply, linking back to the original comment
 * [Why did `dep` use a different revision for package X instead of the revision in the lock file?](#why-did-dep-use-a-different-revision-for-package-x-instead-of-the-revision-in-the-lock-file)
 * [Why is `dep` slow?](#why-is-dep-slow)
 * [How does `dep` handle symbolic links?](#how-does-dep-handle-symbolic-links)
+* [Does `dep` support relative imports?](#does-dep-support-relative-imports)
 
 ## Best Practices
 * [Should I commit my vendor directory?](#should-i-commit-my-vendor-directory)
@@ -277,6 +278,12 @@ When `dep` is invoked with a project root that is a symlink, it will be resolved
 - If neither the symlink nor the resolved path are in a `GOPATH`, then an error is thrown.
 
 This is the only symbolic link support that `dep` really intends to provide. In keeping with the general practices of the `go` tool, `dep` tends to either ignore symlinks (when walking) or copy the symlink itself, depending on the filesystem operation being performed.
+
+## Does `dep` support relative imports?
+
+Dep doesn't allow relative imports. It's one of the few cases in which dep restricts what the Go toolchain allows (although the toolchain already frowns heavily on them, so tread carefully!)
+
+Dep doesn't support them because of the difficulty required trying to prove that a '../' import doesn't escape the tree of the project. 
 
 ## Best Practices
 ### Should I commit my vendor directory?

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -286,7 +286,7 @@ No.
 >  i. the toolchain already frowns heavily on them<br>
 > ii. it's worse for our case, as we start venturing into [dot dot hell](http://doc.cat-v.org/plan_9/4th_edition/papers/lexnames) territory when trying to prove that the import does not escape the tree of the project -[@sdboyer in #899](https://github.com/golang/dep/issues/899#issuecomment-317904001)
 
-For a refresher on Go's recommended workspace organization, see https://golang.org/doc/code.html. Organizing your code this way gives you a unique import path for every package.
+For a refresher on Go's recommended workspace organization, see the ["How To Write Go Code"](https://golang.org/doc/code.html) article in the Go docs. Organizing your code this way gives you a unique import path for every package.
 
 ## Best Practices
 ### Should I commit my vendor directory?

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -282,8 +282,8 @@ This is the only symbolic link support that `dep` really intends to provide. In 
 ## Does `dep` support relative imports?
 
 No.
-> dep simply doesn't allow relative imports. this is one of the few places where we restrict a case that the toolchain itself allows. we disallow them only because:
->  i. the toolchain already frowns heavily on them
+> dep simply doesn't allow relative imports. this is one of the few places where we restrict a case that the toolchain itself allows. we disallow them only because:<br>
+>  i. the toolchain already frowns heavily on them<br>
 > ii. it's worse for our case, as we start venturing into [dot dot hell](http://doc.cat-v.org/plan_9/4th_edition/papers/lexnames) territory when trying to prove that the import does not escape the tree of the project -[@sdboyer in #899](https://github.com/golang/dep/issues/899#issuecomment-317904001)
 
 ## Best Practices


### PR DESCRIPTION
### What does this do / why do we need it?

Adds a FAQ item "Does dep support relative imports?" to docs/FAQ.md. Created in response to https://github.com/golang/dep/issues/910. 

### What should your reviewer look out for in this PR?

Clarity of explanation and correct style - I tried to follow the FAQ's standard structure by pulling an explanation from existing issue discussion and quoting the author / linking to the page. 

### Do you need help or clarification on anything?

Happy to make changes to this if the content needs work!

### Which issue(s) does this PR fix?

<!--

fixes #910

-->
