### PR TITLE
Allow invalid lock version to be added to the Q

### DIFF
--- a/internal/gps/solver.go
+++ b/internal/gps/solver.go
@@ -989,8 +989,8 @@ func (s *solver) getLockVersionIfValid(id ProjectIdentifier) (Version, error) {
 
 		if !found {
 			// No match found, which means we're going to be breaking the lock
+			// Still return the invalid version so that is included in the trace
 			s.b.breakLock()
-			return nil, nil
 		}
 	}
 


### PR DESCRIPTION
# What does this do / why do we need it?
When the version from the lock is immediately discarded due to not matching the constraint, nothing is logged and it's not clear that the lock was broken, or why. Allowing it be be added to the version queue lets it be evaluated first, traced and clearly show why it wasn't used.

I originally tried to log directly in `getLockVersionIfValid` but it caused the trace to look out of order, since that is called before the top level line is printed for the package being evaluated.

# What should your reviewer look out for in this PR?
I don't think so.

# Do you need help or clarification on anything?
I wasn't sure if there was an existing gps unit test/fixture I could piggy back on to validate this new behavior, short of testing the output in a harness test. If not, I'll add a harness test and just check the output.

# Which issue(s) does this PR fix?
This is related to #939, so that at least something is logged when the lock is broken.