### PR TITLE
status: adding counts to verbose output

### DIFF
--- a/cmd/dep/status.go
+++ b/cmd/dep/status.go
@@ -352,8 +352,8 @@ func runStatusAll(ctx *dep.Ctx, out outputter, p *dep.Project, sm gps.SourceMana
 
 		logger.Println("Checking upstream projects:")
 
-		for _, proj := range slp {
-			logger.Println(proj.Ident().ProjectRoot)
+		for i, proj := range slp {
+			logger.Printf("(%d/%d) %s\n", i+1, len(slp), proj.Ident().ProjectRoot)
 
 			bs := BasicStatus{
 				ProjectRoot:  string(proj.Ident().ProjectRoot),
@@ -427,6 +427,7 @@ func runStatusAll(ctx *dep.Ctx, out outputter, p *dep.Project, sm gps.SourceMana
 
 			out.BasicLine(&bs)
 		}
+		logger.Println()
 		out.BasicFooter()
 
 		return digestMismatch, hasMissingPkgs, nil


### PR DESCRIPTION
### What does this do / why do we need it?

Small tweak to verbose status output adding counts so that progress can be roughly monitored.
Before:
```
Checking upstream projects:
cloud.google.com/go
github.com/Azure/azure-sdk-for-go
... (many more projects)
gopkg.in/yaml.v2
honnef.co/go/tools
PROJECT ...
... (table)
```

After:
```
Checking upstream projects:
(1/129) cloud.google.com/go
(2/129) github.com/Azure/azure-sdk-for-go
... (many more projects)
(128/129) gopkg.in/yaml.v2
(129/129) honnef.co/go/tools

PROJECT ...
... (table)
```

### Which issue(s) does this PR fix?

Follow up from #1009, related to #1008
