### PR TITLE
gps: source: requirements tweak

### DIFF
--- a/internal/gps/source.go
+++ b/internal/gps/source.go
@@ -402,7 +402,7 @@ func (sg *sourceGateway) convertToRevision(ctx context.Context, v Version) (Revi
 
 	// The version list is out of date; it's possible this version might
 	// show up after loading it.
-	_, err := sg.require(ctx, sourceIsSetUp|sourceHasLatestVersionList|sourceHasLatestLocally)
+	_, err := sg.require(ctx, sourceIsSetUp|sourceHasLatestVersionList)
 	if err != nil {
 		return "", err
 	}
@@ -507,14 +507,16 @@ func (sg *sourceGateway) require(ctx context.Context, wanted sourceState) (errSt
 					}
 				}
 			case sourceHasLatestVersionList:
-				var pvl []PairedVersion
-				err = sg.suprvsr.do(ctx, sg.src.sourceType(), ctListVersions, func(ctx context.Context) error {
-					pvl, err = sg.src.listVersions(ctx)
-					return err
-				})
+				if len(sg.cache.getAllVersions()) == 0 {
+					var pvl []PairedVersion
+					err = sg.suprvsr.do(ctx, sg.src.sourceType(), ctListVersions, func(ctx context.Context) error {
+						pvl, err = sg.src.listVersions(ctx)
+						return err
+					})
 
-				if err == nil {
-					sg.cache.storeVersionMap(pvl, true)
+					if err == nil {
+						sg.cache.storeVersionMap(pvl, true)
+					}
 				}
 			case sourceHasLatestLocally:
 				err = sg.suprvsr.do(ctx, sg.src.sourceType(), ctSourceFetch, func(ctx context.Context) error {

--- a/internal/gps/source.go
+++ b/internal/gps/source.go
@@ -361,7 +361,7 @@ func (sg *sourceGateway) listPackages(ctx context.Context, pr ProjectRoot, v Ver
 			return pkgtree.PackageTree{}, err
 		}
 
-		err = sg.suprvsr.do(ctx, label, ctGetManifestAndLock, func(ctx context.Context) error {
+		err = sg.suprvsr.do(ctx, label, ctListPackages, func(ctx context.Context) error {
 			ptree, err = sg.src.listPackages(ctx, pr, r)
 			return err
 		})
@@ -507,16 +507,14 @@ func (sg *sourceGateway) require(ctx context.Context, wanted sourceState) (errSt
 					}
 				}
 			case sourceHasLatestVersionList:
-				if len(sg.cache.getAllVersions()) == 0 {
-					var pvl []PairedVersion
-					err = sg.suprvsr.do(ctx, sg.src.sourceType(), ctListVersions, func(ctx context.Context) error {
-						pvl, err = sg.src.listVersions(ctx)
-						return err
-					})
+				var pvl []PairedVersion
+				err = sg.suprvsr.do(ctx, sg.src.sourceType(), ctListVersions, func(ctx context.Context) error {
+					pvl, err = sg.src.listVersions(ctx)
+					return err
+				})
 
-					if err == nil {
-						sg.cache.setVersionMap(pvl)
-					}
+				if err == nil {
+					sg.cache.setVersionMap(pvl)
 				}
 			case sourceHasLatestLocally:
 				err = sg.suprvsr.do(ctx, sg.src.sourceType(), ctSourceFetch, func(ctx context.Context) error {


### PR DESCRIPTION
### What does this do / why do we need it?

Drops `convertToRevision`'s `sourceHasLatestLocally` requirement, and optimizes the `sourceHasLatestVersionList` requirement check. This should increase cache hits.

### What should your reviewer look out for in this PR?

Correctness.

### Which issue(s) does this PR fix?

Related to #431 