### PR TITLE
internal/gps: Parse abbreviated git revisions

### DIFF
--- a/internal/gps/source.go
+++ b/internal/gps/source.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/Masterminds/vcs"
 	"github.com/golang/dep/internal/gps/pkgtree"
 )
 
@@ -451,16 +450,16 @@ func (sg *sourceGateway) revisionPresentIn(ctx context.Context, r Revision) (boo
 	return present, err
 }
 
-func (sg *sourceGateway) commitInfo(ctx context.Context, r Revision) (*vcs.CommitInfo, error) {
+func (sg *sourceGateway) disambiguateRevision(ctx context.Context, r Revision) (Revision, error) {
 	sg.mu.Lock()
 	defer sg.mu.Unlock()
 
 	_, err := sg.require(ctx, sourceIsSetUp|sourceExistsLocally)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
-	return sg.src.commitInfo(ctx, r)
+	return sg.src.disambiguateRevision(ctx, r)
 }
 
 func (sg *sourceGateway) sourceURL(ctx context.Context) (string, error) {
@@ -563,7 +562,7 @@ type source interface {
 	getManifestAndLock(context.Context, ProjectRoot, Revision, ProjectAnalyzer) (Manifest, Lock, error)
 	listPackages(context.Context, ProjectRoot, Revision) (pkgtree.PackageTree, error)
 	revisionPresentIn(Revision) (bool, error)
-	commitInfo(context.Context, Revision) (*vcs.CommitInfo, error)
+	disambiguateRevision(context.Context, Revision) (Revision, error)
 	exportRevisionTo(context.Context, Revision, string) error
 	sourceType() string
 }

--- a/internal/gps/source.go
+++ b/internal/gps/source.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/Masterminds/vcs"
 	"github.com/golang/dep/internal/gps/pkgtree"
 )
 
@@ -450,6 +451,18 @@ func (sg *sourceGateway) revisionPresentIn(ctx context.Context, r Revision) (boo
 	return present, err
 }
 
+func (sg *sourceGateway) commitInfo(ctx context.Context, r Revision) (*vcs.CommitInfo, error) {
+	sg.mu.Lock()
+	defer sg.mu.Unlock()
+
+	_, err := sg.require(ctx, sourceIsSetUp|sourceExistsLocally)
+	if err != nil {
+		return nil, err
+	}
+
+	return sg.src.commitInfo(ctx, r)
+}
+
 func (sg *sourceGateway) sourceURL(ctx context.Context) (string, error) {
 	sg.mu.Lock()
 	defer sg.mu.Unlock()
@@ -550,6 +563,7 @@ type source interface {
 	getManifestAndLock(context.Context, ProjectRoot, Revision, ProjectAnalyzer) (Manifest, Lock, error)
 	listPackages(context.Context, ProjectRoot, Revision) (pkgtree.PackageTree, error)
 	revisionPresentIn(Revision) (bool, error)
+	commitInfo(context.Context, Revision) (*vcs.CommitInfo, error)
 	exportRevisionTo(context.Context, Revision, string) error
 	sourceType() string
 }

--- a/internal/gps/source_manager.go
+++ b/internal/gps/source_manager.go
@@ -511,29 +511,11 @@ func (sm *SourceMgr) DeduceProjectRoot(ip string) (ProjectRoot, error) {
 }
 
 // InferConstraint tries to puzzle out what kind of version is given in a
-// string. Preference is given first for revisions, then branches, then semver
-// constraints, and then plain tags.
+// string. Preference is given first for branches, then semver constraints, then
+// plain tags, and then revisions.
 func (sm *SourceMgr) InferConstraint(s string, pi ProjectIdentifier) (Constraint, error) {
 	if s == "" {
 		return Any(), nil
-	}
-
-	// Bazaar has a three-component GUID separated by dashes. There should be two,
-	// but the email part could contain internal dashes.
-	if strings.Contains(s, "@") && strings.Count(s, "-") >= 2 {
-		// Work from the back to avoid potential confusion from the email
-		i3 := strings.LastIndex(s, "-")
-		// Skip if - is last char, otherwise this would panic on bounds err
-		if len(s) == i3+1 {
-			return NewVersion(s), nil
-		}
-
-		i2 := strings.LastIndex(s[:i3], "-")
-		if _, err := strconv.ParseUint(s[i2+1:i3], 10, 64); err == nil {
-			// Getting this far means it'd pretty much be nuts if it's not a
-			// bzr rev, so don't bother parsing the email.
-			return Revision(s), nil
-		}
 	}
 
 	// Lookup the string in the repository
@@ -570,6 +552,26 @@ func (sm *SourceMgr) InferConstraint(s string, pi ProjectIdentifier) (Constraint
 	r, err := sm.disambiguateRevision(context.TODO(), pi, Revision(s))
 	if err == nil {
 		return r, nil
+	}
+
+	// Bazaar revision
+	//
+	// Bazaar has a three-component GUID separated by dashes. There should be two,
+	// but the email part could contain internal dashes.
+	if strings.Contains(s, "@") && strings.Count(s, "-") >= 2 {
+		// Work from the back to avoid potential confusion from the email
+		i3 := strings.LastIndex(s, "-")
+		// Skip if - is last char, otherwise this would panic on bounds err
+		if len(s) == i3+1 {
+			return NewVersion(s), nil
+		}
+
+		i2 := strings.LastIndex(s[:i3], "-")
+		if _, err := strconv.ParseUint(s[i2+1:i3], 10, 64); err == nil {
+			// Getting this far means it'd pretty much be nuts if it's not a
+			// bzr rev, so don't bother parsing the email.
+			return Revision(s), nil
+		}
 	}
 
 	return nil, errors.Errorf("%s is not a valid version for the package %s(%s)", s, pi.ProjectRoot, pi.Source)

--- a/internal/gps/source_manager.go
+++ b/internal/gps/source_manager.go
@@ -583,9 +583,9 @@ func (sm *SourceMgr) InferConstraint(s string, pi ProjectIdentifier) (Constraint
 	if present, _ := sm.RevisionPresentIn(pi, Revision(s)); present {
 		srcg, err := sm.srcCoord.getSourceGatewayFor(context.TODO(), pi)
 		if err == nil {
-			ci, err := srcg.commitInfo(context.TODO(), Revision(s))
+			r, err := srcg.disambiguateRevision(context.TODO(), Revision(s))
 			if err == nil {
-				return Revision(ci.Commit), nil
+				return r, nil
 			}
 		}
 	}

--- a/internal/gps/source_manager.go
+++ b/internal/gps/source_manager.go
@@ -578,6 +578,18 @@ func (sm *SourceMgr) InferConstraint(s string, pi ProjectIdentifier) (Constraint
 		return version.Unpair(), nil
 	}
 
+	// Abbreviated git revision? If the string is present, there's a good shot of
+	// this.
+	if present, _ := sm.RevisionPresentIn(pi, Revision(s)); present {
+		srcg, err := sm.srcCoord.getSourceGatewayFor(context.TODO(), pi)
+		if err == nil {
+			ci, err := srcg.commitInfo(context.TODO(), Revision(s))
+			if err == nil {
+				return Revision(ci.Commit), nil
+			}
+		}
+	}
+
 	return nil, errors.Errorf("%s is not a valid version for the package %s(%s)", s, pi.ProjectRoot, pi.Source)
 }
 

--- a/internal/gps/source_manager.go
+++ b/internal/gps/source_manager.go
@@ -11,7 +11,6 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -552,26 +551,6 @@ func (sm *SourceMgr) InferConstraint(s string, pi ProjectIdentifier) (Constraint
 	r, err := sm.disambiguateRevision(context.TODO(), pi, Revision(s))
 	if err == nil {
 		return r, nil
-	}
-
-	// Bazaar revision
-	//
-	// Bazaar has a three-component GUID separated by dashes. There should be two,
-	// but the email part could contain internal dashes.
-	if strings.Contains(s, "@") && strings.Count(s, "-") >= 2 {
-		// Work from the back to avoid potential confusion from the email
-		i3 := strings.LastIndex(s, "-")
-		// Skip if - is last char, otherwise this would panic on bounds err
-		if len(s) == i3+1 {
-			return NewVersion(s), nil
-		}
-
-		i2 := strings.LastIndex(s[:i3], "-")
-		if _, err := strconv.ParseUint(s[i2+1:i3], 10, 64); err == nil {
-			// Getting this far means it'd pretty much be nuts if it's not a
-			// bzr rev, so don't bother parsing the email.
-			return Revision(s), nil
-		}
 	}
 
 	return nil, errors.Errorf("%s is not a valid version for the package %s(%s)", s, pi.ProjectRoot, pi.Source)

--- a/internal/gps/source_manager.go
+++ b/internal/gps/source_manager.go
@@ -6,7 +6,6 @@ package gps
 
 import (
 	"context"
-	"encoding/hex"
 	"fmt"
 	"os"
 	"os/signal"
@@ -519,24 +518,13 @@ func (sm *SourceMgr) InferConstraint(s string, pi ProjectIdentifier) (Constraint
 		return Any(), nil
 	}
 
-	slen := len(s)
-	if slen == 40 {
-		if _, err := hex.DecodeString(s); err == nil {
-			// Whether or not it's intended to be a SHA1 digest, this is a
-			// valid byte sequence for that, so go with Revision. This
-			// covers git and hg
-			return Revision(s), nil
-		}
-	}
-
-	// Next, try for bzr, which has a three-component GUID separated by
-	// dashes. There should be two, but the email part could contain
-	// internal dashes
+	// Bazaar has a three-component GUID separated by dashes. There should be two,
+	// but the email part could contain internal dashes.
 	if strings.Contains(s, "@") && strings.Count(s, "-") >= 2 {
 		// Work from the back to avoid potential confusion from the email
 		i3 := strings.LastIndex(s, "-")
 		// Skip if - is last char, otherwise this would panic on bounds err
-		if slen == i3+1 {
+		if len(s) == i3+1 {
 			return NewVersion(s), nil
 		}
 

--- a/internal/gps/source_manager_test.go
+++ b/internal/gps/source_manager_test.go
@@ -36,6 +36,8 @@ func TestSourceManager_InferConstraint(t *testing.T) {
 		"v0.12.0-12-de4dcafe0": svs,
 		"master":               NewBranch("master"),
 		"5b3352dc16517996fb951394bcbbe913a2a616e3": Revision("5b3352dc16517996fb951394bcbbe913a2a616e3"),
+		// abbreviated git ref
+		"3f4c3bea": Revision("3f4c3bea144e112a69bbe5d8d01c1b09a544253f"),
 
 		// valid bzr rev
 		"jess@linux.com-20161116211307-wiuilyamo9ian0m7": Revision("jess@linux.com-20161116211307-wiuilyamo9ian0m7"),

--- a/internal/gps/source_manager_test.go
+++ b/internal/gps/source_manager_test.go
@@ -14,8 +14,75 @@ import (
 func TestSourceManager_InferConstraint(t *testing.T) {
 	t.Parallel()
 
-	testcase := func(str string, pi ProjectIdentifier, want Constraint) func(*testing.T) {
-		return func(t *testing.T) {
+	// Used in git subtests:
+	v081, err := NewSemverConstraintIC("v0.8.1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	v012, err := NewSemverConstraintIC("v0.12.0-12-de4dcafe0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Used in hg and bzr subtests:
+	v1, err := NewSemverConstraintIC("v1.0.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var (
+		gitProj = ProjectIdentifier{ProjectRoot: "github.com/carolynvs/deptest"}
+		bzrProj = ProjectIdentifier{ProjectRoot: "launchpad.net/govcstestbzrrepo"}
+		hgProj  = ProjectIdentifier{ProjectRoot: "bitbucket.org/golang-dep/dep-test"}
+		svnProj = ProjectIdentifier{ProjectRoot: "bitbucket.org/golang-dep/dep-test"}
+
+		testcases = []struct {
+			project ProjectIdentifier
+			name    string
+			str     string
+			want    Constraint
+		}{
+			{gitProj, "empty", "", Any()},
+			{gitProj, "semver-short", "v0.8.1", v081},
+			{gitProj, "long semver constraint", "v0.12.0-12-de4dcafe0", v012},
+			{gitProj, "branch v2", "v2", NewBranch("v2")},
+			{gitProj, "branch master", "master", NewBranch("master")},
+			{gitProj, "long revision", "3f4c3bea144e112a69bbe5d8d01c1b09a544253f",
+				Revision("3f4c3bea144e112a69bbe5d8d01c1b09a544253f")},
+			{gitProj, "short revision", "3f4c3bea",
+				Revision("3f4c3bea144e112a69bbe5d8d01c1b09a544253f")},
+
+			{bzrProj, "empty", "", Any()},
+			{bzrProj, "semver", "v1.0.0", v1},
+			{bzrProj, "revision", "matt@mattfarina.com-20150731135137-pbphasfppmygpl68",
+				Revision("matt@mattfarina.com-20150731135137-pbphasfppmygpl68")},
+
+			{hgProj, "empty", "", Any()},
+			{hgProj, "semver", "v1.0.0", v1},
+			{hgProj, "default branch", "default", NewBranch("default")},
+			{hgProj, "revision", "6f55e1f03d91f8a7cce35d1968eb60a2352e4d59",
+				Revision("6f55e1f03d91f8a7cce35d1968eb60a2352e4d59")},
+			{hgProj, "short revision", "6f55e1f03d91",
+				Revision("6f55e1f03d91f8a7cce35d1968eb60a2352e4d59")},
+		}
+	)
+
+	for _, tc := range testcases {
+		var subtestName string
+		switch tc.project {
+		case gitProj:
+			subtestName = "git-" + tc.name
+		case bzrProj:
+			subtestName = "bzr-" + tc.name
+		case hgProj:
+			subtestName = "hg-" + tc.name
+		case svnProj:
+			subtestName = "svn-" + tc.name
+		default:
+			subtestName = tc.name
+		}
+
+		t.Run(subtestName, func(t *testing.T) {
 			t.Parallel()
 			h := test.NewHelper(t)
 			defer h.Cleanup()
@@ -26,69 +93,17 @@ func TestSourceManager_InferConstraint(t *testing.T) {
 			sm, err := NewSourceManager(h.Path(cacheDir))
 			h.Must(err)
 
-			got, err := sm.InferConstraint(str, pi)
+			got, err := sm.InferConstraint(tc.str, tc.project)
 			h.Must(err)
 
-			wantT := reflect.TypeOf(want)
+			wantT := reflect.TypeOf(tc.want)
 			gotT := reflect.TypeOf(got)
 			if wantT != gotT {
-				t.Errorf("expected type: %s, got %s, for input %s", wantT, gotT, str)
+				t.Errorf("expected type: %s, got %s, for input %s", wantT, gotT, tc.str)
 			}
-			if got.String() != want.String() {
-				t.Errorf("expected value: %s, got %s for input %s", want, got, str)
+			if got.String() != tc.want.String() {
+				t.Errorf("expected value: %s, got %s for input %s", tc.want, got, tc.str)
 			}
-		}
+		})
 	}
-
-	var (
-		gitProj = ProjectIdentifier{ProjectRoot: "github.com/carolynvs/deptest"}
-		bzrProj = ProjectIdentifier{ProjectRoot: "launchpad.net/govcstestbzrrepo"}
-		hgProj  = ProjectIdentifier{ProjectRoot: "bitbucket.org/golang-dep/dep-test"}
-	)
-
-	t.Run("git", func(t *testing.T) {
-		t.Parallel()
-		t.Run("empty", testcase("", gitProj, Any()))
-
-		v081, err := NewSemverConstraintIC("v0.8.1")
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		v012, err := NewSemverConstraintIC("v0.12.0-12-de4dcafe0")
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		t.Run("semver constraint", testcase("v0.8.1", gitProj, v081))
-		t.Run("long semver constraint", testcase("v0.12.0-12-de4dcafe0", gitProj, v012))
-		t.Run("branch v2", testcase("v2", gitProj, NewBranch("v2")))
-		t.Run("branch master", testcase("master", gitProj, NewBranch("master")))
-		t.Run("long revision", testcase("3f4c3bea144e112a69bbe5d8d01c1b09a544253f", gitProj, Revision("3f4c3bea144e112a69bbe5d8d01c1b09a544253f")))
-		t.Run("short revision", testcase("3f4c3bea", gitProj, Revision("3f4c3bea144e112a69bbe5d8d01c1b09a544253f")))
-	})
-
-	t.Run("bzr", func(t *testing.T) {
-		t.Parallel()
-		v1, err := NewSemverConstraintIC("v1.0.0")
-		if err != nil {
-			t.Fatal(err)
-		}
-		t.Run("empty", testcase("", bzrProj, Any()))
-		t.Run("semver", testcase("v1.0.0", bzrProj, v1))
-		t.Run("revision", testcase("matt@mattfarina.com-20150731135137-pbphasfppmygpl68", bzrProj, Revision("matt@mattfarina.com-20150731135137-pbphasfppmygpl68")))
-	})
-
-	t.Run("hg", func(t *testing.T) {
-		t.Parallel()
-		v1, err := NewSemverConstraintIC("v1.0.0")
-		if err != nil {
-			t.Fatal(err)
-		}
-		t.Run("empty", testcase("", hgProj, Any()))
-		t.Run("semver", testcase("v1.0.0", hgProj, v1))
-		t.Run("default branch", testcase("default", hgProj, NewBranch("default")))
-		t.Run("revision", testcase("6f55e1f03d91f8a7cce35d1968eb60a2352e4d59", hgProj, Revision("6f55e1f03d91f8a7cce35d1968eb60a2352e4d59")))
-		t.Run("short revision", testcase("6f55e1f03d91", hgProj, Revision("6f55e1f03d91f8a7cce35d1968eb60a2352e4d59")))
-	})
 }

--- a/internal/gps/source_manager_test.go
+++ b/internal/gps/source_manager_test.go
@@ -35,8 +35,7 @@ func TestSourceManager_InferConstraint(t *testing.T) {
 		"v2":     NewBranch("v2"),
 		"v0.12.0-12-de4dcafe0": svs,
 		"master":               NewBranch("master"),
-		"5b3352dc16517996fb951394bcbbe913a2a616e3": Revision("5b3352dc16517996fb951394bcbbe913a2a616e3"),
-		// abbreviated git ref
+		"3f4c3bea144e112a69bbe5d8d01c1b09a544253f": Revision("3f4c3bea144e112a69bbe5d8d01c1b09a544253f"),
 		"3f4c3bea": Revision("3f4c3bea144e112a69bbe5d8d01c1b09a544253f"),
 
 		// valid bzr rev

--- a/internal/gps/source_manager_test.go
+++ b/internal/gps/source_manager_test.go
@@ -34,7 +34,6 @@ func TestSourceManager_InferConstraint(t *testing.T) {
 		gitProj = ProjectIdentifier{ProjectRoot: "github.com/carolynvs/deptest"}
 		bzrProj = ProjectIdentifier{ProjectRoot: "launchpad.net/govcstestbzrrepo"}
 		hgProj  = ProjectIdentifier{ProjectRoot: "bitbucket.org/golang-dep/dep-test"}
-		svnProj = ProjectIdentifier{ProjectRoot: "bitbucket.org/golang-dep/dep-test"}
 
 		testcases = []struct {
 			project ProjectIdentifier
@@ -76,8 +75,6 @@ func TestSourceManager_InferConstraint(t *testing.T) {
 			subtestName = "bzr-" + tc.name
 		case hgProj:
 			subtestName = "hg-" + tc.name
-		case svnProj:
-			subtestName = "svn-" + tc.name
 		default:
 			subtestName = tc.name
 		}

--- a/internal/gps/vcs_source.go
+++ b/internal/gps/vcs_source.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver"
+	"github.com/Masterminds/vcs"
 	"github.com/golang/dep/internal/fs"
 	"github.com/golang/dep/internal/gps/pkgtree"
 )
@@ -38,6 +39,10 @@ func (bs *baseVCSSource) existsUpstream(ctx context.Context) bool {
 
 func (bs *baseVCSSource) upstreamURL() string {
 	return bs.repo.Remote()
+}
+
+func (bs *baseVCSSource) commitInfo(ctx context.Context, r Revision) (*vcs.CommitInfo, error) {
+	return bs.repo.CommitInfo(string(r))
 }
 
 func (bs *baseVCSSource) getManifestAndLock(ctx context.Context, pr ProjectRoot, r Revision, an ProjectAnalyzer) (Manifest, Lock, error) {

--- a/internal/gps/vcs_source.go
+++ b/internal/gps/vcs_source.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver"
-	"github.com/Masterminds/vcs"
 	"github.com/golang/dep/internal/fs"
 	"github.com/golang/dep/internal/gps/pkgtree"
 )
@@ -41,8 +40,12 @@ func (bs *baseVCSSource) upstreamURL() string {
 	return bs.repo.Remote()
 }
 
-func (bs *baseVCSSource) commitInfo(ctx context.Context, r Revision) (*vcs.CommitInfo, error) {
-	return bs.repo.CommitInfo(string(r))
+func (bs *baseVCSSource) disambiguateRevision(ctx context.Context, r Revision) (Revision, error) {
+	ci, err := bs.repo.CommitInfo(string(r))
+	if err != nil {
+		return "", err
+	}
+	return Revision(ci.Commit), nil
 }
 
 func (bs *baseVCSSource) getManifestAndLock(ctx context.Context, pr ProjectRoot, r Revision, an ProjectAnalyzer) (Manifest, Lock, error) {

--- a/internal/gps/vcs_source.go
+++ b/internal/gps/vcs_source.go
@@ -414,6 +414,21 @@ func (s *bzrSource) listVersions(ctx context.Context) ([]PairedVersion, error) {
 	return vlist, nil
 }
 
+func (s *bzrSource) disambiguateRevision(ctx context.Context, r Revision) (Revision, error) {
+	// If we used the default baseVCSSource behavior here, we would return the
+	// bazaar revision number, which is not a globally unique identifier - it is
+	// only unique within a branch. This is just the way that
+	// github.com/Masterminds/vcs chooses to handle bazaar. We want a
+	// disambiguated unique ID, though, so we need slightly different behavior:
+	// check whether r doesn't error when we try to look it up. If so, trust that
+	// it's a revision.
+	_, err := s.repo.CommitInfo(string(r))
+	if err != nil {
+		return "", err
+	}
+	return r, nil
+}
+
 // hgSource is a generic hg repository implementation that should work with
 // all standard mercurial servers.
 type hgSource struct {


### PR DESCRIPTION
### What does this do / why do we need it?
This changes the SourceManager's `InferConstraint` method to look up any revisions which are present in the source for a project. It does this as a last-gasp effort so that it doesn't prematurely expand a tag or a branch name into a precise commit. In practice, this means it will expand any abbreviated git commit identifiers.

While dep doesn't want to encourage the use of abbreviated git commit identifiers, they come up frequently when we parse vendoring specifiers (like glide.yaml) of existing projects. We should give a shot at parsing these and then expanding them to their unabbreviated form.

### What should your reviewer look out for in this PR?

It is totally possible that there are unintended consequences here. I don't know all the ways in which InferConstraint's output is used.

I also don't know anything about how caching plays in here. I haven't tried to cache anything.

### Which issue(s) does this PR fix?

Fixes #987 