### PR TITLE
Add satisfiability check for case variants

### DIFF
--- a/internal/gps/identifier.go
+++ b/internal/gps/identifier.go
@@ -217,6 +217,9 @@ type completeDep struct {
 	pl []string
 }
 
+// dependency represents an incomplete edge in the depgraph. It has a
+// fully-realized atom as the depender (the tail/source of the edge), and a set
+// of requirements that any atom to be attached at the head/target must satisfy.
 type dependency struct {
 	depender atom
 	dep      completeDep

--- a/internal/gps/manager_test.go
+++ b/internal/gps/manager_test.go
@@ -427,11 +427,12 @@ func TestSourceCreationCounts(t *testing.T) {
 		"case variance across path and URL-based access": {
 			roots: []ProjectIdentifier{
 				ProjectIdentifier{ProjectRoot: ProjectRoot("github.com/sdboyer/gpkt"), Source: "https://github.com/Sdboyer/gpkt"},
+				ProjectIdentifier{ProjectRoot: ProjectRoot("github.com/sdboyer/gpkt"), Source: "https://github.com/SdbOyer/gpkt"},
 				mkPI("github.com/sdboyer/gpkt"),
 				ProjectIdentifier{ProjectRoot: ProjectRoot("github.com/sdboyer/gpkt"), Source: "https://github.com/sdboyeR/gpkt"},
 				mkPI("github.com/sdboyeR/gpkt"),
 			},
-			namecount: 5,
+			namecount: 6,
 			srccount:  1,
 		},
 	}

--- a/internal/gps/manager_test.go
+++ b/internal/gps/manager_test.go
@@ -479,45 +479,55 @@ func TestFSCaseSensitivityConvergesSources(t *testing.T) {
 		t.Skip("Skipping slow test in short mode")
 	}
 
-	sm, clean := mkNaiveSM(t)
-	defer clean()
+	f := func(name string, pi1, pi2 ProjectIdentifier) {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			sm, clean := mkNaiveSM(t)
+			defer clean()
 
-	pi1 := mkPI("github.com/sdboyer/deptest").normalize()
-	sm.SyncSourceFor(pi1)
-	sg1, err := sm.srcCoord.getSourceGatewayFor(context.Background(), pi1)
-	if err != nil {
-		t.Fatal(err)
+			sm.SyncSourceFor(pi1)
+			sg1, err := sm.srcCoord.getSourceGatewayFor(context.Background(), pi1)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			sm.SyncSourceFor(pi2)
+			sg2, err := sm.srcCoord.getSourceGatewayFor(context.Background(), pi2)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			path1 := sg1.src.(*gitSource).repo.LocalPath()
+			t.Log("path1:", path1)
+			stat1, err := os.Stat(path1)
+			if err != nil {
+				t.Fatal(err)
+			}
+			path2 := sg2.src.(*gitSource).repo.LocalPath()
+			t.Log("path2:", path2)
+			stat2, err := os.Stat(path2)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			same, count := os.SameFile(stat1, stat2), len(sm.srcCoord.srcs)
+			if same && count != 1 {
+				t.Log("are same, count", count)
+				t.Fatal("on case-insensitive filesystem, case-varying sources should have been folded together but were not")
+			}
+			if !same && count != 2 {
+				t.Log("not same, count", count)
+				t.Fatal("on case-sensitive filesystem, case-varying sources should not have been folded together, but were")
+			}
+		})
 	}
 
-	pi2 := mkPI("github.com/Sdboyer/deptest").normalize()
-	sm.SyncSourceFor(pi2)
-	sg2, err := sm.srcCoord.getSourceGatewayFor(context.Background(), pi2)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	path1 := sg1.src.(*gitSource).repo.LocalPath()
-	t.Log("path1:", path1)
-	stat1, err := os.Stat(path1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	path2 := sg2.src.(*gitSource).repo.LocalPath()
-	t.Log("path2:", path2)
-	stat2, err := os.Stat(path2)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	same, count := os.SameFile(stat1, stat2), len(sm.srcCoord.srcs)
-	if same && count != 1 {
-		t.Log("are same, count", count)
-		t.Fatal("on case-insensitive filesystem, case-varying sources should have been folded together but were not")
-	}
-	if !same && count != 2 {
-		t.Log("not same, count", count)
-		t.Fatal("on case-sensitive filesystem, case-varying sources should not have been folded together, but were")
-	}
+	folded := mkPI("github.com/sdboyer/deptest").normalize()
+	casevar1 := mkPI("github.com/Sdboyer/deptest").normalize()
+	casevar2 := mkPI("github.com/SdboyeR/deptest").normalize()
+	f("folded first", folded, casevar1)
+	f("folded second", casevar1, folded)
+	f("both unfolded", casevar1, casevar2)
 }
 
 // Regression test for #32

