### PR TITLE
cmd/dep: fix analyzer to always use the same name

### DIFF
--- a/cmd/dep/root_analyzer.go
+++ b/cmd/dep/root_analyzer.go
@@ -161,15 +161,11 @@ func (a *rootAnalyzer) FinalizeRootManifestAndLock(m *dep.Manifest, l *dep.Lock,
 	}
 }
 
+// Info provides metadata on the analyzer algorithm used during solve.
 func (a *rootAnalyzer) Info() gps.ProjectAnalyzerInfo {
-	name := "dep"
-	version := 1
-	if !a.skipTools {
-		name = "dep+import"
-	}
 	return gps.ProjectAnalyzerInfo{
-		Name:    name,
-		Version: version,
+		Name:    "dep",
+		Version: 1,
 	}
 }
 

--- a/cmd/dep/root_analyzer_test.go
+++ b/cmd/dep/root_analyzer_test.go
@@ -14,20 +14,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-func TestRootAnalyzer_Info(t *testing.T) {
-	testCases := map[bool]string{
-		true:  "dep",
-		false: "dep+import",
-	}
-	for skipTools, want := range testCases {
-		a := rootAnalyzer{skipTools: skipTools}
-		got := a.Info().Name
-		if got != want {
-			t.Errorf("Expected the name of the importer with skipTools=%t to be '%s', got '%s'", skipTools, want, got)
-		}
-	}
-}
-
 func TestLookupVersionForLockedProject_MatchRevisionToTag(t *testing.T) {
 	h := test.NewHelper(t)
 	defer h.Cleanup()


### PR DESCRIPTION
### What does this do / why do we need it?
Different names should be used _only_ for different solve algorithms. Otherwise running dep init then dep ensure will always result in a modified lock hash.

### What should your reviewer look out for in this PR?
Nothing.

### Do you need help or clarification on anything?
Nope.

### Which issue(s) does this PR fix?
fixes #917 