### PR TITLE
gps: cmd: add command args to monitoredCmd errors

### DIFF
--- a/internal/gps/cmd.go
+++ b/internal/gps/cmd.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/vcs"
+	"github.com/pkg/errors"
 )
 
 // monitoredCmd wraps a cmd and will keep monitoring the process until it
@@ -127,11 +128,8 @@ func (c *monitoredCmd) hasTimedOut() bool {
 
 func (c *monitoredCmd) combinedOutput(ctx context.Context) ([]byte, error) {
 	c.cmd.Stderr = c.stdout
-	if err := c.run(ctx); err != nil {
-		return c.stdout.Bytes(), err
-	}
-
-	return c.stdout.Bytes(), nil
+	err := c.run(ctx)
+	return c.stdout.Bytes(), errors.Wrapf(err, "command failed: %v", c.cmd.Args)
 }
 
 // activityBuffer is a buffer that keeps track of the last time a Write


### PR DESCRIPTION
### What does this do / why do we need it?

This adds the arguments from a `monitoredCmd` to any errors returned so that we get some more context.
For Example:
```diff
- *  failed to export google.golang.org/api: command killed after 30s of no activity
+ *  failed to export google.golang.org/api: command failed: [dep init -v]: command killed after 30s of no activity
```
