### PR TITLE
dep: Add Manifest constructor

### DIFF
--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -603,9 +603,8 @@ func (cmd *ensureCommand) runAdd(ctx *dep.Ctx, args []string, p *dep.Project, sm
 
 	// Prep post-actions and feedback from adds.
 	var reqlist []string
-	appender := &dep.Manifest{
-		Constraints: make(gps.ProjectConstraints),
-	}
+	appender := dep.NewManifest()
+
 	for pr, instr := range addInstructions {
 		for path := range instr.ephReq {
 			reqlist = append(reqlist, path)

--- a/cmd/dep/glide_importer.go
+++ b/cmd/dep/glide_importer.go
@@ -141,9 +141,7 @@ func (g *glideImporter) convert(pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock, e
 	task.WriteString("...")
 	g.logger.Println(task)
 
-	manifest := &dep.Manifest{
-		Constraints: make(gps.ProjectConstraints),
-	}
+	manifest := dep.NewManifest()
 
 	for _, pkg := range append(g.yaml.Imports, g.yaml.TestImports...) {
 		pc, err := g.buildProjectConstraint(pkg)

--- a/cmd/dep/godep_importer.go
+++ b/cmd/dep/godep_importer.go
@@ -88,9 +88,7 @@ func (g *godepImporter) load(projectDir string) error {
 func (g *godepImporter) convert(pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock, error) {
 	g.logger.Println("Converting from Godeps.json ...")
 
-	manifest := &dep.Manifest{
-		Constraints: make(gps.ProjectConstraints),
-	}
+	manifest := dep.NewManifest()
 	lock := &dep.Lock{}
 
 	for _, pkg := range g.json.Imports {

--- a/cmd/dep/godep_importer_test.go
+++ b/cmd/dep/godep_importer_test.go
@@ -52,7 +52,6 @@ func TestGodepConfig_Convert(t *testing.T) {
 				},
 			},
 			convertTestCase: &convertTestCase{
-
 				projectRoot:    gps.ProjectRoot("github.com/sdboyer/deptest"),
 				wantConstraint: "^1.12.0-12-g2fd980e",
 				wantLockCount:  1,
@@ -70,7 +69,6 @@ func TestGodepConfig_Convert(t *testing.T) {
 				},
 			},
 			convertTestCase: &convertTestCase{
-
 				projectRoot:    gps.ProjectRoot("github.com/sdboyer/deptest"),
 				wantConstraint: "^1.0.0",
 				wantRevision:   gps.Revision("ff2948a2ac8f538c4ecd55962e919d1e13e74baf"),
@@ -83,7 +81,6 @@ func TestGodepConfig_Convert(t *testing.T) {
 				Imports: []godepPackage{{ImportPath: ""}},
 			},
 			convertTestCase: &convertTestCase{
-
 				wantConvertErr: true,
 			},
 		},
@@ -96,7 +93,6 @@ func TestGodepConfig_Convert(t *testing.T) {
 				},
 			},
 			convertTestCase: &convertTestCase{
-
 				wantConvertErr: true,
 			},
 		},
@@ -116,7 +112,6 @@ func TestGodepConfig_Convert(t *testing.T) {
 				},
 			},
 			convertTestCase: &convertTestCase{
-
 				projectRoot:    gps.ProjectRoot("github.com/sdboyer/deptest"),
 				wantLockCount:  1,
 				wantConstraint: "^1.0.0",

--- a/cmd/dep/gopath_scanner.go
+++ b/cmd/dep/gopath_scanner.go
@@ -52,10 +52,9 @@ func (g *gopathScanner) InitializeRootManifestAndLock(rootM *dep.Manifest, rootL
 		return err
 	}
 
-	g.origM = &dep.Manifest{
-		Constraints: g.pd.constraints,
-		Ovr:         make(gps.ProjectConstraints),
-	}
+	g.origM = dep.NewManifest()
+	g.origM.Constraints = g.pd.constraints
+
 	g.origL = &dep.Lock{
 		P: make([]gps.LockedProject, 0, len(g.pd.ondisk)),
 	}

--- a/cmd/dep/gopath_scanner_test.go
+++ b/cmd/dep/gopath_scanner_test.go
@@ -27,19 +27,14 @@ func TestGopathScanner_OverlayManifestConstraints(t *testing.T) {
 	v1 := gps.NewVersion("v1.0.0")
 	v2 := gps.NewVersion("v2.0.0")
 	v3 := gps.NewVersion("v3.0.0")
-	rootM := &dep.Manifest{
-		Constraints: gps.ProjectConstraints{
-			pi1.ProjectRoot: gps.ProjectProperties{Constraint: v1},
-		},
-	}
+	rootM := dep.NewManifest()
+	rootM.Constraints[pi1.ProjectRoot] = gps.ProjectProperties{Constraint: v1}
 	rootL := &dep.Lock{}
+	origM := dep.NewManifest()
+	origM.Constraints[pi1.ProjectRoot] = gps.ProjectProperties{Constraint: v2}
+	origM.Constraints[pi2.ProjectRoot] = gps.ProjectProperties{Constraint: v3}
 	gs := gopathScanner{
-		origM: &dep.Manifest{
-			Constraints: gps.ProjectConstraints{
-				pi1.ProjectRoot: gps.ProjectProperties{Constraint: v2},
-				pi2.ProjectRoot: gps.ProjectProperties{Constraint: v3},
-			},
-		},
+		origM: origM,
 		origL: &dep.Lock{},
 		ctx:   ctx,
 		pd: projectData{
@@ -79,7 +74,7 @@ func TestGopathScanner_OverlayLockProjects(t *testing.T) {
 	h := test.NewHelper(t)
 	ctx := newTestContext(h)
 
-	rootM := &dep.Manifest{}
+	rootM := dep.NewManifest()
 	pi1 := gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot(testProject1)}
 	pi2 := gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot(testProject2)}
 	v1 := gps.NewVersion("v1.0.0")
@@ -89,7 +84,7 @@ func TestGopathScanner_OverlayLockProjects(t *testing.T) {
 		P: []gps.LockedProject{gps.NewLockedProject(pi1, v1, []string{})},
 	}
 	gs := gopathScanner{
-		origM: &dep.Manifest{Constraints: make(gps.ProjectConstraints)},
+		origM: dep.NewManifest(),
 		origL: &dep.Lock{
 			P: []gps.LockedProject{
 				gps.NewLockedProject(pi1, v2, []string{}), // ignored, already exists in lock

--- a/cmd/dep/root_analyzer.go
+++ b/cmd/dep/root_analyzer.go
@@ -52,10 +52,7 @@ func (a *rootAnalyzer) InitializeRootManifestAndLock(dir string, pr gps.ProjectR
 	}
 
 	if rootM == nil {
-		rootM = &dep.Manifest{
-			Constraints: make(gps.ProjectConstraints),
-			Ovr:         make(gps.ProjectConstraints),
-		}
+		rootM = dep.NewManifest()
 	}
 	if rootL == nil {
 		rootL = &dep.Lock{}
@@ -88,7 +85,8 @@ func (a *rootAnalyzer) importManifestAndLock(dir string, pr gps.ProjectRoot, sup
 		}
 	}
 
-	var emptyManifest = &dep.Manifest{Constraints: make(gps.ProjectConstraints), Ovr: make(gps.ProjectConstraints)}
+	var emptyManifest = dep.NewManifest()
+
 	return emptyManifest, nil, nil
 }
 

--- a/cmd/dep/vndr_importer.go
+++ b/cmd/dep/vndr_importer.go
@@ -86,11 +86,9 @@ func (v *vndrImporter) loadVndrFile(dir string) error {
 
 func (v *vndrImporter) convert(pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock, error) {
 	var (
-		manifest = &dep.Manifest{
-			Constraints: make(gps.ProjectConstraints),
-		}
-		lock = &dep.Lock{}
-		err  error
+		manifest = dep.NewManifest()
+		lock     = &dep.Lock{}
+		err      error
 	)
 
 	for _, pkg := range v.packages {

--- a/cmd/dep/vndr_importer_test.go
+++ b/cmd/dep/vndr_importer_test.go
@@ -175,16 +175,13 @@ func TestVndrConfig_Import(t *testing.T) {
 
 	constraint, err := gps.NewSemverConstraint("^2.0.0")
 	h.Must(err)
-	wantM := &dep.Manifest{
-		Constraints: gps.ProjectConstraints{
-			"github.com/sdboyer/deptest": gps.ProjectProperties{
-				Source:     "https://github.com/sdboyer/deptest.git",
-				Constraint: gps.Revision("3f4c3bea144e112a69bbe5d8d01c1b09a544253f"),
-			},
-			"github.com/sdboyer/deptestdos": gps.ProjectProperties{
-				Constraint: constraint,
-			},
-		},
+	wantM := dep.NewManifest()
+	wantM.Constraints["github.com/sdboyer/deptest"] = gps.ProjectProperties{
+		Source:     "https://github.com/sdboyer/deptest.git",
+		Constraint: gps.Revision("3f4c3bea144e112a69bbe5d8d01c1b09a544253f"),
+	}
+	wantM.Constraints["github.com/sdboyer/deptestdos"] = gps.ProjectProperties{
+		Constraint: constraint,
 	}
 	if !reflect.DeepEqual(wantM, m) {
 		t.Errorf("unexpected manifest\nhave=%+v\nwant=%+v", m, wantM)

--- a/manifest.go
+++ b/manifest.go
@@ -51,6 +51,14 @@ type rawProject struct {
 	Source   string `toml:"source,omitempty"`
 }
 
+// NewManifest instantites a new manifest.
+func NewManifest() *Manifest {
+	return &Manifest{
+		Constraints: make(gps.ProjectConstraints),
+		Ovr:         make(gps.ProjectConstraints),
+	}
+}
+
 func validateManifest(s string) ([]error, error) {
 	var warns []error
 	// Load the TomlTree from string
@@ -172,12 +180,12 @@ func readManifest(r io.Reader) (*Manifest, []error, error) {
 }
 
 func fromRawManifest(raw rawManifest) (*Manifest, error) {
-	m := &Manifest{
-		Constraints: make(gps.ProjectConstraints, len(raw.Constraints)),
-		Ovr:         make(gps.ProjectConstraints, len(raw.Overrides)),
-		Ignored:     raw.Ignored,
-		Required:    raw.Required,
-	}
+	m := NewManifest()
+
+	m.Constraints = make(gps.ProjectConstraints, len(raw.Constraints))
+	m.Ovr = make(gps.ProjectConstraints, len(raw.Overrides))
+	m.Ignored = raw.Ignored
+	m.Required = raw.Required
 
 	for i := 0; i < len(raw.Constraints); i++ {
 		name, prj, err := toProject(raw.Constraints[i])

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -62,23 +62,18 @@ func TestWriteManifest(t *testing.T) {
 	golden := "manifest/golden.toml"
 	want := h.GetTestFileString(golden)
 	c, _ := gps.NewSemverConstraint("^0.12.0")
-	m := &Manifest{
-		Constraints: map[gps.ProjectRoot]gps.ProjectProperties{
-			gps.ProjectRoot("github.com/golang/dep/internal/gps"): {
-				Constraint: c,
-			},
-			gps.ProjectRoot("github.com/babble/brook"): {
-				Constraint: gps.Revision("d05d5aca9f895d19e9265839bffeadd74a2d2ecb"),
-			},
-		},
-		Ovr: map[gps.ProjectRoot]gps.ProjectProperties{
-			gps.ProjectRoot("github.com/golang/dep/internal/gps"): {
-				Source:     "https://github.com/golang/dep/internal/gps",
-				Constraint: gps.NewBranch("master"),
-			},
-		},
-		Ignored: []string{"github.com/foo/bar"},
+	m := NewManifest()
+	m.Constraints[gps.ProjectRoot("github.com/golang/dep/internal/gps")] = gps.ProjectProperties{
+		Constraint: c,
 	}
+	m.Constraints[gps.ProjectRoot("github.com/babble/brook")] = gps.ProjectProperties{
+		Constraint: gps.Revision("d05d5aca9f895d19e9265839bffeadd74a2d2ecb"),
+	}
+	m.Ovr[gps.ProjectRoot("github.com/golang/dep/internal/gps")] = gps.ProjectProperties{
+		Source:     "https://github.com/golang/dep/internal/gps",
+		Constraint: gps.NewBranch("master"),
+	}
+	m.Ignored = []string{"github.com/foo/bar"}
 
 	got, err := m.MarshalTOML()
 	if err != nil {

--- a/project_test.go
+++ b/project_test.go
@@ -62,10 +62,13 @@ func TestFindRoot(t *testing.T) {
 }
 
 func TestProjectMakeParams(t *testing.T) {
+	m := NewManifest()
+	m.Ignored = []string{"ignoring this"}
+
 	p := Project{
 		AbsRoot:    "someroot",
 		ImportRoot: gps.ProjectRoot("Some project root"),
-		Manifest:   &Manifest{Ignored: []string{"ignoring this"}},
+		Manifest:   m,
 		Lock:       &Lock{},
 	}
 


### PR DESCRIPTION
### What does this do / why do we need it?

The constructor will be used to ensure the prune variable is always set to prune nested `vendor/` dirs.

### What should your reviewer look out for in this PR?

Did I replace all initializations of `dep.Manifest`?

### Which issue(s) does this PR fix?

Breaking down #952