### PR TITLE
[WIP] Respect canonical import comments

### DIFF
--- a/internal/gps/_testdata/src/canon_confl/a.go
+++ b/internal/gps/_testdata/src/canon_confl/a.go
@@ -1,0 +1,9 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package canonical // import "vanity1"
+
+var (
+	A = "A"
+)

--- a/internal/gps/_testdata/src/canon_confl/b.go
+++ b/internal/gps/_testdata/src/canon_confl/b.go
@@ -1,0 +1,9 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package canonical // import "vanity2"
+
+var (
+	B = "B"
+)

--- a/internal/gps/_testdata/src/canonical/main.go
+++ b/internal/gps/_testdata/src/canonical/main.go
@@ -1,0 +1,9 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pkg // import "canonical"
+
+var (
+	A = "A"
+)

--- a/internal/gps/_testdata/src/canonical/sub/sub.go
+++ b/internal/gps/_testdata/src/canonical/sub/sub.go
@@ -1,0 +1,5 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package sub // import "canonical/subpackage"

--- a/internal/gps/identifier.go
+++ b/internal/gps/identifier.go
@@ -41,10 +41,10 @@ import (
 type ProjectRoot string
 
 // A ProjectIdentifier provides the name and source location of a dependency. It
-// is related to, but differs in two keys ways from, an plain import path.
+// is related to, but differs in two key ways from, a plain import path.
 //
 // First, ProjectIdentifiers do not identify a single package. Rather, they
-// encompasses the whole tree of packages, including tree's root - the
+// encompass the whole tree of packages, including tree's root - the
 // ProjectRoot. In gps' current design, this ProjectRoot almost always
 // corresponds to the root of a repository.
 //

--- a/internal/gps/pkgtree/pkgtree.go
+++ b/internal/gps/pkgtree/pkgtree.go
@@ -157,13 +157,11 @@ func ListPackages(fileRoot, importRoot string) (PackageTree, error) {
 		// see any.
 		var lim []string
 		for _, imp := range append(pkg.Imports, pkg.TestImports...) {
-			switch {
-			// Do allow the single-dot, at least for now
-			case imp == "..":
-				lim = append(lim, imp)
-			case strings.HasPrefix(imp, "./"):
-				lim = append(lim, imp)
-			case strings.HasPrefix(imp, "../"):
+			if build.IsLocalImport(imp) {
+				// Do allow the single-dot, at least for now
+				if imp == "." {
+					continue
+				}
 				lim = append(lim, imp)
 			}
 		}

--- a/internal/gps/pkgtree/pkgtree.go
+++ b/internal/gps/pkgtree/pkgtree.go
@@ -318,7 +318,6 @@ var (
 	slashSlash = []byte("//")
 	slashStar  = []byte("/*")
 	starSlash  = []byte("*/")
-	newline    = []byte("\n")
 	importKwd  = []byte("import ")
 )
 

--- a/internal/gps/pkgtree/pkgtree.go
+++ b/internal/gps/pkgtree/pkgtree.go
@@ -155,10 +155,13 @@ func ListPackages(fileRoot, importRoot string) (PackageTree, error) {
 		}
 
 		if pkg.CommentPath != "" && !strings.HasPrefix(pkg.CommentPath, importRoot) {
-			return &NonCanonicalImportRoot{
-				ImportRoot: importRoot,
-				Canonical:  pkg.CommentPath,
+			ptree.Packages[ip] = PackageOrErr{
+				Err: &NonCanonicalImportRoot{
+					ImportRoot: importRoot,
+					Canonical:  pkg.CommentPath,
+				},
 			}
+			return nil
 		}
 
 		// This area has some...fuzzy rules, but check all the imports for
@@ -355,7 +358,7 @@ func findImportComment(pkgName *ast.Ident, c *ast.CommentGroup) string {
 }
 
 // ConflictingImportComments indicates that the package declares more than one
-// different canonical paths.
+// different canonical path.
 type ConflictingImportComments struct {
 	ImportPath     string
 	ImportComments []string
@@ -367,7 +370,7 @@ func (e *ConflictingImportComments) Error() string {
 }
 
 // NonCanonicalImportRoot reports the situation when the dependee imports a
-// package via something else that the package's declared canonical path.
+// package via something other than the package's declared canonical path.
 type NonCanonicalImportRoot struct {
 	ImportRoot string
 	Canonical  string

--- a/internal/gps/pkgtree/pkgtree_test.go
+++ b/internal/gps/pkgtree/pkgtree_test.go
@@ -1292,6 +1292,52 @@ func TestListPackages(t *testing.T) {
 				},
 			},
 		},
+		"canonical": {
+			fileRoot:   j("canonical"),
+			importRoot: "canonical",
+			out: PackageTree{
+				ImportRoot: "canonical",
+				Packages: map[string]PackageOrErr{
+					"canonical": {
+						P: Package{
+							ImportPath:  "canonical",
+							CommentPath: "canonical",
+							Name:        "pkg",
+							Imports:     []string{},
+						},
+					},
+					"canonical/sub": {
+						P: Package{
+							ImportPath:  "canonical/sub",
+							CommentPath: "canonical/subpackage",
+							Name:        "sub",
+							Imports:     []string{},
+						},
+					},
+				},
+			},
+		},
+		"conflicting canonical comments": {
+			fileRoot:   j("canon_confl"),
+			importRoot: "canon_confl",
+			out:        PackageTree{},
+			err: &ConflictingImportComments{
+				ImportPath: "canon_confl",
+				ImportComments: []string{
+					"vanity1",
+					"vanity2",
+				},
+			},
+		},
+		"non-canonical": {
+			fileRoot:   j("canonical"),
+			importRoot: "noncanonical",
+			out:        PackageTree{},
+			err: &NonCanonicalImportRoot{
+				ImportRoot: "noncanonical",
+				Canonical:  "canonical",
+			},
+		},
 	}
 
 	for name, fix := range table {

--- a/internal/gps/pkgtree/pkgtree_test.go
+++ b/internal/gps/pkgtree/pkgtree_test.go
@@ -1323,7 +1323,7 @@ func TestListPackages(t *testing.T) {
 			out:        PackageTree{},
 			err: &ConflictingImportComments{
 				ImportPath: "canon_confl",
-				ImportComments: []string{
+				ConflictingImportComments: []string{
 					"vanity1",
 					"vanity2",
 				},

--- a/internal/gps/pkgtree/pkgtree_test.go
+++ b/internal/gps/pkgtree/pkgtree_test.go
@@ -1332,10 +1332,22 @@ func TestListPackages(t *testing.T) {
 		"non-canonical": {
 			fileRoot:   j("canonical"),
 			importRoot: "noncanonical",
-			out:        PackageTree{},
-			err: &NonCanonicalImportRoot{
+			out: PackageTree{
 				ImportRoot: "noncanonical",
-				Canonical:  "canonical",
+				Packages: map[string]PackageOrErr{
+					"noncanonical": PackageOrErr{
+						Err: &NonCanonicalImportRoot{
+							ImportRoot: "noncanonical",
+							Canonical:  "canonical",
+						},
+					},
+					"noncanonical/sub": PackageOrErr{
+						Err: &NonCanonicalImportRoot{
+							ImportRoot: "noncanonical",
+							Canonical:  "canonical/subpackage",
+						},
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
### What does this do / why do we need it?

This adds capability to pkgtree to extract canonical import path comments from the packages. That will later be used as additional constraints when solving the dependencies (will come in a separate PR).

(And a couple unrelated typo fixes and code cleanups along the way)

### What should your reviewer look out for in this PR?

### Do you need help or clarification on anything?

I was wondering, at the very end of `ListPackages`, where the [package gets added to the `Packages` map](https://github.com/golang/dep/blob/master/internal/gps/pkgtree/pkgtree.go#L180), should I also add a copy with a canonical path key like blow? So that solver could see both versions available?

```go
if pkg.CommentPath != "" {
	ptree.Packages[pkg.CommentPath] = PackageOrErr{
		P: pkg,
	}
}
```

Also, is there a way to develop from my fork? Can't even get tests running:

```
$ go test $(go list ./internal/gps/pkgtree/...)
# github.com/rtfb/dep/internal/gps/pkgtree
internal/gps/pkgtree/pkgtree_test.go:20:2: use of internal package not allowed
FAIL	github.com/rtfb/dep/internal/gps/pkgtree [setup failed]
```

It works fine on the main golang/dep repo, but then transplanting pieces of code to another repo before committing is tedious.

### Which issue(s) does this PR fix?

This is phase 1 for issue #902.