### PR TITLE
Verify logger is non-nil in WriteDepTree

### DIFF
--- a/internal/gps/result.go
+++ b/internal/gps/result.go
@@ -66,7 +66,9 @@ func WriteDepTree(basedir string, l Lock, sm SourceManager, sv bool, logger *log
 	for _, p := range l.Projects() {
 		to := filepath.FromSlash(filepath.Join(basedir, string(p.Ident().ProjectRoot)))
 
-		logger.Printf("Writing out %s@%s", p.Ident().errString(), p.Version())
+		if logger != nil {
+			logger.Printf("Writing out %s@%s", p.Ident().errString(), p.Version())
+		}
 		err = sm.ExportProject(p.Ident(), p.Version(), to)
 		if err != nil {
 			removeAll(basedir)


### PR DESCRIPTION
### What does this do / why do we need it?

Only utilizes `logger` if non-nil in `gps.WriteDepTree`, fixes panic reported in #1003.

### What should your reviewer look out for in this PR?

### Do you need help or clarification on anything?

Does this need a test? As far as I can see, there's currently no tests for general log output.

### Which issue(s) does this PR fix?

Fixes #1003.