### PR TITLE
vendor directory writes: add counts to verbose logging, limits writers, abort on error

### DIFF
--- a/internal/gps/identifier.go
+++ b/internal/gps/identifier.go
@@ -148,6 +148,10 @@ func (i ProjectIdentifier) errString() string {
 	return fmt.Sprintf("%s (from %s)", i.ProjectRoot, i.Source)
 }
 
+func (i ProjectIdentifier) String() string {
+	return i.errString()
+}
+
 func (i ProjectIdentifier) normalize() ProjectIdentifier {
 	if i.Source == "" {
 		i.Source = string(i.ProjectRoot)

--- a/internal/gps/result.go
+++ b/internal/gps/result.go
@@ -9,7 +9,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -47,6 +46,8 @@ type solution struct {
 	solv Solver
 }
 
+const concurrentWriters = 16
+
 // WriteDepTree takes a basedir and a Lock, and exports all the projects
 // listed in the lock to the appropriate target location within the basedir.
 //
@@ -82,7 +83,7 @@ func WriteDepTree(basedir string, l Lock, sm SourceManager, sv bool, logger *log
 	}
 	close(writeCh)
 	// Launch writers.
-	writers := runtime.GOMAXPROCS(-1)
+	writers := concurrentWriters
 	if len(lps) < writers {
 		writers = len(lps)
 	}

--- a/txn_writer.go
+++ b/txn_writer.go
@@ -455,8 +455,9 @@ func (sw *SafeWriter) PrintPreparedActions(output *log.Logger, verbose bool) err
 	if sw.writeVendor {
 		if verbose {
 			output.Printf("Would have written the following %d projects to the vendor directory:\n", len(sw.lock.Projects()))
-			for _, project := range sw.lock.Projects() {
-				output.Println(project)
+			lps := sw.lock.Projects()
+			for i, p := range lps {
+				output.Printf("(%d/%d) %s@%s\n", i+1, len(lps), p.Ident(), p.Version())
 			}
 		} else {
 			output.Printf("Would have written %d projects to the vendor directory.\n", len(sw.lock.Projects()))


### PR DESCRIPTION
### What does this do / why do we need it?

This change adds counts to some of the verbose logging lists:
1) `dry-run` vendor directories (`Would have written..`)
2) normal run vendor directories (`Wrote...`/`Failed to write...`, previously logged `Writing...` prior to work)
3) normal run vendor errors list (`Failed to write dep tree...`)

2 is concurrent and I/O limited, so this should help communicate progress to the user. 1 and 3 log immediately, but I still think the count/total is valuable for reference, grouping, and just scrolling through a really long list.

Example:
```
...
(46/84) Wrote github.com/pelletier/go-buffruneio@v0.2.0
(47/84) Wrote github.com/go-openapi/validate@master
(48/84) Wrote github.com/golang/groupcache@master
(49/84) Wrote github.com/go-openapi/analysis@master
(50/84) Wrote github.com/sirupsen/logrus@v1.0.3
(51/84) Wrote github.com/gorilla/mux@v1.4.0
(52/84) Wrote github.com/cactus/go-statsd-client@v3.1.0
(53/84) Wrote github.com/urfave/cli@v1.20.0
(54/84) Wrote github.com/spf13/afero@master
...
```

Edit: Second commit refactors the concurrency for limiting writers and aborting on error.


### What should your reviewer look out for in this PR?

- concurrency simplifications
- better logs messages 
- more places to add counts

### Which issue(s) does this PR fix?

Follow up from #1037 