--- a/internal/gps/manager_test.go
+++ b/internal/gps/manager_test.go
@@ -349,8 +349,8 @@ func TestMgrMethodsFailWithBadPath(t *testing.T) {
 }
 
 type sourceCreationTestFixture struct {
-	roots              []ProjectIdentifier
-	urlcount, srccount int
+	roots               []ProjectIdentifier
+	namecount, srccount int
 }
 
 func (f sourceCreationTestFixture) run(t *testing.T) {
@@ -365,8 +365,8 @@ func (f sourceCreationTestFixture) run(t *testing.T) {
 		}
 	}
 
-	if len(sm.srcCoord.nameToURL) != f.urlcount {
-		t.Errorf("want %v names in the name->url map, but got %v. contents: \n%v", f.urlcount, len(sm.srcCoord.nameToURL), sm.srcCoord.nameToURL)
+	if len(sm.srcCoord.nameToURL) != f.namecount {
+		t.Errorf("want %v names in the name->url map, but got %v. contents: \n%v", f.namecount, len(sm.srcCoord.nameToURL), sm.srcCoord.nameToURL)
 	}
 
 	if len(sm.srcCoord.srcs) != f.srccount {
@@ -390,16 +390,26 @@ func TestSourceCreationCounts(t *testing.T) {
 				mkPI("gopkg.in/sdboyer/gpkt.v2"),
 				mkPI("gopkg.in/sdboyer/gpkt.v3"),
 			},
-			urlcount: 6,
-			srccount: 3,
+			namecount: 6,
+			srccount:  3,
 		},
 		"gopkgin separation from github": {
 			roots: []ProjectIdentifier{
 				mkPI("gopkg.in/sdboyer/gpkt.v1"),
 				mkPI("github.com/sdboyer/gpkt"),
 			},
-			urlcount: 4,
-			srccount: 2,
+			namecount: 4,
+			srccount:  2,
+		},
+		"case variance across path and URL-based access": {
+			roots: []ProjectIdentifier{
+				ProjectIdentifier{ProjectRoot: ProjectRoot("github.com/sdboyer/gpkt"), Source: "https://github.com/Sdboyer/gpkt"},
+				mkPI("github.com/sdboyer/gpkt"),
+				ProjectIdentifier{ProjectRoot: ProjectRoot("github.com/sdboyer/gpkt"), Source: "https://github.com/sdboyeR/gpkt"},
+				mkPI("github.com/sdboyeR/gpkt"),
+			},
+			namecount: 5,
+			srccount:  1,
 		},
 	}
 

--- a/internal/gps/manager_test.go
+++ b/internal/gps/manager_test.go
@@ -467,9 +467,10 @@ func TestGetSources(t *testing.T) {
 	})
 
 	// nine entries (of which three are dupes): for each vcs, raw import path,
-	// the https url, and the http url
-	if len(sm.srcCoord.nameToURL) != 9 {
-		t.Errorf("Should have nine discrete entries in the nameToURL map, got %v", len(sm.srcCoord.nameToURL))
+	// the https url, and the http url. also three more from case folding of
+	// github.com/Masterminds/VCSTestRepo -> github.com/masterminds/vcstestrepo
+	if len(sm.srcCoord.nameToURL) != 12 {
+		t.Errorf("Should have twelve discrete entries in the nameToURL map, got %v", len(sm.srcCoord.nameToURL))
 	}
 	clean()
 }

