### PR TITLE
cmd/dep: fix vndrImporter's rev->constraint logic

### DIFF
--- a/cmd/dep/glide_importer_test.go
+++ b/cmd/dep/glide_importer_test.go
@@ -88,6 +88,7 @@ func TestGlideConfig_Convert(t *testing.T) {
 				wantLockCount:  1,
 				wantConstraint: "^1.0.0",
 				wantVersion:    "v1.0.0",
+				wantRevision:   "ff2948a2ac8f538c4ecd55962e919d1e13e74baf",
 			},
 		},
 		"revision only": {
@@ -110,6 +111,7 @@ func TestGlideConfig_Convert(t *testing.T) {
 				projectRoot:   "github.com/sdboyer/deptest",
 				wantLockCount: 1,
 				wantRevision:  gps.Revision("ff2948a2ac8f538c4ecd55962e919d1e13e74baf"),
+				wantVersion:   "v1.0.0",
 			},
 		},
 		"with ignored package": {

--- a/cmd/dep/godep_importer_test.go
+++ b/cmd/dep/godep_importer_test.go
@@ -56,6 +56,7 @@ func TestGodepConfig_Convert(t *testing.T) {
 				wantConstraint: "^1.12.0-12-g2fd980e",
 				wantLockCount:  1,
 				wantVersion:    "v1.0.0",
+				wantRevision:   "ff2948a2ac8f538c4ecd55962e919d1e13e74baf",
 			},
 		},
 		"empty comment": {
@@ -116,6 +117,7 @@ func TestGodepConfig_Convert(t *testing.T) {
 				wantLockCount:  1,
 				wantConstraint: "^1.0.0",
 				wantVersion:    "v1.0.0",
+				wantRevision:   "ff2948a2ac8f538c4ecd55962e919d1e13e74baf",
 			},
 		},
 	}

--- a/cmd/dep/root_analyzer.go
+++ b/cmd/dep/root_analyzer.go
@@ -173,6 +173,22 @@ func (a *rootAnalyzer) Info() gps.ProjectAnalyzerInfo {
 	}
 }
 
+// isVersion determines if the specified value is a version/tag in the project.
+func isVersion(pi gps.ProjectIdentifier, value string, sm gps.SourceManager) (bool, gps.Version, error) {
+	versions, err := sm.ListVersions(pi)
+	if err != nil {
+		return false, nil, errors.Wrapf(err, "list versions for %s(%s)", pi.ProjectRoot, pi.Source) // means repo does not exist
+	}
+
+	for _, version := range versions {
+		if value == version.String() {
+			return true, version, nil
+		}
+	}
+
+	return false, nil, nil
+}
+
 // lookupVersionForLockedProject figures out the appropriate version for a locked
 // project based on the locked revision and the constraint from the manifest.
 // First try matching the revision to a version, then try the constraint from the

--- a/cmd/dep/root_analyzer.go
+++ b/cmd/dep/root_analyzer.go
@@ -181,6 +181,10 @@ func isVersion(pi gps.ProjectIdentifier, value string, sm gps.SourceManager) (bo
 	}
 
 	for _, version := range versions {
+		if version.Type() != gps.IsVersion && version.Type() != gps.IsSemver {
+			continue
+		}
+
 		if value == version.String() {
 			return true, version, nil
 		}

--- a/cmd/dep/root_analyzer_test.go
+++ b/cmd/dep/root_analyzer_test.go
@@ -179,11 +179,11 @@ func TestIsVersion(t *testing.T) {
 			h.Must(err)
 
 			if testcase.wantIsVersion != gotIsVersion {
-				t.Fatalf("Expected isVersion for %s to be %t", value, testcase.wantIsVersion)
+				t.Fatalf("unexpected isVersion result for %s: \n\t(GOT) %v \n\t(WNT) %v", value, gotIsVersion, testcase.wantIsVersion)
 			}
 
 			if testcase.wantVersion != gotVersion {
-				t.Fatalf("Expected version for %s to be %s, got %s", value, testcase.wantVersion, gotVersion)
+				t.Fatalf("unexpected version for %s: \n\t(GOT) %v \n\t(WNT) %v", value, testcase.wantVersion, gotVersion)
 			}
 		})
 	}
