### PR TITLE
init: more verbose logging

### DIFF
--- a/cmd/dep/init.go
+++ b/cmd/dep/init.go
@@ -133,9 +133,15 @@ func (cmd *initCommand) Run(ctx *dep.Ctx, args []string) error {
 	sm.UseDefaultSignalHandling()
 	defer sm.Release()
 
+	if ctx.Verbose {
+		ctx.Out.Println("Getting direct dependencies...")
+	}
 	pkgT, directDeps, err := getDirectDependencies(sm, p)
 	if err != nil {
 		return err
+	}
+	if ctx.Verbose {
+		ctx.Out.Printf("Checked %d directories for packages.\nFound %d direct dependencies.\n", len(pkgT.Packages), len(directDeps))
 	}
 
 	// Initialize with imported data, then fill in the gaps using the GOPATH


### PR DESCRIPTION
### What does this do / why do we need it?

This proposes some additional verbose logging for `init`. It fills in some of the downtime before the solver starts logging.

Example output (with fancy diff highlighting I just discovered):

```diff
dep init -v
+ Getting direct dependencies...
+ Checked 4407 directories for packages.
+ Found 39 direct dependencies.
Root project is "github.com/treeder/functions"
...
```

### What should your reviewer look out for in this PR?

Better log message/format ideas. Should we consider logging incrementally while scanning the directories as well?

### Which issue(s) does this PR fix?

I didn't see an issue for `init -v`, but #1008 covering `status -v` is related