### PR TITLE
gps: ProjectIdentifier: drop errString()method in favor of implicit String() calls

### DIFF
--- a/internal/gps/identifier.go
+++ b/internal/gps/identifier.go
@@ -141,15 +141,11 @@ func (i ProjectIdentifier) normalizedSource() string {
 	return i.Source
 }
 
-func (i ProjectIdentifier) errString() string {
+func (i ProjectIdentifier) String() string {
 	if i.Source == "" || i.Source == string(i.ProjectRoot) {
 		return string(i.ProjectRoot)
 	}
 	return fmt.Sprintf("%s (from %s)", i.ProjectRoot, i.Source)
-}
-
-func (i ProjectIdentifier) String() string {
-	return i.errString()
 }
 
 func (i ProjectIdentifier) normalize() ProjectIdentifier {

--- a/internal/gps/lock.go
+++ b/internal/gps/lock.go
@@ -201,7 +201,7 @@ func (lp LockedProject) Packages() []string {
 
 func (lp LockedProject) String() string {
 	return fmt.Sprintf("%s@%s with packages: %v",
-		lp.Ident().errString(), lp.Version(), lp.pkgs)
+		lp.Ident(), lp.Version(), lp.pkgs)
 }
 
 type safeLock struct {

--- a/internal/gps/manager_test.go
+++ b/internal/gps/manager_test.go
@@ -563,14 +563,14 @@ func TestMultiFetchThreadsafe(t *testing.T) {
 
 				switch op {
 				case 0:
-					t.Run(fmt.Sprintf("deduce:%v:%s", opcount, id.errString()), func(t *testing.T) {
+					t.Run(fmt.Sprintf("deduce:%v:%s", opcount, id), func(t *testing.T) {
 						t.Parallel()
 						if _, err := sm.DeduceProjectRoot(string(id.ProjectRoot)); err != nil {
 							t.Error(err)
 						}
 					})
 				case 1:
-					t.Run(fmt.Sprintf("sync:%v:%s", opcount, id.errString()), func(t *testing.T) {
+					t.Run(fmt.Sprintf("sync:%v:%s", opcount, id), func(t *testing.T) {
 						t.Parallel()
 						err := sm.SyncSourceFor(id)
 						if err != nil {
@@ -578,7 +578,7 @@ func TestMultiFetchThreadsafe(t *testing.T) {
 						}
 					})
 				case 2:
-					t.Run(fmt.Sprintf("listVersions:%v:%s", opcount, id.errString()), func(t *testing.T) {
+					t.Run(fmt.Sprintf("listVersions:%v:%s", opcount, id), func(t *testing.T) {
 						t.Parallel()
 						vl, err := sm.ListVersions(id)
 						if err != nil {
@@ -589,7 +589,7 @@ func TestMultiFetchThreadsafe(t *testing.T) {
 						}
 					})
 				case 3:
-					t.Run(fmt.Sprintf("exists:%v:%s", opcount, id.errString()), func(t *testing.T) {
+					t.Run(fmt.Sprintf("exists:%v:%s", opcount, id), func(t *testing.T) {
 						t.Parallel()
 						y, err := sm.SourceExists(id)
 						if err != nil {

--- a/internal/gps/solve_basic_test.go
+++ b/internal/gps/solve_basic_test.go
@@ -1350,7 +1350,7 @@ func (sm *depspecSourceManager) GetManifestAndLock(id ProjectIdentifier, v Versi
 	}
 
 	// TODO(sdboyer) proper solver-type errors
-	return nil, nil, fmt.Errorf("Project %s at version %s could not be found", id.errString(), v)
+	return nil, nil, fmt.Errorf("Project %s at version %s could not be found", id, v)
 }
 
 func (sm *depspecSourceManager) ExternalReach(id ProjectIdentifier, v Version) (map[string][]string, error) {
@@ -1358,7 +1358,7 @@ func (sm *depspecSourceManager) ExternalReach(id ProjectIdentifier, v Version) (
 	if m, exists := sm.rm[pid]; exists {
 		return m, nil
 	}
-	return nil, fmt.Errorf("No reach data for %s at version %s", id.errString(), v)
+	return nil, fmt.Errorf("No reach data for %s at version %s", id, v)
 }
 
 func (sm *depspecSourceManager) ListPackages(id ProjectIdentifier, v Version) (pkgtree.PackageTree, error) {
@@ -1428,12 +1428,12 @@ func (sm *depspecSourceManager) ListVersions(id ProjectIdentifier) ([]PairedVers
 			// the test doesn't need revision info, anyway.
 			pvl = append(pvl, tv.Pair(Revision("FAKEREV")))
 		default:
-			panic(fmt.Sprintf("unreachable: type of version was %#v for spec %s", ds.v, id.errString()))
+			panic(fmt.Sprintf("unreachable: type of version was %#v for spec %s", ds.v, id))
 		}
 	}
 
 	if len(pvl) == 0 {
-		return nil, fmt.Errorf("Project %s could not be found", id.errString())
+		return nil, fmt.Errorf("Project %s could not be found", id)
 	}
 	return pvl, nil
 }
@@ -1445,7 +1445,7 @@ func (sm *depspecSourceManager) RevisionPresentIn(id ProjectIdentifier, r Revisi
 		}
 	}
 
-	return false, fmt.Errorf("Project %s has no revision %s", id.errString(), r)
+	return false, fmt.Errorf("Project %s has no revision %s", id, r)
 }
 
 func (sm *depspecSourceManager) SourceExists(id ProjectIdentifier) (bool, error) {
@@ -1461,7 +1461,7 @@ func (sm *depspecSourceManager) SourceExists(id ProjectIdentifier) (bool, error)
 func (sm *depspecSourceManager) SyncSourceFor(id ProjectIdentifier) error {
 	// Ignore err because it can't happen
 	if exist, _ := sm.SourceExists(id); !exist {
-		return fmt.Errorf("Source %s does not exist", id.errString())
+		return fmt.Errorf("Source %s does not exist", id)
 	}
 	return nil
 }

--- a/internal/gps/solve_bimodal_test.go
+++ b/internal/gps/solve_bimodal_test.go
@@ -1208,7 +1208,7 @@ func (sm *bmSourceManager) ListPackages(id ProjectIdentifier, v Version) (pkgtre
 		}
 	}
 
-	return pkgtree.PackageTree{}, fmt.Errorf("Project %s at version %s could not be found", id.errString(), v)
+	return pkgtree.PackageTree{}, fmt.Errorf("Project %s at version %s could not be found", id, v)
 }
 
 func (sm *bmSourceManager) GetManifestAndLock(id ProjectIdentifier, v Version, an ProjectAnalyzer) (Manifest, Lock, error) {
@@ -1222,7 +1222,7 @@ func (sm *bmSourceManager) GetManifestAndLock(id ProjectIdentifier, v Version, a
 	}
 
 	// TODO(sdboyer) proper solver-type errors
-	return nil, nil, fmt.Errorf("Project %s at version %s could not be found", id.errString(), v)
+	return nil, nil, fmt.Errorf("Project %s at version %s could not be found", id, v)
 }
 
 // computeBimodalExternalMap takes a set of depspecs and computes an

--- a/internal/gps/solve_failures.go
+++ b/internal/gps/solve_failures.go
@@ -27,7 +27,7 @@ func a2vs(a atom) string {
 		return "(root)"
 	}
 
-	return fmt.Sprintf("%s@%s", a.id.errString(), a.v)
+	return fmt.Sprintf("%s@%s", a.id, a.v)
 }
 
 type traceError interface {
@@ -95,7 +95,7 @@ type disjointConstraintFailure struct {
 func (e *disjointConstraintFailure) Error() string {
 	if len(e.failsib) == 1 {
 		str := "Could not introduce %s, as it has a dependency on %s with constraint %s, which has no overlap with existing constraint %s from %s"
-		return fmt.Sprintf(str, a2vs(e.goal.depender), e.goal.dep.Ident.errString(), e.goal.dep.Constraint.String(), e.failsib[0].dep.Constraint.String(), a2vs(e.failsib[0].depender))
+		return fmt.Sprintf(str, a2vs(e.goal.depender), e.goal.dep.Ident, e.goal.dep.Constraint.String(), e.failsib[0].dep.Constraint.String(), a2vs(e.failsib[0].depender))
 	}
 
 	var buf bytes.Buffer
@@ -105,12 +105,12 @@ func (e *disjointConstraintFailure) Error() string {
 		sibs = e.failsib
 
 		str := "Could not introduce %s, as it has a dependency on %s with constraint %s, which has no overlap with the following existing constraints:\n"
-		fmt.Fprintf(&buf, str, a2vs(e.goal.depender), e.goal.dep.Ident.errString(), e.goal.dep.Constraint.String())
+		fmt.Fprintf(&buf, str, a2vs(e.goal.depender), e.goal.dep.Ident, e.goal.dep.Constraint.String())
 	} else {
 		sibs = e.nofailsib
 
 		str := "Could not introduce %s, as it has a dependency on %s with constraint %s, which does not overlap with the intersection of existing constraints from other currently selected packages:\n"
-		fmt.Fprintf(&buf, str, a2vs(e.goal.depender), e.goal.dep.Ident.errString(), e.goal.dep.Constraint.String())
+		fmt.Fprintf(&buf, str, a2vs(e.goal.depender), e.goal.dep.Ident, e.goal.dep.Constraint.String())
 	}
 
 	for _, c := range sibs {
@@ -122,7 +122,7 @@ func (e *disjointConstraintFailure) Error() string {
 
 func (e *disjointConstraintFailure) traceString() string {
 	var buf bytes.Buffer
-	fmt.Fprintf(&buf, "constraint %s on %s disjoint with other dependers:\n", e.goal.dep.Constraint.String(), e.goal.dep.Ident.errString())
+	fmt.Fprintf(&buf, "constraint %s on %s disjoint with other dependers:\n", e.goal.dep.Constraint.String(), e.goal.dep.Ident)
 	for _, f := range e.failsib {
 		fmt.Fprintf(
 			&buf,
@@ -159,7 +159,7 @@ func (e *constraintNotAllowedFailure) Error() string {
 	return fmt.Sprintf(
 		"Could not introduce %s, as it has a dependency on %s with constraint %s, which does not allow the currently selected version of %s",
 		a2vs(e.goal.depender),
-		e.goal.dep.Ident.errString(),
+		e.goal.dep.Ident,
 		e.goal.dep.Constraint,
 		e.v,
 	)
@@ -198,7 +198,7 @@ func (e *versionNotAllowedFailure) Error() string {
 			"Could not introduce %s, as it is not allowed by constraint %s from project %s.",
 			a2vs(e.goal),
 			e.failparent[0].dep.Constraint.String(),
-			e.failparent[0].depender.id.errString(),
+			e.failparent[0].depender.id,
 		)
 	}
 
@@ -268,9 +268,9 @@ func (e *sourceMismatchFailure) traceString() string {
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "disagreement on network addr for %s:\n", e.shared)
 
-	fmt.Fprintf(&buf, "  %s from %s\n", e.mismatch, e.prob.id.errString())
+	fmt.Fprintf(&buf, "  %s from %s\n", e.mismatch, e.prob.id)
 	for _, dep := range e.sel {
-		fmt.Fprintf(&buf, "  %s from %s\n", e.current, dep.depender.id.errString())
+		fmt.Fprintf(&buf, "  %s from %s\n", e.current, dep.depender.id)
 	}
 
 	return buf.String()
@@ -361,7 +361,7 @@ func (e *checkeeHasProblemPackagesFailure) traceString() string {
 		} else {
 			fmt.Fprintf(&buf, " required by:")
 			for _, pa := range errdep.deppers {
-				fmt.Fprintf(&buf, "\n\t\t%s at %s", pa.id.errString(), pa.v)
+				fmt.Fprintf(&buf, "\n\t\t%s at %s", pa.id, pa.v)
 			}
 		}
 	}
@@ -411,7 +411,7 @@ func (e *depHasProblemPackagesFailure) Error() string {
 			"Could not introduce %s, as it requires package %s from %s, but in version %s that package %s",
 			a2vs(e.goal.depender),
 			pkg,
-			e.goal.dep.Ident.errString(),
+			e.goal.dep.Ident,
 			e.v,
 			fcause(pkg),
 		)
@@ -421,7 +421,7 @@ func (e *depHasProblemPackagesFailure) Error() string {
 	fmt.Fprintf(
 		&buf, "Could not introduce %s, as it requires problematic packages from %s (current version %s):",
 		a2vs(e.goal.depender),
-		e.goal.dep.Ident.errString(),
+		e.goal.dep.Ident,
 		e.v,
 	)
 
@@ -451,7 +451,7 @@ func (e *depHasProblemPackagesFailure) traceString() string {
 	fmt.Fprintf(
 		&buf, "%s depping on %s at %s has problem subpkg(s):",
 		a2vs(e.goal.depender),
-		e.goal.dep.Ident.errString(),
+		e.goal.dep.Ident,
 		e.v,
 	)
 
@@ -481,7 +481,7 @@ func (e *nonexistentRevisionFailure) Error() string {
 	return fmt.Sprintf(
 		"Could not introduce %s, as it requires %s at revision %s, but that revision does not exist",
 		a2vs(e.goal.depender),
-		e.goal.dep.Ident.errString(),
+		e.goal.dep.Ident,
 		e.r,
 	)
 }
@@ -491,6 +491,6 @@ func (e *nonexistentRevisionFailure) traceString() string {
 		"%s wants missing rev %s of %s",
 		a2vs(e.goal.depender),
 		e.r,
-		e.goal.dep.Ident.errString(),
+		e.goal.dep.Ident,
 	)
 }

--- a/internal/gps/solver.go
+++ b/internal/gps/solver.go
@@ -670,7 +670,7 @@ func (s *solver) getImportsAndConstraintsOf(a atomWithPackages) ([]string, []com
 			}
 
 			// Nope, it's actually full-on not there.
-			return nil, nil, fmt.Errorf("package %s does not exist within project %s", pkg, a.a.id.errString())
+			return nil, nil, fmt.Errorf("package %s does not exist within project %s", pkg, a.a.id)
 		}
 
 		for _, ex := range ie.External {
@@ -887,7 +887,7 @@ func (s *solver) findValidVersion(q *versionQueue, pl []string) error {
 
 	for {
 		cur := q.current()
-		s.traceInfo("try %s@%s", q.id.errString(), cur)
+		s.traceInfo("try %s@%s", q.id, cur)
 		err := s.check(atomWithPackages{
 			a: atom{
 				id: q.id,

--- a/internal/gps/trace.go
+++ b/internal/gps/trace.go
@@ -27,7 +27,7 @@ func (s *solver) traceCheckPkgs(bmi bimodalIdentifier) {
 	}
 
 	prefix := getprei(len(s.vqs) + 1)
-	s.tl.Printf("%s\n", tracePrefix(fmt.Sprintf("? revisit %s to add %v pkgs", bmi.id.errString(), len(bmi.pl)), prefix, prefix))
+	s.tl.Printf("%s\n", tracePrefix(fmt.Sprintf("? revisit %s to add %v pkgs", bmi.id, len(bmi.pl)), prefix, prefix))
 }
 
 func (s *solver) traceCheckQueue(q *versionQueue, bmi bimodalIdentifier, cont bool, offset int) {
@@ -53,7 +53,7 @@ func (s *solver) traceCheckQueue(q *versionQueue, bmi bimodalIdentifier, cont bo
 		verb = "attempt"
 	}
 
-	s.tl.Printf("%s\n", tracePrefix(fmt.Sprintf("%s? %s %s with %v pkgs; %s versions to try", indent, verb, bmi.id.errString(), len(bmi.pl), vlen), prefix, prefix))
+	s.tl.Printf("%s\n", tracePrefix(fmt.Sprintf("%s? %s %s with %v pkgs; %s versions to try", indent, verb, bmi.id, len(bmi.pl), vlen), prefix, prefix))
 }
 
 // traceStartBacktrack is called with the bmi that first failed, thus initiating
@@ -65,9 +65,9 @@ func (s *solver) traceStartBacktrack(bmi bimodalIdentifier, err error, pkgonly b
 
 	var msg string
 	if pkgonly {
-		msg = fmt.Sprintf("%s%s could not add %v pkgs to %s; begin backtrack", innerIndent, backChar, len(bmi.pl), bmi.id.errString())
+		msg = fmt.Sprintf("%s%s could not add %v pkgs to %s; begin backtrack", innerIndent, backChar, len(bmi.pl), bmi.id)
 	} else {
-		msg = fmt.Sprintf("%s%s no more versions of %s to try; begin backtrack", innerIndent, backChar, bmi.id.errString())
+		msg = fmt.Sprintf("%s%s no more versions of %s to try; begin backtrack", innerIndent, backChar, bmi.id)
 	}
 
 	prefix := getprei(len(s.sel.projects))
@@ -83,9 +83,9 @@ func (s *solver) traceBacktrack(bmi bimodalIdentifier, pkgonly bool) {
 
 	var msg string
 	if pkgonly {
-		msg = fmt.Sprintf("%s backtrack: popped %v pkgs from %s", backChar, len(bmi.pl), bmi.id.errString())
+		msg = fmt.Sprintf("%s backtrack: popped %v pkgs from %s", backChar, len(bmi.pl), bmi.id)
 	} else {
-		msg = fmt.Sprintf("%s backtrack: no more versions of %s to try", backChar, bmi.id.errString())
+		msg = fmt.Sprintf("%s backtrack: no more versions of %s to try", backChar, bmi.id)
 	}
 
 	prefix := getprei(len(s.sel.projects))


### PR DESCRIPTION
### What does this do / why do we need it?

Follows up from #1043 ([comment](https://github.com/golang/dep/pull/1043/files#r134214321)) to remove the `ProjectIdentifier.errString()` method, and move the implementation into `String()`. Callers now implicitly call `String()` instead.
