### PR TITLE
Add 'golang' to go get URL of Setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ $ brew upgrade dep
 If you're interested in hacking on `dep`, you can install via `go get`:
 
 ```sh
-go get -u github.com/dep/cmd/dep
+go get -u github.com/golang/dep/cmd/dep
 ```
 
 To start managing dependencies using dep, run the following from your project's root directory:


### PR DESCRIPTION
This fixes the URL of the `go get` command in the Setup section of the documentation.

Without this, it of course shows an error.

```
fatal: could not read Username for 'https://github.com': terminal prompts disabled
package github.com/dep/cmd/dep: exit status 128
```