### PR TITLE
fix(status): print verbose messages

### DIFF
--- a/cmd/dep/status.go
+++ b/cmd/dep/status.go
@@ -10,6 +10,8 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"io/ioutil"
+	"log"
 	"sort"
 	"text/tabwriter"
 
@@ -316,8 +318,12 @@ func runStatusAll(ctx *dep.Ctx, out outputter, p *dep.Project, sm gps.SourceMana
 		Manifest:        p.Manifest,
 		// Locks aren't a part of the input hash check, so we can omit it.
 	}
+
+	logger := ctx.Err
 	if ctx.Verbose {
 		params.TraceLogger = ctx.Err
+	} else {
+		logger = log.New(ioutil.Discard, "", 0)
 	}
 
 	if err := ctx.ValidateParams(sm, params); err != nil {
@@ -344,7 +350,11 @@ func runStatusAll(ctx *dep.Ctx, out outputter, p *dep.Project, sm gps.SourceMana
 
 		out.BasicHeader()
 
+		logger.Println("Checking upstream projects:")
+
 		for _, proj := range slp {
+			logger.Println(proj.Ident().ProjectRoot)
+
 			bs := BasicStatus{
 				ProjectRoot:  string(proj.Ident().ProjectRoot),
 				PackageCount: len(proj.Packages()),


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].
-->

### What does this do / why do we need it?

Adds verbose messages to `status`. This is required to provide some feedback when the operation takes too long.

```
$ dep status -v
Checking upstream projects:
github.com/Masterminds/semver
github.com/Masterminds/vcs
github.com/armon/go-radix
github.com/go-yaml/yaml
github.com/nightlyone/lockfile
github.com/pelletier/go-buffruneio
github.com/pelletier/go-toml
github.com/pkg/errors
github.com/sdboyer/constext
...
```

### What should your reviewer look out for in this PR?

Verbose message. Maybe better wording?

### Do you need help or clarification on anything?

Anything else that we can log here?

### Which issue(s) does this PR fix?

Related to #1008 