--- a/internal/gps/manager_test.go
+++ b/internal/gps/manager_test.go
@@ -5,6 +5,7 @@
 package gps
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io/ioutil"
@@ -13,9 +14,11 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"text/tabwriter"
 	"time"
 
 	"github.com/golang/dep/internal/test"
@@ -371,6 +374,26 @@ func (f sourceCreationTestFixture) run(t *testing.T) {
 
 	if len(sm.srcCoord.srcs) != f.srccount {
 		t.Errorf("want %v gateways in the sources map, but got %v", f.srccount, len(sm.srcCoord.srcs))
+	}
+
+	var keys []string
+	for k := range sm.srcCoord.nameToURL {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var buf bytes.Buffer
+	w := tabwriter.NewWriter(&buf, 0, 4, 2, ' ', 0)
+	fmt.Fprint(w, "NAME\tMAPPED URL\n")
+	for _, r := range keys {
+		fmt.Fprintf(w, "%s\t%s\n", r, sm.srcCoord.nameToURL[r])
+	}
+	w.Flush()
+	t.Log("\n", buf.String())
+
+	t.Log("SRC KEYS")
+	for k := range sm.srcCoord.srcs {
+		t.Log(k)
 	}
 }
 

--- a/internal/gps/satisfy.go
+++ b/internal/gps/satisfy.go
@@ -239,6 +239,32 @@ func (s *solver) checkRootCaseConflicts(a atomWithPackages, cdep completeDep) er
 		s.fail(d.depender.id)
 	}
 
