### PR TITLE
Don't assume every git repository has a HEAD

### DIFF
--- a/internal/gps/vcs_source.go
+++ b/internal/gps/vcs_source.go
@@ -201,15 +201,18 @@ func (s *gitSource) listVersions(ctx context.Context) (vlist []PairedVersion, er
 	//
 	// If all of those conditions are met, then the user would end up with an
 	// erroneous non-default branch in their lock file.
-	headrev := Revision(all[0][:40])
+	var headrev Revision
 	var onedef, multidef, defmaster bool
 
 	smap := make(map[string]bool)
 	uniq := 0
-	vlist = make([]PairedVersion, len(all)-1) // less 1, because always ignore HEAD
+	vlist = make([]PairedVersion, len(all))
 	for _, pair := range all {
 		var v PairedVersion
-		if string(pair[46:51]) == "heads" {
+		if string(pair[41:]) == "HEAD" {
+			// If HEAD is present, it's always first
+			headrev = Revision(pair[:40])
+		} else if string(pair[46:51]) == "heads" {
 			rev := Revision(pair[:40])
 
 			isdef := rev == headrev

--- a/internal/gps/vcs_source_test.go
+++ b/internal/gps/vcs_source_test.go
@@ -548,8 +548,7 @@ func TestGitSourceListVersionsNoHEAD(t *testing.T) {
 	un := "file://" + repoPath
 	u, err := url.Parse(un)
 	if err != nil {
-		t.Errorf("URL was bad, lolwut? errtext: %s", err)
-		return
+		t.Fatalf("Error parsing URL %s: %s", un, err)
 	}
 	mb := maybeGitSource{u}
 
@@ -557,26 +556,26 @@ func TestGitSourceListVersionsNoHEAD(t *testing.T) {
 	superv := newSupervisor(ctx)
 	isrc, _, err := mb.try(ctx, cpath, newMemoryCache(), superv)
 	if err != nil {
-		t.Fatalf("unexpected error while setting up gitSource for test repo: %s", err)
+		t.Fatalf("Unexpected error while setting up gitSource for test repo: %s", err)
 	}
 
 	err = isrc.initLocal(ctx)
 	if err != nil {
-		t.Fatalf("error on cloning git repo: %s", err)
+		t.Fatalf("Error on cloning git repo: %s", err)
 	}
 
 	src, ok := isrc.(*gitSource)
 	if !ok {
-		t.Fatalf("expected a gitSource, got a %T", isrc)
+		t.Fatalf("Expected a gitSource, got a %T", isrc)
 	}
 
 	pvlist, err := src.listVersions(ctx)
 	if err != nil {
-		t.Fatalf("unexpected error getting version pairs from git repo: %s", err)
+		t.Fatalf("Unexpected error getting version pairs from git repo: %s", err)
 	}
 
 	if len(pvlist) != 1 {
-		t.Errorf("expected 1 version pair from listVersions(), got %d", len(pvlist))
+		t.Errorf("Unexpected version pair length:\n\t(GOT): %d\n\t(WNT): %d", len(pvlist), 1)
 	}
 }
 

--- a/internal/gps/vcs_source_test.go
+++ b/internal/gps/vcs_source_test.go
@@ -538,7 +538,7 @@ func TestGitSourceListVersionsNoHEAD(t *testing.T) {
 
 	// Create test repo with a single commit on the master branch
 	h.RunGit(repoPath, "init")
-	h.RunGit(repoPath, "commit", "--allow-empty", `--message="Initial commit"`)
+	h.RunGit(repoPath, "commit", "--allow-empty", `--message="Initial commit"`, `--author="Test author <test@example.com>"`)
 
 	// Make HEAD point at a nonexistent branch (deleting it is not allowed)
 	// The `git ls-remote` that listVersions() calls will not return a HEAD ref

--- a/internal/gps/vcs_source_test.go
+++ b/internal/gps/vcs_source_test.go
@@ -524,7 +524,7 @@ func testHgSourceInteractions(t *testing.T) {
 	<-donech
 }
 
-func Test_gitSource_listVersions_noHEAD(t *testing.T) {
+func TestGitSourceListVersionsNoHEAD(t *testing.T) {
 	t.Parallel()
 
 	requiresBins(t, "git")

--- a/internal/gps/vcs_source_test.go
+++ b/internal/gps/vcs_source_test.go
@@ -538,7 +538,9 @@ func TestGitSourceListVersionsNoHEAD(t *testing.T) {
 
 	// Create test repo with a single commit on the master branch
 	h.RunGit(repoPath, "init")
-	h.RunGit(repoPath, "commit", "--allow-empty", `--message="Initial commit"`, `--author="Test author <test@example.com>"`)
+	h.RunGit(repoPath, "config", "--local", "user.email", "test@example.com")
+	h.RunGit(repoPath, "config", "--local", "user.name", "Test author")
+	h.RunGit(repoPath, "commit", "--allow-empty", `--message="Initial commit"`)
 
 	// Make HEAD point at a nonexistent branch (deleting it is not allowed)
 	// The `git ls-remote` that listVersions() calls will not return a HEAD ref

--- a/internal/gps/vcs_source_test.go
+++ b/internal/gps/vcs_source_test.go
@@ -547,7 +547,7 @@ func TestGitSourceListVersionsNoHEAD(t *testing.T) {
 	// because it points at a nonexistent branch
 	h.RunGit(repoPath, "symbolic-ref", "HEAD", "refs/heads/nonexistent")
 
-	un := "file://" + repoPath
+	un := "file://" + filepath.ToSlash(repoPath)
 	u, err := url.Parse(un)
 	if err != nil {
 		t.Fatalf("Error parsing URL %s: %s", un, err)


### PR DESCRIPTION
### What does this do / why do we need it?

The code that determines the versions of a git repository assumes that all git repositories have a `HEAD`. It panics when this is not the case.

### What should your reviewer look out for in this PR?

Not sure if the big comment block above the changes should be edited.

### Do you need help or clarification on anything?

Is using the zero value of `Revision` like this okay?

### Which issue(s) does this PR fix?

Fixes #1051, Fixes #1112 