### PR TITLE
 Correct the Gopkg.toml vs Gopkg.lock URL in FAQ.md: /docs is missing in the URL

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -372,4 +372,4 @@ stripping out nested `vendor` directories.
 
 ## How do I configure a dependency that doesn't tag its releases?
 
-Add a constraint to `Gopkg.toml` that specifies `branch: "master"` (or whichever branch you need) in the `[[constraint]]` for that dependency. `dep ensure` will determine the current revision of your dependency's master branch, and place it in `Gopkg.lock` for you. See also: [What is the difference between Gopkg.toml and Gopkg.lock?](https://github.com/golang/dep/blob/master/FAQ.md#what-is-the-difference-between-gopkgtoml-the-manifest-and-gopkglock-the-lock)
+Add a constraint to `Gopkg.toml` that specifies `branch: "master"` (or whichever branch you need) in the `[[constraint]]` for that dependency. `dep ensure` will determine the current revision of your dependency's master branch, and place it in `Gopkg.lock` for you. See also: [What is the difference between Gopkg.toml and Gopkg.lock?](https://github.com/golang/dep/blob/master/docs/FAQ.md#what-is-the-difference-between-gopkgtoml-the-manifest-and-gopkglock-the-lock)

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -372,4 +372,4 @@ stripping out nested `vendor` directories.
 
 ## How do I configure a dependency that doesn't tag its releases?
 
-Add a constraint to `Gopkg.toml` that specifies `branch: "master"` (or whichever branch you need) in the `[[constraint]]` for that dependency. `dep ensure` will determine the current revision of your dependency's master branch, and place it in `Gopkg.lock` for you. See also: [What is the difference between Gopkg.toml and Gopkg.lock?](https://github.com/golang/dep/blob/master/docs/FAQ.md#what-is-the-difference-between-gopkgtoml-the-manifest-and-gopkglock-the-lock)
+Add a constraint to `Gopkg.toml` that specifies `branch: "master"` (or whichever branch you need) in the `[[constraint]]` for that dependency. `dep ensure` will determine the current revision of your dependency's master branch, and place it in `Gopkg.lock` for you. See also: [What is the difference between Gopkg.toml and Gopkg.lock?](#what-is-the-difference-between-gopkgtoml-the-manifest-and-gopkglock-the-lock)


### PR DESCRIPTION
### What does this do / why do we need it?
Fixes the broken link in FAQ.md

### What should your reviewer look out for in this PR?
Just the doc URL.

### Do you need help or clarification on anything?
I think, this is the right path. 

### Which issue(s) does this PR fix?
This is a minor fix. But, feel free to let me know if I should create an issue for this.

Thanks. 
