### PR TITLE
ensure: tweaks to align no-vendor behavior and verbose/dry-run logging

### DIFF
--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -295,7 +295,7 @@ func (cmd *ensureCommand) runVendorOnly(ctx *dep.Ctx, args []string, p *dep.Proj
 	}
 
 	if cmd.dryRun {
-		return sw.PrintPreparedActions(ctx.Err, ctx.Verbose)
+		return sw.PrintPreparedActions(ctx.Out, ctx.Verbose)
 	}
 
 	logger := ctx.Err

--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -244,7 +244,7 @@ func (cmd *ensureCommand) runDefault(ctx *dep.Ctx, args []string, p *dep.Project
 		}
 
 		if cmd.dryRun {
-			return sw.PrintPreparedActions(ctx.Verbose, ctx.Out)
+			return sw.PrintPreparedActions(ctx.Out, ctx.Verbose)
 		}
 
 		logger := ctx.Err
@@ -269,7 +269,7 @@ func (cmd *ensureCommand) runDefault(ctx *dep.Ctx, args []string, p *dep.Project
 		return err
 	}
 	if cmd.dryRun {
-		return sw.PrintPreparedActions(ctx.Verbose, ctx.Out)
+		return sw.PrintPreparedActions(ctx.Out, ctx.Verbose)
 	}
 
 	logger := ctx.Err
@@ -295,7 +295,7 @@ func (cmd *ensureCommand) runVendorOnly(ctx *dep.Ctx, args []string, p *dep.Proj
 	}
 
 	if cmd.dryRun {
-		return sw.PrintPreparedActions(ctx.Verbose, ctx.Err)
+		return sw.PrintPreparedActions(ctx.Err, ctx.Verbose)
 	}
 
 	logger := ctx.Err
@@ -390,7 +390,7 @@ func (cmd *ensureCommand) runUpdate(ctx *dep.Ctx, args []string, p *dep.Project,
 		return err
 	}
 	if cmd.dryRun {
-		return sw.PrintPreparedActions(ctx.Verbose, ctx.Out)
+		return sw.PrintPreparedActions(ctx.Out, ctx.Verbose)
 	}
 
 	logger := ctx.Err
@@ -644,7 +644,7 @@ func (cmd *ensureCommand) runAdd(ctx *dep.Ctx, args []string, p *dep.Project, sm
 	}
 
 	if cmd.dryRun {
-		return sw.PrintPreparedActions(ctx.Verbose, ctx.Out)
+		return sw.PrintPreparedActions(ctx.Out, ctx.Verbose)
 	}
 
 	logger := ctx.Err

--- a/txn_writer.go
+++ b/txn_writer.go
@@ -418,7 +418,7 @@ fail:
 }
 
 // PrintPreparedActions logs the actions a call to Write would perform.
-func (sw *SafeWriter) PrintPreparedActions(verbose bool, output *log.Logger) error {
+func (sw *SafeWriter) PrintPreparedActions(output *log.Logger, verbose bool) error {
 	if sw.HasManifest() {
 		if verbose {
 			m, err := sw.Manifest.MarshalTOML()
@@ -443,15 +443,12 @@ func (sw *SafeWriter) PrintPreparedActions(verbose bool, output *log.Logger) err
 				output.Printf("Would have written %s.\n", LockName)
 			}
 		} else {
-			if verbose {
-				diff, err := formatLockDiff(*sw.lockDiff)
-				if err != nil {
-					return errors.Wrap(err, "ensure DryRun cannot serialize the lock diff")
-				}
-				output.Printf("Would have written the following changes to %s:\n%s\n", LockName, diff)
-			} else {
-				output.Printf("Would have written changes to %s.\n", LockName)
+			output.Printf("Would have written the following changes to %s:\n", LockName)
+			diff, err := formatLockDiff(*sw.lockDiff)
+			if err != nil {
+				return errors.Wrap(err, "ensure DryRun cannot serialize the lock diff")
 			}
+			output.Println(diff)
 		}
 	}
 


### PR DESCRIPTION
### What does this do / why do we need it?

This PR proposes a few tweaks to the `ensure` command, which intend only to increase consistency and orthogonality:
- log about synced lock file sooner (so included regardless of `no-vendor`)
- respect `no-vendor` even if the lock file was not already synced
- align `dry-run` logging via `PrintPreparedActions` usages
- modify `PrintPreparedActions` to handle verbosity

### What should your reviewer look out for in this PR?

Oversights, better log messages.