### PR TITLE
Fix missing branch in dep ensure -add: introduce hoist from lock

### DIFF
--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -7,6 +7,7 @@ package main
 import (
 	"bytes"
 	"flag"
+	"fmt"
 	"go/build"
 	"os"
 	"path/filepath"
@@ -587,14 +588,19 @@ func (cmd *ensureCommand) runAdd(ctx *dep.Ctx, args []string, p *dep.Project, sm
 
 		if instr.typ&isInManifest == 0 {
 			var pp gps.ProjectProperties
+			var found bool
 			for _, proj := range solution.Projects() {
 				// We compare just ProjectRoot instead of the whole
 				// ProjectIdentifier here because an empty source on the input side
 				// could have been converted into a source by the solver.
 				if proj.Ident().ProjectRoot == pr {
+					found = true
 					pp = getProjectPropertiesFromVersion(proj.Version())
 					break
 				}
+			}
+			if !found {
+				panic(fmt.Sprintf("unreachable: solution did not contain -add argument %s, but solver did not fail", pr))
 			}
 			pp.Source = instr.id.Source
 

--- a/cmd/dep/testdata/harness_tests/ensure/add/all-new-double/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/ensure/add/all-new-double/final/Gopkg.toml
@@ -2,3 +2,7 @@
 [[constraint]]
   name = "github.com/sdboyer/deptest"
   version = "1.0.0"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/sdboyer/deptesttres"

--- a/cmd/dep/testdata/harness_tests/ensure/add/all-new/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/ensure/add/all-new/final/Gopkg.toml
@@ -2,3 +2,7 @@
 [[constraint]]
   branch = "master"
   name = "github.com/sdboyer/deptesttres"
+
+[[constraint]]
+  name = "github.com/sdboyer/deptest"
+  version = "1.0.0"


### PR DESCRIPTION
### What does this do / why do we need it?

This completes a major bit of #489 that was missing - converting whatever's in the lock to a constraint that we can append into `Gopkg.toml` when no version constraint was given on the CLI.

### What should your reviewer look out for in this PR?

This was easier than i thought it would be. Have i missed something?