### PR TITLE
Apply common validations to all import conversion unit tests

### DIFF
--- a/cmd/dep/glide_importer_test.go
+++ b/cmd/dep/glide_importer_test.go
@@ -174,7 +174,7 @@ func TestGlideConfig_Convert(t *testing.T) {
 			manifest, lock, convertErr := g.convert(testCase.projectRoot)
 			err := validateConvertTestCase(testCase.convertTestCase, manifest, lock, convertErr)
 			if err != nil {
-				t.Fatalf("%+v", err)
+				t.Fatalf("%#v", err)
 			}
 		})
 	}

--- a/cmd/dep/godep_importer_test.go
+++ b/cmd/dep/godep_importer_test.go
@@ -141,7 +141,7 @@ func TestGodepConfig_Convert(t *testing.T) {
 			manifest, lock, convertErr := g.convert(testCase.projectRoot)
 			err := validateConvertTestCase(testCase.convertTestCase, manifest, lock, convertErr)
 			if err != nil {
-				t.Fatalf("%+v", err)
+				t.Fatalf("%#v", err)
 			}
 		})
 	}

--- a/cmd/dep/root_analyzer_test.go
+++ b/cmd/dep/root_analyzer_test.go
@@ -171,14 +171,17 @@ type convertTestCase struct {
 // validateConvertTestCase returns an error if any of the importer's
 // conversion validations failed.
 func validateConvertTestCase(testCase *convertTestCase, manifest *dep.Manifest, lock *dep.Lock, convertErr error) error {
-	if convertErr != nil {
-		if testCase.wantConvertErr {
-			return nil
+	if testCase.wantConvertErr {
+		if convertErr == nil {
+			return errors.New("Expected the conversion to fail, but it did not return an error")
 		}
-
-		return convertErr
+		return nil
 	}
-	
+
+	if convertErr != nil {
+		return errors.Wrap(convertErr, "Expected the conversion to pass, but it returned an error")
+	}
+
 	// Ignored projects checks.
 	if len(manifest.Ignored) != testCase.wantIgnoreCount {
 		return errors.Errorf("Expected manifest to have %d ignored project(s), got %d",


### PR DESCRIPTION
### What does this do / why do we need it?
#897 took the first steps to standardize what all the importers test. This takes it a bit further so that each importer isn't re-implementing the validations. I also noticed a few properties weren't being validated consistently:

* Remove `matchVersionPair` flag and validate the cast anytime a `wantRevision` was specified.
* Always validate lock properties when a lock is generated.

Heads up: This will impact #978. 
