### PR TITLE
cmd/dep: fix vndr importpath validation

### DIFF
--- a/cmd/dep/vndr_importer.go
+++ b/cmd/dep/vndr_importer.go
@@ -92,6 +92,12 @@ func (v *vndrImporter) convert(pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock, er
 	)
 
 	for _, pkg := range v.packages {
+		// ImportPath must not be empty
+		if pkg.importPath == "" {
+			err := errors.New("Invalid vndr configuration, missing import path")
+			return nil, nil, err
+		}
+
 		pc := gps.ProjectConstraint{
 			Ident: gps.ProjectIdentifier{
 				ProjectRoot: gps.ProjectRoot(pkg.importPath),


### PR DESCRIPTION
### What does this do / why do we need it?
#1013 found a bug in the validation for our vndr importer.  It was relying on a later function erroring out when no import path is present in the config file, instead of explicitly checking for it.

### What should your reviewer look out for in this PR?
This is small and is blocking another PR, so I'm going to merge myself once the tests pass.

### Do you need help or clarification on anything?
Nope.

### Which issue(s) does this PR fix?
Unblocks #1013
