### PR TITLE
Update out-of-sync error message in ensure

### DIFF
--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -333,7 +333,7 @@ func (cmd *ensureCommand) runUpdate(ctx *dep.Ctx, args []string, p *dep.Project,
 	// "pending" changes, or the -update that caused the problem?).
 	// TODO(sdboyer) reduce this to a warning?
 	if !bytes.Equal(p.Lock.InputHash(), solver.HashInputs()) {
-		return errors.Errorf("%s and %s are out of sync. Run a plain dep ensure to resync them before attempting to -update", dep.ManifestName, dep.LockName)
+		return errors.Errorf("%s is out of sync with %s or the project's imports. Run \"dep ensure\" to resync them first before running \"dep ensure -update\"", dep.LockName, dep.ManifestName)
 	}
 
 	// When -update is specified without args, allow every dependency to change
@@ -428,7 +428,7 @@ func (cmd *ensureCommand) runAdd(ctx *dep.Ctx, args []string, p *dep.Project, sm
 	// "pending" changes, or the -add that caused the problem?).
 	// TODO(sdboyer) reduce this to a warning?
 	if p.Lock != nil && !bytes.Equal(p.Lock.InputHash(), solver.HashInputs()) {
-		return errors.Errorf("%s and %s are out of sync. Run a plain dep ensure to resync them before attempting to -add", dep.ManifestName, dep.LockName)
+		return errors.Errorf("%s is out of sync with %s or the project's imports. Run \"dep ensure\" to resync them first before running \"dep ensure -add\"", dep.LockName, dep.ManifestName)
 	}
 
 	rm, _ := params.RootPackageTree.ToReachMap(true, true, false, p.Manifest.IgnoredPackages())

--- a/cmd/dep/testdata/harness_tests/ensure/add/errs/desync/testcase.json
+++ b/cmd/dep/testdata/harness_tests/ensure/add/errs/desync/testcase.json
@@ -2,5 +2,5 @@
   "commands": [
     ["ensure", "-add", "foobar.com/baz"]
   ],
-  "error-expected": "Gopkg.toml and Gopkg.lock are out of sync. Run a plain dep ensure to resync them before attempting to -add"
+  "error-expected": "Gopkg.lock is out of sync with Gopkg.toml or the project's imports. Run \"dep ensure\" to resync them first before running \"dep ensure -add\""
 }

--- a/cmd/dep/testdata/harness_tests/ensure/update/errs/desync/testcase.json
+++ b/cmd/dep/testdata/harness_tests/ensure/update/errs/desync/testcase.json
@@ -2,5 +2,5 @@
   "commands": [
     ["ensure", "-update"]
   ],
-  "error-expected": "Gopkg.toml and Gopkg.lock are out of sync. Run a plain dep ensure to resync them before attempting to -update"
+  "error-expected": "Gopkg.lock is out of sync with Gopkg.toml or the project's imports. Run \"dep ensure\" to resync them first before running \"dep ensure -update\""
 }


### PR DESCRIPTION
### What does this do / why do we need it?

Update out of sync error message from:

> Gopkg.toml and Gopkg.lock are out of sync. Run a plain dep ensure to resync them before attempting to -add

to:

> Gopkg.lock is out of sync with either Gopkg.toml or the project code. Run a plain dep ensure to resync them before attempting to -add

for both add and update.

### Do you need help or clarification on anything?

Any better suggestions?

### Which issue(s) does this PR fix?

fixes #1104 