### PR TITLE
Protoype: allow constraint.source to be a sub-package of an repo

### DIFF
--- a/internal/gps/manager_test.go
+++ b/internal/gps/manager_test.go
@@ -354,14 +354,14 @@ func TestGetSources(t *testing.T) {
 			t.Run(lpi.normalizedSource(), func(t *testing.T) {
 				t.Parallel()
 
-				srcg, err := sm.srcCoord.getSourceGatewayFor(ctx, lpi)
+				srcg, _, err := sm.srcCoord.getSourceGatewayFor(ctx, lpi)
 				if err != nil {
 					t.Errorf("unexpected error setting up source: %s", err)
 					return
 				}
 
 				// Re-get the same, make sure they are the same
-				srcg2, err := sm.srcCoord.getSourceGatewayFor(ctx, lpi)
+				srcg2, _, err := sm.srcCoord.getSourceGatewayFor(ctx, lpi)
 				if err != nil {
 					t.Errorf("unexpected error re-getting source: %s", err)
 				} else if srcg != srcg2 {
@@ -370,7 +370,7 @@ func TestGetSources(t *testing.T) {
 
 				// All of them _should_ select https, so this should work
 				lpi.Source = "https://" + lpi.Source
-				srcg3, err := sm.srcCoord.getSourceGatewayFor(ctx, lpi)
+				srcg3, _, err := sm.srcCoord.getSourceGatewayFor(ctx, lpi)
 				if err != nil {
 					t.Errorf("unexpected error getting explicit https source: %s", err)
 				} else if srcg != srcg3 {
@@ -379,7 +379,7 @@ func TestGetSources(t *testing.T) {
 
 				// Now put in http, and they should differ
 				lpi.Source = "http://" + string(lpi.ProjectRoot)
-				srcg4, err := sm.srcCoord.getSourceGatewayFor(ctx, lpi)
+				srcg4, _, err := sm.srcCoord.getSourceGatewayFor(ctx, lpi)
 				if err != nil {
 					t.Errorf("unexpected error getting explicit http source: %s", err)
 				} else if srcg == srcg4 {

--- a/internal/gps/source_manager.go
+++ b/internal/gps/source_manager.go
@@ -382,7 +382,7 @@ func (sm *SourceMgr) GetManifestAndLock(id ProjectIdentifier, v Version, an Proj
 		return nil, nil, smIsReleased{}
 	}
 
-	srcg, err := sm.srcCoord.getSourceGatewayFor(context.TODO(), id)
+	srcg, _, err := sm.srcCoord.getSourceGatewayFor(context.TODO(), id)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -397,12 +397,13 @@ func (sm *SourceMgr) ListPackages(id ProjectIdentifier, v Version) (pkgtree.Pack
 		return pkgtree.PackageTree{}, smIsReleased{}
 	}
 
-	srcg, err := sm.srcCoord.getSourceGatewayFor(context.TODO(), id)
+	srcg, postfix, err := sm.srcCoord.getSourceGatewayFor(context.TODO(), id)
 	if err != nil {
 		return pkgtree.PackageTree{}, err
 	}
 
-	return srcg.listPackages(context.TODO(), id.ProjectRoot, v)
+	ret, err := srcg.listPackages(context.TODO(), postfix, id.ProjectRoot, v)
+	return ret, err
 }
 
 // ListVersions retrieves a list of the available versions for a given
@@ -422,7 +423,7 @@ func (sm *SourceMgr) ListVersions(id ProjectIdentifier) ([]PairedVersion, error)
 		return nil, smIsReleased{}
 	}
 
-	srcg, err := sm.srcCoord.getSourceGatewayFor(context.TODO(), id)
+	srcg, _, err := sm.srcCoord.getSourceGatewayFor(context.TODO(), id)
 	if err != nil {
 		// TODO(sdboyer) More-er proper-er errors
 		return nil, err
@@ -438,7 +439,7 @@ func (sm *SourceMgr) RevisionPresentIn(id ProjectIdentifier, r Revision) (bool, 
 		return false, smIsReleased{}
 	}
 
-	srcg, err := sm.srcCoord.getSourceGatewayFor(context.TODO(), id)
+	srcg, _, err := sm.srcCoord.getSourceGatewayFor(context.TODO(), id)
 	if err != nil {
 		// TODO(sdboyer) More-er proper-er errors
 		return false, err
@@ -454,7 +455,7 @@ func (sm *SourceMgr) SourceExists(id ProjectIdentifier) (bool, error) {
 		return false, smIsReleased{}
 	}
 
-	srcg, err := sm.srcCoord.getSourceGatewayFor(context.TODO(), id)
+	srcg, _, err := sm.srcCoord.getSourceGatewayFor(context.TODO(), id)
 	if err != nil {
 		return false, err
 	}
@@ -472,7 +473,7 @@ func (sm *SourceMgr) SyncSourceFor(id ProjectIdentifier) error {
 		return smIsReleased{}
 	}
 
-	srcg, err := sm.srcCoord.getSourceGatewayFor(context.TODO(), id)
+	srcg, _, err := sm.srcCoord.getSourceGatewayFor(context.TODO(), id)
 	if err != nil {
 		return err
 	}
@@ -487,7 +488,7 @@ func (sm *SourceMgr) ExportProject(id ProjectIdentifier, v Version, to string) e
 		return smIsReleased{}
 	}
 
-	srcg, err := sm.srcCoord.getSourceGatewayFor(context.TODO(), id)
+	srcg, _, err := sm.srcCoord.getSourceGatewayFor(context.TODO(), id)
 	if err != nil {
 		return err
 	}

--- a/internal/gps/source_test.go
+++ b/internal/gps/source_test.go
@@ -40,7 +40,7 @@ func testSourceGateway(t *testing.T) {
 			sc := newSourceCoordinator(superv, newDeductionCoordinator(superv), cachedir)
 
 			id := mkPI("github.com/sdboyer/deptest")
-			sg, err := sc.getSourceGatewayFor(ctx, id)
+			sg, _, err := sc.getSourceGatewayFor(ctx, id)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -123,7 +123,7 @@ func testSourceGateway(t *testing.T) {
 				t.Fatalf("wanted nonexistent err when passing bad version, got: %s", err)
 			}
 
-			_, err = sg.listPackages(ctx, ProjectRoot("github.com/sdboyer/deptest"), badver)
+			_, err = sg.listPackages(ctx, "", ProjectRoot("github.com/sdboyer/deptest"), badver)
 			if err == nil {
 				t.Fatal("wanted err on nonexistent version")
 			} else if err.Error() != wanterr.Error() {
@@ -150,7 +150,7 @@ func testSourceGateway(t *testing.T) {
 				},
 			}
 
-			ptree, err := sg.listPackages(ctx, ProjectRoot("github.com/sdboyer/deptest"), Revision("ff2948a2ac8f538c4ecd55962e919d1e13e74baf"))
+			ptree, err := sg.listPackages(ctx, "", ProjectRoot("github.com/sdboyer/deptest"), Revision("ff2948a2ac8f538c4ecd55962e919d1e13e74baf"))
 			if err != nil {
 				t.Fatalf("unexpected err when getting package tree with known rev: %s", err)
 			}
@@ -158,7 +158,7 @@ func testSourceGateway(t *testing.T) {
 				t.Fatalf("got incorrect PackageTree:\n\t(GOT): %#v\n\t(WNT): %#v", ptree, wantptree)
 			}
 
-			ptree, err = sg.listPackages(ctx, ProjectRoot("github.com/sdboyer/deptest"), NewVersion("v1.0.0"))
+			ptree, err = sg.listPackages(ctx, "", ProjectRoot("github.com/sdboyer/deptest"), NewVersion("v1.0.0"))
 			if err != nil {
 				t.Fatalf("unexpected err when getting package tree with unpaired good version: %s", err)
 			}

--- a/internal/gps/vcs_source.go
+++ b/internal/gps/vcs_source.go
@@ -84,13 +84,13 @@ func (bs *baseVCSSource) updateLocal(ctx context.Context) error {
 	return nil
 }
 
-func (bs *baseVCSSource) listPackages(ctx context.Context, pr ProjectRoot, r Revision) (ptree pkgtree.PackageTree, err error) {
+func (bs *baseVCSSource) listPackages(ctx context.Context, sourceRoot string, pr ProjectRoot, r Revision) (ptree pkgtree.PackageTree, err error) {
 	err = bs.repo.updateVersion(ctx, r.String())
 
 	if err != nil {
 		err = unwrapVcsErr(err)
 	} else {
-		ptree, err = pkgtree.ListPackages(bs.repo.LocalPath(), string(pr))
+		ptree, err = pkgtree.ListPackages(filepath.Join(bs.repo.LocalPath(), sourceRoot), string(pr))
 	}
 
 	return


### PR DESCRIPTION
This prototypes to have non-root packages as `constraint.source` values:

```
[[override]]
  name = "k8s.io/apimachinery"
  source = "github.com/sttts/k8s-dep-e2e/internal/_staging/k8s.io/apimachinery"
```

Compare https://github.com/fabulous-gopher/k8s-dep-e2e/pull/7 as an example repo.