### PR TITLE
fix(manifest): validate project roots in manifest

### DIFF
--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -160,6 +160,10 @@ func (cmd *ensureCommand) Run(ctx *dep.Ctx, args []string) error {
 	sm.UseDefaultSignalHandling()
 	defer sm.Release()
 
+	if err := dep.ValidateProjectRoots(ctx, p.Manifest, sm); err != nil {
+		return err
+	}
+
 	params := p.MakeParams()
 	if ctx.Verbose {
 		params.TraceLogger = ctx.Err

--- a/cmd/dep/status.go
+++ b/cmd/dep/status.go
@@ -190,6 +190,10 @@ func (cmd *statusCommand) Run(ctx *dep.Ctx, args []string) error {
 	sm.UseDefaultSignalHandling()
 	defer sm.Release()
 
+	if err := dep.ValidateProjectRoots(ctx, p.Manifest, sm); err != nil {
+		return err
+	}
+
 	var buf bytes.Buffer
 	var out outputter
 	switch {

--- a/manifest.go
+++ b/manifest.go
@@ -190,7 +190,7 @@ func ValidateProjectRoots(c *Ctx, m *Manifest, sm gps.SourceManager) error {
 	var valErr error
 	if len(errorCh) > 0 {
 		valErr = errInvalidProjectRoot
-		c.Err.Printf("The Following issues were found in Gopkg.toml:\n\n")
+		c.Err.Printf("The following issues were found in Gopkg.toml:\n\n")
 		for err := range errorCh {
 			c.Err.Println("  ✗", err.Error())
 		}

--- a/manifest.go
+++ b/manifest.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"regexp"
 	"sort"
+	"sync"
 
 	"github.com/golang/dep/internal/gps"
 	"github.com/pelletier/go-toml"
@@ -22,10 +23,11 @@ const ManifestName = "Gopkg.toml"
 
 // Errors
 var (
-	errInvalidConstraint = errors.New("\"constraint\" must be a TOML array of tables")
-	errInvalidOverride   = errors.New("\"override\" must be a TOML array of tables")
-	errInvalidRequired   = errors.New("\"required\" must be a TOML list of strings")
-	errInvalidIgnored    = errors.New("\"ignored\" must be a TOML list of strings")
+	errInvalidConstraint  = errors.New("\"constraint\" must be a TOML array of tables")
+	errInvalidOverride    = errors.New("\"override\" must be a TOML array of tables")
+	errInvalidRequired    = errors.New("\"required\" must be a TOML list of strings")
+	errInvalidIgnored     = errors.New("\"ignored\" must be a TOML list of strings")
+	errInvalidProjectRoot = errors.New("ProjectRoot name validation failed")
 )
 
 // Manifest holds manifest file data and implements gps.RootManifest.
@@ -166,17 +168,37 @@ func ValidateProjectRoots(c *Ctx, m *Manifest, sm gps.SourceManager) error {
 		projectRoots = append(projectRoots, pr)
 	}
 
+	// Channel to receive all the errors
+	errorCh := make(chan error, len(projectRoots))
+
+	var wg sync.WaitGroup
 	for _, pr := range projectRoots {
-		origPR, err := sm.DeduceProjectRoot(string(pr))
-		if err != nil {
-			return errors.Wrapf(err, "could not deduce project root for %s", pr)
-		}
-		if origPR != pr {
-			c.Err.Printf("dep: WARNING: the name for %q in Gopkg.toml should be changed to %q", pr, origPR)
-		}
+		wg.Add(1)
+		go func(pr gps.ProjectRoot) {
+			defer wg.Done()
+			origPR, err := sm.DeduceProjectRoot(string(pr))
+			if err != nil {
+				errorCh <- err
+			} else if origPR != pr {
+				errorCh <- fmt.Errorf("the name for %q should be changed to %q", pr, origPR)
+			}
+		}(pr)
 	}
 
-	return nil
+	wg.Wait()
+	close(errorCh)
+
+	var valErr error
+	if len(errorCh) > 0 {
+		valErr = errInvalidProjectRoot
+		c.Err.Printf("The Following issues were found in Gopkg.toml:\n\n")
+		for err := range errorCh {
+			c.Err.Println("  ✗", err.Error())
+		}
+		c.Err.Println()
+	}
+
+	return valErr
 }
 
 // readManifest returns a Manifest read from r and a slice of validation warnings.

--- a/manifest.go
+++ b/manifest.go
@@ -172,7 +172,7 @@ func ValidateProjectRoots(c *Ctx, m *Manifest, sm gps.SourceManager) error {
 			return errors.Wrapf(err, "could not deduce project root for %s", pr)
 		}
 		if origPR != pr {
-			c.Err.Printf("dep: WARNING: name %q in Gopkg.toml should be project root", pr)
+			c.Err.Printf("dep: WARNING: the name for %q in Gopkg.toml should be changed to %q", pr, origPR)
 		}
 	}
 

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -393,7 +393,7 @@ func TestValidateProjectRoots(t *testing.T) {
 			name: "valid project root",
 			manifest: Manifest{
 				Constraints: map[gps.ProjectRoot]gps.ProjectProperties{
-					gps.ProjectRoot("github.com/goland/dep"): {
+					gps.ProjectRoot("github.com/golang/dep"): {
 						Constraint: gps.Any(),
 					},
 				},

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -426,9 +426,9 @@ func TestValidateProjectRoots(t *testing.T) {
 			},
 			wantError: false,
 			wantWarn: []string{
-				"name \"github.com/golang/dep/foo\" in Gopkg.toml should be project root",
-				"name \"github.com/golang/mock/bar\" in Gopkg.toml should be project root",
-				"name \"github.com/golang/go/xyz\" in Gopkg.toml should be project root",
+				"the name for \"github.com/golang/dep/foo\" in Gopkg.toml should be changed to \"github.com/golang/dep\"",
+				"the name for \"github.com/golang/mock/bar\" in Gopkg.toml should be changed to \"github.com/golang/mock\"",
+				"the name for \"github.com/golang/go/xyz\" in Gopkg.toml should be changed to \"github.com/golang/go\"",
 			},
 		},
 		{

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -380,13 +380,13 @@ func TestValidateProjectRoots(t *testing.T) {
 	cases := []struct {
 		name      string
 		manifest  Manifest
-		wantError bool
+		wantError error
 		wantWarn  []string
 	}{
 		{
 			name:      "empty Manifest",
 			manifest:  Manifest{},
-			wantError: false,
+			wantError: nil,
 			wantWarn:  []string{},
 		},
 		{
@@ -398,7 +398,7 @@ func TestValidateProjectRoots(t *testing.T) {
 					},
 				},
 			},
-			wantError: false,
+			wantError: nil,
 			wantWarn:  []string{},
 		},
 		{
@@ -424,11 +424,11 @@ func TestValidateProjectRoots(t *testing.T) {
 					},
 				},
 			},
-			wantError: false,
+			wantError: errInvalidProjectRoot,
 			wantWarn: []string{
-				"the name for \"github.com/golang/dep/foo\" in Gopkg.toml should be changed to \"github.com/golang/dep\"",
-				"the name for \"github.com/golang/mock/bar\" in Gopkg.toml should be changed to \"github.com/golang/mock\"",
-				"the name for \"github.com/golang/go/xyz\" in Gopkg.toml should be changed to \"github.com/golang/go\"",
+				"the name for \"github.com/golang/dep/foo\" should be changed to \"github.com/golang/dep\"",
+				"the name for \"github.com/golang/mock/bar\" should be changed to \"github.com/golang/mock\"",
+				"the name for \"github.com/golang/go/xyz\" should be changed to \"github.com/golang/go\"",
 			},
 		},
 		{
@@ -440,7 +440,7 @@ func TestValidateProjectRoots(t *testing.T) {
 					},
 				},
 			},
-			wantError: true,
+			wantError: errInvalidProjectRoot,
 			wantWarn:  []string{},
 		},
 	}
@@ -469,14 +469,14 @@ func TestValidateProjectRoots(t *testing.T) {
 			// Empty the buffer for every case
 			stderrOutput.Reset()
 			err := ValidateProjectRoots(ctx, &c.manifest, sm)
-			if err != nil && !c.wantError {
-				t.Fatalf("Unexpected error while validating project roots: %q", err)
+			if err != c.wantError {
+				t.Fatalf("Unexpected error while validating project roots:\n\t(GOT): %v\n\t(WNT): %v", err, c.wantError)
 			}
 
 			warnings := stderrOutput.String()
 			for _, warn := range c.wantWarn {
 				if !strings.Contains(warnings, warn) {
-					t.Fatalf("Expected ValidateProjectRoot warnings to contain: %q", warn)
+					t.Fatalf("Expected ValidateProjectRoot errors to contain: %q", warn)
 				}
 			}
 		})

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -5,7 +5,10 @@
 package dep
 
 import (
+	"bytes"
 	"errors"
+	"io/ioutil"
+	"log"
 	"reflect"
 	"strings"
 	"testing"
@@ -370,5 +373,112 @@ func TestValidateManifest(t *testing.T) {
 				t.Fatalf("Manifest errors are not as expected: \n\t(MISSING) %v\n\t(FROM) %v", er, c.wantWarn)
 			}
 		}
+	}
+}
+
+func TestValidateProjectRoots(t *testing.T) {
+	cases := []struct {
+		name      string
+		manifest  Manifest
+		wantError bool
+		wantWarn  []string
+	}{
+		{
+			name:      "empty Manifest",
+			manifest:  Manifest{},
+			wantError: false,
+			wantWarn:  []string{},
+		},
+		{
+			name: "valid project root",
+			manifest: Manifest{
+				Constraints: map[gps.ProjectRoot]gps.ProjectProperties{
+					gps.ProjectRoot("github.com/goland/dep"): {
+						Constraint: gps.Any(),
+					},
+				},
+			},
+			wantError: false,
+			wantWarn:  []string{},
+		},
+		{
+			name: "invalid project roots in Constraints and Overrides",
+			manifest: Manifest{
+				Constraints: map[gps.ProjectRoot]gps.ProjectProperties{
+					gps.ProjectRoot("github.com/golang/dep/foo"): {
+						Constraint: gps.Any(),
+					},
+					gps.ProjectRoot("github.com/golang/go/xyz"): {
+						Constraint: gps.Any(),
+					},
+					gps.ProjectRoot("github.com/golang/fmt"): {
+						Constraint: gps.Any(),
+					},
+				},
+				Ovr: map[gps.ProjectRoot]gps.ProjectProperties{
+					gps.ProjectRoot("github.com/golang/mock/bar"): {
+						Constraint: gps.Any(),
+					},
+					gps.ProjectRoot("github.com/golang/mock"): {
+						Constraint: gps.Any(),
+					},
+				},
+			},
+			wantError: false,
+			wantWarn: []string{
+				"name \"github.com/golang/dep/foo\" in Gopkg.toml should be project root",
+				"name \"github.com/golang/mock/bar\" in Gopkg.toml should be project root",
+				"name \"github.com/golang/go/xyz\" in Gopkg.toml should be project root",
+			},
+		},
+		{
+			name: "invalid source path",
+			manifest: Manifest{
+				Constraints: map[gps.ProjectRoot]gps.ProjectProperties{
+					gps.ProjectRoot("github.com/golang"): {
+						Constraint: gps.Any(),
+					},
+				},
+			},
+			wantError: true,
+			wantWarn:  []string{},
+		},
+	}
+
+	h := test.NewHelper(t)
+	defer h.Cleanup()
+
+	h.TempDir("src")
+	pwd := h.Path(".")
+
+	// Capture the stderr to verify the warnings
+	stderrOutput := &bytes.Buffer{}
+	errLogger := log.New(stderrOutput, "", 0)
+	ctx := &Ctx{
+		GOPATH: pwd,
+		Out:    log.New(ioutil.Discard, "", 0),
+		Err:    errLogger,
+	}
+
+	sm, err := ctx.SourceManager()
+	h.Must(err)
+	defer sm.Release()
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// Empty the buffer for every case
+			stderrOutput.Reset()
+			err := ValidateProjectRoots(ctx, &c.manifest, sm)
+			if err != nil && !c.wantError {
+				t.Fatalf("Unexpected error while validating project roots: %q", err)
+			}
+
+			warnings := stderrOutput.String()
+			for _, warn := range c.wantWarn {
+				if !strings.Contains(warnings, warn) {
+					t.Fatalf("Expected ValidateProjectRoot warnings to contain: %q", warn)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
Validating ProjectRoot(s) require source manager, which is created after
loading the project. Hence, ProjectRoot validation can't be done in
existing validateManifest.

This change adds `ValidateProjectRoots()` which validates only the Constraint
and Override names to be valid ProjectRoot. Warnings are issued at stderr when
invalid ProjectRoot is found in manifest.

`ensure` and `status` call `ValidateProjectRoots()` expecitly.

<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].
-->

### What does this do / why do we need it?
Validates ProjectRoots in manifest.

### What should your reviewer look out for in this PR?
The warning and error messages.

### Do you need help or clarification on anything?
Should we warn or just error out when an invalid ProjectRoot is found?

### Which issue(s) does this PR fix?

fixes #984 