### PR TITLE
gps: source cache: interface tweaks and implementation optimizations

### DIFF
--- a/internal/gps/maybe_source.go
+++ b/internal/gps/maybe_source.go
@@ -112,7 +112,7 @@ func (m maybeGitSource) try(ctx context.Context, cachedir string, c singleSource
 		return nil, 0, err
 	}
 
-	c.storeVersionMap(vl, true)
+	c.setVersionMap(vl)
 	state := sourceIsSetUp | sourceExistsUpstream | sourceHasLatestVersionList
 
 	if r.CheckLocal() {
@@ -173,7 +173,7 @@ func (m maybeGopkginSource) try(ctx context.Context, cachedir string, c singleSo
 		return nil, 0, err
 	}
 
-	c.storeVersionMap(vl, true)
+	c.setVersionMap(vl)
 	state := sourceIsSetUp | sourceExistsUpstream | sourceHasLatestVersionList
 
 	if r.CheckLocal() {

--- a/internal/gps/source.go
+++ b/internal/gps/source.go
@@ -514,7 +514,7 @@ func (sg *sourceGateway) require(ctx context.Context, wanted sourceState) (errSt
 				})
 
 				if err == nil {
-					sg.cache.storeVersionMap(pvl, true)
+					sg.cache.setVersionMap(pvl)
 				}
 			case sourceHasLatestLocally:
 				err = sg.suprvsr.do(ctx, sg.src.sourceType(), ctSourceFetch, func(ctx context.Context) error {

--- a/internal/gps/source_cache.go
+++ b/internal/gps/source_cache.go
@@ -34,11 +34,10 @@ type singleSourceCache interface {
 	// Store the mappings between a set of PairedVersions' surface versions
 	// their corresponding revisions.
 	//
-	// If flush is true, the existing list of versions will be purged before
-	// writing. Revisions will have their pairings purged, but record of the
-	// revision existing will be kept, on the assumption that revisions are
-	// immutable and permanent.
-	storeVersionMap(versionList []PairedVersion, flush bool)
+	// The existing list of versions will be purged before writing. Revisions
+	// will have their pairings purged, but record of the revision existing will
+	// be kept, on the assumption that revisions are immutable and permanent.
+	setVersionMap(versionList []PairedVersion)
 
 	// Get the list of unpaired versions corresponding to the given revision.
 	getVersionsFor(Revision) ([]UnpairedVersion, bool)
@@ -135,20 +134,17 @@ func (c *singleSourceCacheMemory) getPackageTree(r Revision) (pkgtree.PackageTre
 	return ptree, has
 }
 
-func (c *singleSourceCacheMemory) storeVersionMap(versionList []PairedVersion, flush bool) {
+func (c *singleSourceCacheMemory) setVersionMap(versionList []PairedVersion) {
 	c.mut.Lock()
-	if flush {
-		// TODO(sdboyer) how do we handle cache consistency here - revs that may
-		// be out of date vis-a-vis the ptrees or infos maps?
-		for r := range c.rMap {
-			c.rMap[r] = nil
-		}
-
-		c.vMap = make(map[UnpairedVersion]Revision)
+	// TODO(sdboyer) how do we handle cache consistency here - revs that may
+	// be out of date vis-a-vis the ptrees or infos maps?
+	for r := range c.rMap {
+		c.rMap[r] = nil
 	}
 
-	for _, v := range versionList {
-		pv := v.(PairedVersion)
+	c.vMap = make(map[UnpairedVersion]Revision)
+
+	for _, pv := range versionList {
 		u, r := pv.Unpair(), pv.Revision()
 		c.vMap[u] = r
 		c.rMap[r] = append(c.rMap[r], u)
@@ -172,6 +168,9 @@ func (c *singleSourceCacheMemory) getVersionsFor(r Revision) ([]UnpairedVersion,
 }
 
 func (c *singleSourceCacheMemory) getAllVersions() []PairedVersion {
+	if len(c.vMap) == 0 {
+		return nil
+	}
 	vlist := make([]PairedVersion, 0, len(c.vMap))
 	for v, r := range c.vMap {
 		vlist = append(vlist, v.Pair(r))

--- a/internal/gps/source_cache_test.go
+++ b/internal/gps/source_cache_test.go
@@ -180,7 +180,7 @@ func TestSingleSourceCache(t *testing.T) {
 			NewVersion(ver).Pair(rev2),
 		}
 		SortPairedForDowngrade(versions)
-		c.storeVersionMap(versions, true)
+		c.setVersionMap(versions)
 
 		t.Run("getAllVersions", func(t *testing.T) {
 			got := c.getAllVersions()


### PR DESCRIPTION
### What does this do / why do we need it?

Changes a `singleSourceCache` method's signature from `storeVersionMap(versionList []PairedVersion, flush bool)` to `setVersionMap(versionList []PairedVersion)`, because all current usages flush and it simplifies the implementations (particularly for the persistent cache, since timestamps/TTLs come into play).

There are also some small related optimizations sprinkled in.

### What should your reviewer look out for in this PR?

Reasons to leave the `flush` parameter as is.

### Do you need help or clarification on anything?

Nope.

### Which issue(s) does this PR fix?

Related to #431 - Preparation for persistent cache.