+	// If a project has multiple packages that import each other, we treat that
+	// as establishing a canonical case variant for the ProjectRoot. It's possible,
+	// however, that that canonical variant is not the same one that others
+	// imported it under. If that's the situation, then we'll have arrived here
+	// when visiting the project, not its dependers, having misclassified its
+	// internal imports as external. That means the atomWithPackages will
+	// be the wrong case variant induced by the importers, and the cdep will be
+	// a link pointing back at the canonical case variant.
+	//
+	// If this is the case, use a special failure, wrongCaseFailure, that
+	// makes a stronger statement as to the correctness of case variants.
+	//
+	// TODO(sdboyer) This approach to marking failure is less than great, as
+	// this will mark the current atom as failed, as well, causing the
+	// backtracker to work through it. While that could prove fruitful, it's
+	// quite likely just to be wasted effort. Addressing this - if that's a good
+	// idea - would entail creating another path back out of checking to enable
+	// backjumping directly to the incorrect importers.
+	if current == a.a.id.ProjectRoot {
+		return &wrongCaseFailure{
+			correct: pr,
+			goal:    dependency{depender: a.a, dep: cdep},
+			badcase: deps,
+		}
+	}
+
 	return &caseMismatchFailure{
 		goal:    dependency{depender: a.a, dep: cdep},
 		current: current,

--- a/internal/gps/satisfy.go
+++ b/internal/gps/satisfy.go
@@ -54,7 +54,7 @@ func (s *solver) check(a atomWithPackages, pkgonly bool) error {
 		if err = s.checkIdentMatches(a, dep); err != nil {
 			return err
 		}
-		if err = s.checkCaseConflicts(a, dep); err != nil {
+		if err = s.checkRootCaseConflicts(a, dep); err != nil {
 			return err
 		}
 		if err = s.checkDepsConstraintsAllowable(a, dep); err != nil {
@@ -221,19 +221,19 @@ func (s *solver) checkIdentMatches(a atomWithPackages, cdep completeDep) error {
 	return nil
 }
 
-// checkCaseConflicts ensures that the ProjectRoot specified in the completeDep
+// checkRootCaseConflicts ensures that the ProjectRoot specified in the completeDep
 // does not have case conflicts with any existing dependencies.
 //
 // We only need to check the ProjectRoot, rather than any packages therein, as
 // the later check for package existence is case-sensitive.
-func (s *solver) checkCaseConflicts(a atomWithPackages, cdep completeDep) error {
+func (s *solver) checkRootCaseConflicts(a atomWithPackages, cdep completeDep) error {
 	pr := cdep.workingConstraint.Ident.ProjectRoot
 	hasConflict, current := s.sel.findCaseConflicts(pr)
 	if !hasConflict {
 		return nil
 	}
 
-	curid, _ := s.sel.getIdentFor(pr)
+	curid, _ := s.sel.getIdentFor(current)
 	deps := s.sel.getDependenciesOn(curid)
 	for _, d := range deps {
 		s.fail(d.depender.id)

--- a/internal/gps/selection.go
+++ b/internal/gps/selection.go
@@ -83,11 +83,11 @@ func (s *selection) findCaseConflicts(pr ProjectRoot) (bool, ProjectRoot) {
 func (s *selection) pushDep(dep dependency) {
 	pr := dep.dep.Ident.ProjectRoot
 	deps := s.deps[pr]
-	s.deps[pr] = append(deps, dep)
-
-	if len(deps) == 1 {
+	if len(deps) == 0 {
 		s.foldRoots[toFold(string(pr))] = pr
 	}
+
+	s.deps[pr] = append(deps, dep)
 }
 
 func (s *selection) popDep(id ProjectIdentifier) (dep dependency) {

--- a/internal/gps/solve_basic_test.go
+++ b/internal/gps/solve_basic_test.go
@@ -399,6 +399,9 @@ type basicFixture struct {
 	changeall bool
 	// individual projects to change
 	changelist []ProjectRoot
+	// if the fixture is currently broken/expected to fail, this has a message
+	// recording why
+	broken string
 }
 
 func (f basicFixture) name() string {

--- a/internal/gps/solve_failures.go
+++ b/internal/gps/solve_failures.go
@@ -71,6 +71,49 @@ func (e *noVersionError) traceString() string {
 	return buf.String()
 }
 
+// caseMismatchFailure occurs when there are import paths that differ only by
+// case. The compiler disallows this case.
+type caseMismatchFailure struct {
+	// goal is the depender atom that tried to introduce the case-varying name,
+	// along with the case-varying name.
+	goal dependency
+	// current is the specific casing of a ProjectRoot that is presently
+	// selected for all possible case variations of its contained unicode code
+	// points.
+	current ProjectRoot
+	// failsib is the list of active dependencies that have determined the
+	// specific casing for the target project.
+	failsib []dependency
+}
+
+func (e *caseMismatchFailure) Error() string {
+	if len(e.failsib) == 1 {
+		str := "Could not introduce %s due to a case-only variation: it depends on %q, but %q was already established as the case variant for that project root by depender %s"
+		return fmt.Sprintf(str, a2vs(e.goal.depender), e.goal.dep.Ident.ProjectRoot, e.current, a2vs(e.failsib[0].depender))
+	}
+
+	var buf bytes.Buffer
+
+	str := "Could not introduce %s due to a case-only variation: it depends on %q, but %q was already established as the case variant for that project root by the following other dependers:\n"
+	fmt.Fprintf(&buf, str, e.goal.dep.Ident.ProjectRoot, e.current, a2vs(e.goal.depender))
+
+	for _, c := range e.failsib {
+		fmt.Fprintf(&buf, "\t%s\n", a2vs(c.depender))
+	}
+
+	return buf.String()
+}
+
+func (e *caseMismatchFailure) traceString() string {
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "case-only variation in dependency on %q; %q already established by:\n", e.goal.dep.Ident.ProjectRoot, e.current)
+	for _, f := range e.failsib {
+		fmt.Fprintf(&buf, "%s\n", a2vs(f.depender))
+	}
+
+	return buf.String()
+}
+
 // disjointConstraintFailure occurs when attempting to introduce an atom that
 // itself has an acceptable version, but one of its dependency constraints is
 // disjoint with one or more dependency constraints already active for that

--- a/internal/gps/solve_failures.go
+++ b/internal/gps/solve_failures.go
@@ -132,13 +132,13 @@ type wrongCaseFailure struct {
 
 func (e *wrongCaseFailure) Error() string {
 	if len(e.badcase) == 1 {
-		str := "Could not introduce %s; mutual imports by its packages establish %q as the canonical casing for root, but %s tried to import it as %q"
+		str := "Could not introduce %s; imports amongst its packages establish %q as the canonical casing for root, but %s tried to import it as %q"
 		return fmt.Sprintf(str, a2vs(e.goal.depender), e.correct, a2vs(e.badcase[0].depender), e.badcase[0].dep.Ident.ProjectRoot)
 	}
 
 	var buf bytes.Buffer
 
-	str := "Could not introduce %s; mutual imports by its packages establish %q as the canonical casing for root, but the following projects tried to import it as %q"
+	str := "Could not introduce %s; imports amongst its packages establish %q as the canonical casing for root, but the following projects tried to import it as %q"
 	fmt.Fprintf(&buf, str, a2vs(e.goal.depender), e.correct, e.badcase[0].dep.Ident.ProjectRoot)
 
 	for _, c := range e.badcase {

--- a/internal/gps/solve_failures.go
+++ b/internal/gps/solve_failures.go
@@ -139,7 +139,7 @@ func (e *wrongCaseFailure) Error() string {
 	var buf bytes.Buffer
 
 	str := "Could not introduce %s; its packages import each other using %q, establishing that as correct, but the following projects tried to import it as %q"
-	return fmt.Sprintf(str, a2vs(e.goal.depender), e.correct, e.badcase[0].dep.Ident.ProjectRoot)
+	fmt.Fprintf(&buf, str, a2vs(e.goal.depender), e.correct, e.badcase[0].dep.Ident.ProjectRoot)
 
 	for _, c := range e.badcase {
 		fmt.Fprintf(&buf, "\t%s\n", a2vs(c.depender))

--- a/internal/gps/solve_failures.go
+++ b/internal/gps/solve_failures.go
@@ -132,13 +132,13 @@ type wrongCaseFailure struct {
 
 func (e *wrongCaseFailure) Error() string {
 	if len(e.badcase) == 1 {
-		str := "Could not introduce %s; its packages import each other using %q, establishing that as correct, but %s tried to import it as %q"
+		str := "Could not introduce %s; mutual imports by its packages establish %q as the canonical casing for root, but %s tried to import it as %q"
 		return fmt.Sprintf(str, a2vs(e.goal.depender), e.correct, a2vs(e.badcase[0].depender), e.badcase[0].dep.Ident.ProjectRoot)
 	}
 
 	var buf bytes.Buffer
 
-	str := "Could not introduce %s; its packages import each other using %q, establishing that as correct, but the following projects tried to import it as %q"
+	str := "Could not introduce %s; mutual imports by its packages establish %q as the canonical casing for root, but the following projects tried to import it as %q"
 	fmt.Fprintf(&buf, str, a2vs(e.goal.depender), e.correct, e.badcase[0].dep.Ident.ProjectRoot)
 
 	for _, c := range e.badcase {

--- a/internal/gps/solve_test.go
+++ b/internal/gps/solve_test.go
@@ -60,6 +60,9 @@ func TestBasicSolves(t *testing.T) {
 
 func solveBasicsAndCheck(fix basicFixture, t *testing.T) (res Solution, err error) {
 	sm := newdepspecSM(fix.ds, nil)
+	if fix.broken != "" {
+		t.Skip(fix.broken)
+	}
 
 	params := SolveParameters{
 		RootDir:         string(fix.ds[0].n),
@@ -103,6 +106,9 @@ func TestBimodalSolves(t *testing.T) {
 
 func solveBimodalAndCheck(fix bimodalFixture, t *testing.T) (res Solution, err error) {
 	sm := newbmSM(fix)
+	if fix.broken != "" {
+		t.Skip(fix.broken)
+	}
 
 	params := SolveParameters{
 		RootDir:         string(fix.ds[0].n),

--- a/internal/gps/solver.go
+++ b/internal/gps/solver.go
@@ -307,8 +307,9 @@ func Prepare(params SolveParameters, sm SourceManager) (Solver, error) {
 
 	// Initialize stacks and queues
 	s.sel = &selection{
-		deps: make(map[ProjectRoot][]dependency),
-		vu:   s.vUnify,
+		deps:     make(map[ProjectRoot][]dependency),
+		prLenMap: make(map[int][]ProjectRoot),
+		vu:       s.vUnify,
 	}
 	s.unsel = &unselected{
 		sl:  make([]bimodalIdentifier, 0),

--- a/internal/gps/solver.go
+++ b/internal/gps/solver.go
@@ -307,9 +307,9 @@ func Prepare(params SolveParameters, sm SourceManager) (Solver, error) {
 
 	// Initialize stacks and queues
 	s.sel = &selection{
-		deps:     make(map[ProjectRoot][]dependency),
-		prLenMap: make(map[int][]ProjectRoot),
-		vu:       s.vUnify,
+		deps:      make(map[ProjectRoot][]dependency),
+		foldRoots: make(map[string]ProjectRoot),
+		vu:        s.vUnify,
 	}
 	s.unsel = &unselected{
 		sl:  make([]bimodalIdentifier, 0),

--- a/internal/gps/source.go
+++ b/internal/gps/source.go
@@ -85,39 +85,58 @@ func (sc *sourceCoordinator) getSourceGatewayFor(ctx context.Context, id Project
 	}
 	sc.srcmut.RUnlock()
 
+	// Without a direct match, we must fold the input name to a generally
+	// stable, caseless variant and primarily work from that. This ensures that
+	// on case-insensitive filesystems, we do not end up with multiple
+	// sourceGateways for paths that vary only by case. We perform folding
+	// unconditionally, independent of whether the underlying fs is
+	// case-sensitive, in order to ensure uniform behavior.
+	//
+	// This has significant implications. It is effectively deciding that the
+	// ProjectRoot portion of import paths are case-insensitive, which is by no
+	// means an invariant maintained by all hosting systems. If this presents a
+	// problem in practice, then we can explore expanding the deduction system
+	// to include case-sensitivity-for-roots metadata and treat it on a
+	// host-by-host basis. Such cases would still be rejected by the Go
+	// toolchain's compiler, though, and case-sensitivity in root names is
+	// likely to be at least frowned on if not disallowed by most hosting
+	// systems. So we follow this path, which is both a vastly simpler solution
+	// and one that seems quite likely to work in practice.
+	foldedNormalName := toFold(normalizedName)
+
 	// No gateway exists for this path yet; set up a proto, being careful to fold
-	// together simultaneous attempts on the same path.
+	// together simultaneous attempts on the same case-folded path.
 	sc.psrcmut.Lock()
-	if chans, has := sc.protoSrcs[normalizedName]; has {
+	if chans, has := sc.protoSrcs[foldedNormalName]; has {
 		// Another goroutine is already working on this normalizedName. Fold
 		// in with that work by attaching our return channels to the list.
 		rc := srcReturnChans{
 			ret: make(chan *sourceGateway, 1),
 			err: make(chan error, 1),
 		}
-		sc.protoSrcs[normalizedName] = append(chans, rc)
+		sc.protoSrcs[foldedNormalName] = append(chans, rc)
 		sc.psrcmut.Unlock()
 		return rc.awaitReturn()
 	}
 
-	sc.protoSrcs[normalizedName] = []srcReturnChans{}
+	sc.protoSrcs[foldedNormalName] = []srcReturnChans{}
 	sc.psrcmut.Unlock()
 
 	doReturn := func(sg *sourceGateway, err error) {
 		sc.psrcmut.Lock()
 		if sg != nil {
-			for _, rc := range sc.protoSrcs[normalizedName] {
+			for _, rc := range sc.protoSrcs[foldedNormalName] {
 				rc.ret <- sg
 			}
 		} else if err != nil {
-			for _, rc := range sc.protoSrcs[normalizedName] {
+			for _, rc := range sc.protoSrcs[foldedNormalName] {
 				rc.err <- err
 			}
 		} else {
 			panic("sg and err both nil")
 		}
 
-		delete(sc.protoSrcs, normalizedName)
+		delete(sc.protoSrcs, foldedNormalName)
 		sc.psrcmut.Unlock()
 	}
 
@@ -136,7 +155,7 @@ func (sc *sourceCoordinator) getSourceGatewayFor(ctx context.Context, id Project
 	// and bailing out if we find an entry.
 	var srcGate *sourceGateway
 	sc.srcmut.RLock()
-	if url, has := sc.nameToURL[normalizedName]; has {
+	if url, has := sc.nameToURL[foldedNormalName]; has {
 		if srcGate, has := sc.srcs[url]; has {
 			sc.srcmut.RUnlock()
 			doReturn(srcGate, nil)
@@ -149,10 +168,10 @@ func (sc *sourceCoordinator) getSourceGatewayFor(ctx context.Context, id Project
 	srcGate = newSourceGateway(pd.mb, sc.supervisor, sc.cachedir)
 
 	// The normalized name is usually different from the source URL- e.g.
-	// github.com/golang/dep/internal/gps vs. https://github.com/golang/dep/internal/gps. But it's
-	// possible to arrive here with a full URL as the normalized name - and
-	// both paths *must* lead to the same sourceGateway instance in order to
-	// ensure disk access is correctly managed.
+	// github.com/sdboyer/gps vs. https://github.com/sdboyer/gps. But it's
+	// possible to arrive here with a full URL as the normalized name - and both
+	// paths *must* lead to the same sourceGateway instance in order to ensure
+	// disk access is correctly managed.
 	//
 	// Therefore, we now must query the sourceGateway to get the actual
 	// sourceURL it's operating on, and ensure it's *also* registered at
@@ -173,6 +192,12 @@ func (sc *sourceCoordinator) getSourceGatewayFor(ctx context.Context, id Project
 	sc.nameToURL[normalizedName] = url
 	if url != normalizedName {
 		sc.nameToURL[url] = url
+	}
+
+	// Make sure we have both the folded and unfolded names recorded in the map,
+	// should they differ.
+	if normalizedName != foldedNormalName {
+		sc.nameToURL[foldedNormalName] = url
 	}
 
 	if sa, has := sc.srcs[url]; has {

--- a/internal/gps/strings.go
+++ b/internal/gps/strings.go
@@ -1,0 +1,51 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gps
+
+import (
+	"bytes"
+	"unicode"
+	"unicode/utf8"
+)
+
+// toFold returns a string with the property that strings.EqualFold(s, t) iff
+// ToFold(s) == ToFold(t) This lets us test a large set of strings for
+// fold-equivalent duplicates without making a quadratic number of calls to
+// EqualFold. Note that strings.ToUpper and strings.ToLower do not have the
+// desired property in some corner cases.
+//
+// This is hoisted from toolchain internals: src/cmd/go/internal/str/str.go
+func toFold(s string) string {
+	// Fast path: all ASCII, no upper case.
+	// Most paths look like this already.
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= utf8.RuneSelf || 'A' <= c && c <= 'Z' {
+			goto Slow
+		}
+	}
+	return s
+
+Slow:
+	var buf bytes.Buffer
+	for _, r := range s {
+		// SimpleFold(x) cycles to the next equivalent rune > x
+		// or wraps around to smaller values. Iterate until it wraps,
+		// and we've found the minimum value.
+		for {
+			r0 := r
+			r = unicode.SimpleFold(r0)
+			if r <= r0 {
+				break
+			}
+		}
+		// Exception to allow fast path above: A-Z => a-z
+		if 'A' <= r && r <= 'Z' {
+			r += 'a' - 'A'
+		}
+		buf.WriteRune(r)
+	}
+	return buf.String()
+}


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].
-->

### What does this do / why do we need it?

This introduces a new satisfiability check in the solver that ensures we don't have any import paths that vary only by path. It's actually really just `ProjectRoots`, not import paths as a whole, because internal package paths are implicitly verified to be the right case by the package existence checker - that's grounded in the reality of a case-sensitive comparison against what's been read from disk and built into the `PackageTree`.

The effect of this is that dep will only allow one case-variant of any given import path in a solution/a `Gopkg.lock`. It will search until it finds combinations of versions of projects that maintain this invariant - as well as all other satisfiability criteria, like version constraints - or fail out with an informative message if no such combination exists.

### What should your reviewer look out for in this PR?

still need a handful more tests to cover the combinations

### Do you need help or clarification on anything?

### Which issue(s) does this PR fix?

several, at least.

fixes #433
fixes #797 
fixes #806 