### PR TITLE
cmd/dep: always ensure that gps.SolveParameters are validated

### DIFF
--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -209,15 +209,8 @@ func (cmd *ensureCommand) runDefault(ctx *dep.Ctx, args []string, p *dep.Project
 		return errors.New("dep ensure only takes spec arguments with -add or -update")
 	}
 
-	if err := gps.ValidateParams(params, sm); err != nil {
-		if deduceErrs, ok := err.(gps.DeductionErrs); ok {
-			ctx.Err.Println("The following errors occurred while deducing packages:")
-			for ip, dErr := range deduceErrs {
-				ctx.Err.Printf("  * \"%s\": %s", ip, dErr)
-			}
-			ctx.Err.Println()
-		}
-		return errors.Wrap(err, "validateParams")
+	if err := ctx.ValidateParams(sm, params); err != nil {
+		return err
 	}
 
 	solver, err := gps.Prepare(params, sm)
@@ -298,6 +291,10 @@ func (cmd *ensureCommand) runVendorOnly(ctx *dep.Ctx, args []string, p *dep.Proj
 func (cmd *ensureCommand) runUpdate(ctx *dep.Ctx, args []string, p *dep.Project, sm gps.SourceManager, params gps.SolveParameters) error {
 	if p.Lock == nil {
 		return errors.Errorf("-update works by updating the versions recorded in %s, but %s does not exist", dep.LockName, dep.LockName)
+	}
+
+	if err := ctx.ValidateParams(sm, params); err != nil {
+		return err
 	}
 
 	// We'll need to discard this prepared solver as later work changes params,
@@ -385,6 +382,10 @@ func (cmd *ensureCommand) runUpdate(ctx *dep.Ctx, args []string, p *dep.Project,
 func (cmd *ensureCommand) runAdd(ctx *dep.Ctx, args []string, p *dep.Project, sm gps.SourceManager, params gps.SolveParameters) error {
 	if len(args) == 0 {
 		return errors.New("must specify at least one project or package to -add")
+	}
+
+	if err := ctx.ValidateParams(sm, params); err != nil {
+		return err
 	}
 
 	// We'll need to discard this prepared solver as later work changes params,

--- a/cmd/dep/init.go
+++ b/cmd/dep/init.go
@@ -164,6 +164,10 @@ func (cmd *initCommand) Run(ctx *dep.Ctx, args []string) error {
 		params.TraceLogger = ctx.Err
 	}
 
+	if err := ctx.ValidateParams(sm, params); err != nil {
+		return err
+	}
+
 	s, err := gps.Prepare(params, sm)
 	if err != nil {
 		return errors.Wrap(err, "prepare solver")

--- a/cmd/dep/status.go
+++ b/cmd/dep/status.go
@@ -284,6 +284,10 @@ func runStatusAll(ctx *dep.Ctx, out outputter, p *dep.Project, sm gps.SourceMana
 		params.TraceLogger = ctx.Err
 	}
 
+	if err := ctx.ValidateParams(sm, params); err != nil {
+		return digestMismatch, hasMissingPkgs, err
+	}
+
 	s, err := gps.Prepare(params, sm)
 	if err != nil {
 		return digestMismatch, hasMissingPkgs, errors.Errorf("could not set up solver for input hashing: %s", err)

--- a/context.go
+++ b/context.go
@@ -248,3 +248,19 @@ func (c *Ctx) AbsForImport(path string) (string, error) {
 	}
 	return posspath, nil
 }
+
+// ValidateParams ensure that solving can be completed with the specified params.
+func (c *Ctx) ValidateParams(sm gps.SourceManager, params gps.SolveParameters) error {
+	err := gps.ValidateParams(params, sm)
+	if err != nil {
+		if deduceErrs, ok := err.(gps.DeductionErrs); ok {
+			c.Err.Println("The following errors occurred while deducing packages:")
+			for ip, dErr := range deduceErrs {
+				c.Err.Printf("  * \"%s\": %s", ip, dErr)
+			}
+			c.Err.Println()
+		}
+	}
+
+	return errors.Wrap(err, "validateParams")
+}


### PR DESCRIPTION
Same as #697 

Ensure that we validate `gps.SolveParameters` in `dep init`, `dep status` and the new modes in `dep ensure`.