### PR TITLE
Made command timeouts configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,15 @@ You might, for example, include a constraint in your manifest that specifies `ve
 * `0.2.3` becomes the range `>=0.2.3, <0.3.0`
 * `0.0.3` becomes the range `>=0.0.3, <0.1.0`
 
+## Timeouts
+
+`dep ensure` can sometime fail on very slow system due to underlying operations taking too long to perform. This is especially true on Windows due to filesystem issues.
+
+If the built-in timeouts are not suitable to your environment, you can override those by setting specific environment variables:
+
+* `DEP_EXPENSIVE_CMD_TIMEOUT`: Set the maximum number of seconds expensive operations can take. The default is 2 minutes (120 seconds).
+* `DEP_DEFAULT_CMD_TIMEOUT`: Set the maximum number of seconds common operations can take. The default is 10 seconds.
+
 ## Feedback
 
 Feedback is greatly appreciated.

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ You might, for example, include a constraint in your manifest that specifies `ve
 
 ## Timeouts
 
-`dep ensure` can sometime fail on very slow system due to underlying operations taking too long to perform. This is especially true on Windows due to filesystem issues.
+`dep ensure` can sometime fail on very slow system due to underlying operations taking too long to perform.
 
 If the built-in timeouts are not suitable to your environment, you can override those by setting specific environment variables:
 


### PR DESCRIPTION
### What does this do / why do we need it?

This PR allows users to override the various timeouts currently hard-coded within `dep`.

We noticed that some of our developers constantly hit the 10s default command timeout when issuing a `dep ensure -update` in our current development environment. Some developers with the same environment manage to get `dep ensure` to work, but we suspect they are very close to the 10s mark as well as the overrall command execution time is slow. It is unclear which commands exactly takes so long.

This happens mostly on Windows.

One solution would be to raise the default timeout but... what "magic" value should we use ? I suspect that even if we raised it to 30s, some other people would still have the issue on even slower systems. Hence the rationale of making it overridable with environment variables.

### What should your reviewer look out for in this PR?

It should not break the current behavior.

If a user sets `DEP_EXPENSIVE_CMD_TIMEOUT` or `DEP_DEFAULT_CMD_TIMEOUT`, `dep` honors these timeouts accordingly.

### Do you need help or clarification on anything?

Nope.

### Which issue(s) does this PR fix?

None.