### PR TITLE
Unify alternate source IDs in solver to avoid duplicate projects

### DIFF
--- a/internal/gps/solve_bimodal_test.go
+++ b/internal/gps/solve_bimodal_test.go
@@ -353,6 +353,28 @@ var bimodalFixtures = map[string]bimodalFixture{
 			"b 1.0.2",
 		),
 	},
+	"unify project on disjoint package imports + source switching": {
+		ds: []depspec{
+			dsp(mkDepspec("root 0.0.0", "b from baz 1.0.0"),
+				pkg("root", "a", "b"),
+			),
+			dsp(mkDepspec("a 1.0.0"),
+				pkg("a", "b/foo"),
+			),
+			dsp(mkDepspec("b 1.0.0"),
+				pkg("b"),
+				pkg("b/foo"),
+			),
+			dsp(mkDepspec("baz 1.0.0"),
+				pkg("b"),
+				pkg("b/foo"),
+			),
+		},
+		r: mksolution(
+			"a 1.0.0",
+			mklp("b from baz 1.0.0", ".", "foo"),
+		),
+	},
 	"project cycle not involving root": {
 		ds: []depspec{
 			dsp(mkDepspec("root 0.0.0", "a ~1.0.0"),

--- a/internal/gps/solver.go
+++ b/internal/gps/solver.go
@@ -1253,8 +1253,16 @@ func (s *solver) selectAtom(a atomWithPackages, pkgonly bool) {
 		}
 
 		if len(newp) > 0 {
+			// If there was a previously-established alternate source for this
+			// dependency, but the current atom did not express one (and getting
+			// here means the atom passed the source hot-swapping check - see
+			// checkIdentMatches()), then we have to create the new bmi with the
+			// alternate source. Otherwise, we end up with two discrete project
+			// entries for the project root in the final output, one with the
+			// alternate source, and one without. See #969.
+			id, _ := s.sel.getIdentFor(dep.Ident.ProjectRoot)
 			bmi := bimodalIdentifier{
-				id: dep.Ident,
+				id: id,
 				pl: newp,
 				// This puts in a preferred version if one's in the map, else
 				// drops in the zero value (nil)


### PR DESCRIPTION
Fixes #969. This is insanely deep in the solver, so I'm not actually expecting anyone to review it.

In short, when we encountered a dependency for the second time, and the first time established an alternate `source`, but the second time did not (a case we allow for now even though it's maybe kind of a bad idea - #428), we weren't keeping track of that alternate source on the new bimodal identifier that was pushed into the unselected queue.

We have a new test case that now and only passes with the new change.