### PR TITLE
cleanup errors

### DIFF
--- a/cmd/dep/init.go
+++ b/cmd/dep/init.go
@@ -84,7 +84,7 @@ func (cmd *initCommand) Run(ctx *dep.Ctx, args []string) error {
 			root = filepath.Join(ctx.WorkingDir, args[0])
 		}
 		if err := os.MkdirAll(root, os.FileMode(0777)); err != nil {
-			return errors.Errorf("unable to create directory %s , err %v", root, err)
+			return errors.Wrapf(err, "unable to create directory %s", root)
 		}
 	}
 

--- a/cmd/dep/status.go
+++ b/cmd/dep/status.go
@@ -315,7 +315,7 @@ func runStatusAll(ctx *dep.Ctx, out outputter, p *dep.Project, sm gps.SourceMana
 	// code from the current project.
 	ptree, err := pkgtree.ListPackages(p.ResolvedAbsRoot, string(p.ImportRoot))
 	if err != nil {
-		return digestMismatch, hasMissingPkgs, errors.Errorf("analysis of local packages failed: %v", err)
+		return digestMismatch, hasMissingPkgs, errors.Wrapf(err, "analysis of local packages failed")
 	}
 
 	// Set up a solver in order to check the InputHash.
@@ -340,7 +340,7 @@ func runStatusAll(ctx *dep.Ctx, out outputter, p *dep.Project, sm gps.SourceMana
 
 	s, err := gps.Prepare(params, sm)
 	if err != nil {
-		return digestMismatch, hasMissingPkgs, errors.Errorf("could not set up solver for input hashing: %s", err)
+		return digestMismatch, hasMissingPkgs, errors.Wrapf(err, "could not set up solver for input hashing")
 	}
 
 	cm := collectConstraints(ptree, p, sm)

--- a/context.go
+++ b/context.go
@@ -138,7 +138,7 @@ func (c *Ctx) LoadProject() (*Project, error) {
 		c.Err.Printf("dep: WARNING: %v\n", warn)
 	}
 	if err != nil {
-		return nil, errors.Errorf("error while parsing %s: %s", mp, err)
+		return nil, errors.Wrapf(err, "error while parsing %s", mp)
 	}
 
 	lp := filepath.Join(p.AbsRoot, LockName)
@@ -149,13 +149,13 @@ func (c *Ctx) LoadProject() (*Project, error) {
 			return p, nil
 		}
 		// But if a lock does exist and we can't open it, that's a problem
-		return nil, errors.Errorf("could not open %s: %s", lp, err)
+		return nil, errors.Wrapf(err, "could not open %s", lp)
 	}
 	defer lf.Close()
 
 	p.Lock, err = readLock(lf)
 	if err != nil {
-		return nil, errors.Errorf("error while parsing %s: %s", lp, err)
+		return nil, errors.Wrapf(err, "error while parsing %s", lp)
 	}
 
 	return p, nil

--- a/internal/gps/source_manager.go
+++ b/internal/gps/source_manager.go
@@ -533,7 +533,7 @@ func (sm *SourceMgr) InferConstraint(s string, pi ProjectIdentifier) (Constraint
 	var version PairedVersion
 	versions, err := sm.ListVersions(pi)
 	if err != nil {
-		return nil, errors.Wrapf(err, "list versions for %s(%s)", pi.ProjectRoot, pi.Source) // means repo does not exist
+		return nil, errors.Wrapf(err, "list versions for %s", pi) // means repo does not exist
 	}
 	SortPairedForUpgrade(versions)
 	for _, v := range versions {


### PR DESCRIPTION
### What does this do / why do we need it?

Just a bit of error cleanup. 
- Leverage implicit `ProjectIdentifier.String()`
- Swap in `errors.Wrap...` when tacking the error on as the last argument to `Errorf`