@@ -277,12 +277,12 @@ func validateConvertTestCase(testCase *convertTestCase, manifest *dep.Manifest, 
 		}
 
 		if gotRevision != testCase.wantRevision {
-			return errors.Errorf("Expected locked revision to be '%s', got %s",
+			return errors.Errorf("unexpected locked revision : \n\t(GOT) %v \n\t(WNT) %v",
 				testCase.wantRevision,
 				gotRevision)
 		}
 		if gotVersion != testCase.wantVersion {
-			return errors.Errorf("Expected locked version to be '%s', got %s",
+			return errors.Errorf("unexpected locked version: \n\t(GOT) %v \n\t(WNT) %v",
 				testCase.wantVersion,
 				gotVersion)
 		}

--- a/cmd/dep/root_analyzer_test.go
+++ b/cmd/dep/root_analyzer_test.go
@@ -154,6 +154,41 @@ func TestProjectExistsInLock(t *testing.T) {
 	}
 }
 
+func TestIsVersion(t *testing.T) {
+	testcases := map[string]struct {
+		wantIsVersion bool
+		wantVersion   gps.Version
+	}{
+		"v1.0.0": {wantIsVersion: true, wantVersion: gps.NewVersion("v1.0.0").Pair("ff2948a2ac8f538c4ecd55962e919d1e13e74baf")},
+		"3f4c3bea144e112a69bbe5d8d01c1b09a544253f": {wantIsVersion: false},
+		"master": {wantIsVersion: false},
+	}
+
+	pi := gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot("github.com/sdboyer/deptest")}
+	h := test.NewHelper(t)
+	defer h.Cleanup()
+
+	ctx := newTestContext(h)
+	sm, err := ctx.SourceManager()
+	h.Must(err)
+	defer sm.Release()
+
+	for value, testcase := range testcases {
+		t.Run(value, func(t *testing.T) {
+			gotIsVersion, gotVersion, err := isVersion(pi, value, sm)
+			h.Must(err)
+
+			if testcase.wantIsVersion != gotIsVersion {
+				t.Fatalf("Expected isVersion for %s to be %t", value, testcase.wantIsVersion)
+			}
+
+			if testcase.wantVersion != gotVersion {
+				t.Fatalf("Expected version for %s to be %s, got %s", value, testcase.wantVersion, gotVersion)
+			}
+		})
+	}
+}
+
 // convertTestCase is a common set of validations applied to the result
 // of an importer converting from an external config format to dep's.
 type convertTestCase struct {

--- a/cmd/dep/testdata/vndr/golden.txt
+++ b/cmd/dep/testdata/vndr/golden.txt
@@ -1,6 +1,6 @@
 Detected vndr configuration file...
 Converting from vendor.conf...
-  Using 3f4c3bea144e112a69bbe5d8d01c1b09a544253f as initial hint for imported dep github.com/sdboyer/deptest
+  Using ^0.8.1 as initial constraint for imported dep github.com/sdboyer/deptest
   Trying v0.8.1 (3f4c3be) as initial lock for imported dep github.com/sdboyer/deptest
   Using ^2.0.0 as initial constraint for imported dep github.com/sdboyer/deptestdos
-  Trying * (v2.0.0) as initial lock for imported dep github.com/sdboyer/deptestdos
+  Trying v2.0.0 (5c60720) as initial lock for imported dep github.com/sdboyer/deptestdos

--- a/cmd/dep/vndr_importer.go
+++ b/cmd/dep/vndr_importer.go
@@ -121,12 +121,13 @@ func (v *vndrImporter) convert(pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock, er
 			Constraint: gps.Any(),
 		}
 
+		// A vndr entry could contain either a version or a revision
 		isVersion, version, err := isVersion(pc.Ident, pkg.reference, v.sm)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		// Check if the revision was tagged with a version
+		// If the reference is a revision, check if it is tagged with a version
 		if !isVersion {
 			revision := gps.Revision(pkg.reference)
 			version, err = lookupVersionForLockedProject(pc.Ident, nil, revision, v.sm)


### PR DESCRIPTION
### What does this do / why do we need it?
I missed this during my review of the [original vndr PR](https://github.com/golang/dep/pull/978/). When I went to update the vndr tests to use the new standardized importer validations, it found some bugs when setting a constraint from a revision:

* When a revision is specified, if it's tagged with a semver, use that to default a constraint.
* When it's a revision, and we can't guess a constraint, use `gps.Any` instead of the revision itself (never pin during import).

FYI, after this is in I'll fix govend's importer in a separate PR. It isn't using `gps.Any` when the constraint can't be inferred.

### What should your reviewer look out for in this PR?
Anything else I missed... The new validations do a good job of catching mistakes as long as we are feeding in all the appropriate test cases. I did tweak the validations to always check everything because a) it's easier and b) helps finds bugs.

### Do you need help or clarification on anything?
Nope!

### Which issue(s) does this PR fix?
None.