### PR TITLE
cmd/dep: make checkErrors more lenient

### DIFF
--- a/cmd/dep/testdata/harness_tests/ensure/pkg-errors/case1/testcase.json
+++ b/cmd/dep/testdata/harness_tests/ensure/pkg-errors/case1/testcase.json
@@ -3,6 +3,6 @@
     ["init", "-no-examples", "-skip-tools"],
     ["ensure", "-update"]
   ],
-  "error-expected": "all dirs lacked any go code",
+  "error-expected": "no dirs contained any Go code",
   "vendor-final": []
 }

--- a/cmd/dep/testdata/harness_tests/ensure/pkg-errors/case2/testcase.json
+++ b/cmd/dep/testdata/harness_tests/ensure/pkg-errors/case2/testcase.json
@@ -2,6 +2,6 @@
     "commands": [
         ["ensure"]
     ],
-    "error-expected": "Found 1 errors",
+    "error-expected": "found 1 errors",
     "vendor-final": []
 }


### PR DESCRIPTION
### What does this do / why do we need it?
`checkErrors` currently doesn't allow `dep ensure` to be used in a project that contains any Go files with build errors. This PR update `checkErrors` to return a warning instead of an error as long as the project contains some compilable Go files.

### What should your reviewer look out for in this PR?

Does this make sense?

### Do you need help or clarification on anything?

Why did we add that check in the first case?
### Which issue(s) does this PR fix?

Fixes #995