### PR TITLE
Guard against errs in stripVendor WalkFunc

### DIFF
--- a/internal/gps/result.go
+++ b/internal/gps/result.go
@@ -79,7 +79,10 @@ func WriteDepTree(basedir string, l Lock, sm SourceManager, sv bool, logger *log
 			}
 
 			if sv {
-				filepath.Walk(to, stripVendor)
+				err := filepath.Walk(to, stripVendor)
+				if err != nil {
+					errCh <- errors.Wrapf(err, "failed to strip vendor from %s", p.Ident().ProjectRoot)
+				}
 			}
 			wg.Done()
 		}(p)

--- a/internal/gps/result.go
+++ b/internal/gps/result.go
@@ -71,11 +71,13 @@ func WriteDepTree(basedir string, l Lock, sm SourceManager, sv bool, logger *log
 	for _, p := range l.Projects() {
 		wg.Add(1)
 		go func(p LockedProject) {
+			defer wg.Done()
 			to := filepath.FromSlash(filepath.Join(basedir, string(p.Ident().ProjectRoot)))
 			logger.Printf("Writing out %s@%s", p.Ident().errString(), p.Version())
 
 			if err := sm.ExportProject(p.Ident(), p.Version(), to); err != nil {
 				errCh <- errors.Wrapf(err, "failed to export %s", p.Ident().ProjectRoot)
+				return
 			}
 
 			if sv {
@@ -84,7 +86,7 @@ func WriteDepTree(basedir string, l Lock, sm SourceManager, sv bool, logger *log
 					errCh <- errors.Wrapf(err, "failed to strip vendor from %s", p.Ident().ProjectRoot)
 				}
 			}
-			wg.Done()
+			return
 		}(p)
 	}
 

--- a/internal/gps/result.go
+++ b/internal/gps/result.go
@@ -86,7 +86,6 @@ func WriteDepTree(basedir string, l Lock, sm SourceManager, sv bool, logger *log
 					errCh <- errors.Wrapf(err, "failed to strip vendor from %s", p.Ident().ProjectRoot)
 				}
 			}
-			return
 		}(p)
 	}
 

--- a/internal/gps/strip_vendor.go
+++ b/internal/gps/strip_vendor.go
@@ -12,7 +12,7 @@ import (
 )
 
 func stripVendor(path string, info os.FileInfo, err error) error {
-	if err != nil && err != filepath.SkipDir {
+	if err != nil {
 		return err
 	}
 

--- a/internal/gps/strip_vendor.go
+++ b/internal/gps/strip_vendor.go
@@ -17,20 +17,28 @@ func stripVendor(path string, info os.FileInfo, err error) error {
 	}
 
 	if info.Name() == "vendor" {
-		if _, err := os.Lstat(path); err == nil {
-			if (info.Mode() & os.ModeSymlink) != 0 {
-				realInfo, err := os.Stat(path)
-				if err != nil {
-					return err
-				}
-				if realInfo.IsDir() {
-					return os.Remove(path)
-				}
+		if _, err := os.Lstat(path); err != nil {
+			return err
+		}
+
+		if (info.Mode() & os.ModeSymlink) != 0 {
+			realInfo, err := os.Stat(path)
+			if err != nil {
+				return err
 			}
-			if info.IsDir() {
-				return removeAll(path)
+			if realInfo.IsDir() {
+				return os.Remove(path)
 			}
 		}
+
+		if info.IsDir() {
+			if err := removeAll(path); err != nil {
+				return err
+			}
+			return filepath.SkipDir
+		}
+
+		return nil
 	}
 
 	return nil

--- a/internal/gps/strip_vendor.go
+++ b/internal/gps/strip_vendor.go
@@ -6,9 +6,16 @@
 
 package gps
 
-import "os"
+import (
+	"os"
+	"path/filepath"
+)
 
 func stripVendor(path string, info os.FileInfo, err error) error {
+	if err != nil && err != filepath.SkipDir {
+		return err
+	}
+
 	if info.Name() == "vendor" {
 		if _, err := os.Lstat(path); err == nil {
 			if (info.Mode() & os.ModeSymlink) != 0 {

--- a/internal/gps/strip_vendor_windows.go
+++ b/internal/gps/strip_vendor_windows.go
@@ -10,6 +10,10 @@ import (
 )
 
 func stripVendor(path string, info os.FileInfo, err error) error {
+	if err != nil && err != filepath.SkipDir {
+		return err
+	}
+
 	if info.Name() == "vendor" {
 		if _, err := os.Lstat(path); err == nil {
 			symlink := (info.Mode() & os.ModeSymlink) != 0

--- a/internal/gps/strip_vendor_windows.go
+++ b/internal/gps/strip_vendor_windows.go
@@ -40,7 +40,10 @@ func stripVendor(path string, info os.FileInfo, err error) error {
 				}
 
 			case dir:
-				return removeAll(path)
+				if err := removeAll(path); err != nil {
+					return err
+				}
+				return filepath.SkipDir
 			}
 		}
 	}

--- a/internal/gps/strip_vendor_windows.go
+++ b/internal/gps/strip_vendor_windows.go
@@ -10,7 +10,7 @@ import (
 )
 
 func stripVendor(path string, info os.FileInfo, err error) error {
-	if err != nil && err != filepath.SkipDir {
+	if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].
-->

### What does this do / why do we need it?

defends against errors/panics in the `filepath.WalkFunc` we use to strip out vendor directories, `gps.stripVendor()`

### What should your reviewer look out for in this PR?


### Which issue(s) does this PR fix?

fixes #1022