### PR TITLE
gps: unwrapVcsErr cleanup

### DIFF
--- a/internal/gps/source_errors.go
+++ b/internal/gps/source_errors.go
@@ -5,20 +5,21 @@
 package gps
 
 import (
-	"fmt"
-
 	"github.com/Masterminds/vcs"
+	"github.com/pkg/errors"
 )
 
-// unwrapVcsErr will extract actual command output from a vcs err, if possible
-//
-// TODO this is really dumb, lossy, and needs proper handling
+// unwrapVcsErr recognizes *vcs.LocalError and *vsc.RemoteError, and returns a form
+// preserving the actual vcs command output and error, in addition to the message.
+// All other types pass through unchanged.
 func unwrapVcsErr(err error) error {
-	switch verr := err.(type) {
+	switch t := err.(type) {
 	case *vcs.LocalError:
-		return fmt.Errorf("%s: %s", verr.Error(), verr.Out())
+		cause, out, msg := t.Original(), t.Out(), t.Error()
+		return errors.Wrap(errors.Wrap(cause, out), msg)
 	case *vcs.RemoteError:
-		return fmt.Errorf("%s: %s", verr.Error(), verr.Out())
+		cause, out, msg := t.Original(), t.Out(), t.Error()
+		return errors.Wrap(errors.Wrap(cause, out), msg)
 	default:
 		return err
 	}


### PR DESCRIPTION
### What does this do / why do we need it?

This PR addresses a `TODO` from`unwrapVcsErr`:

```go
// TODO this is really dumb, lossy, and needs proper handling
func unwrapVcsErr(err error) error {
...
```

This function was returning errors like `<message>: <command output>`, and ignoring the available `error`.
Now it wraps up the error like we've been doing elsewhere: (`errors.Wrap(err, out)`), and then wraps *that* error with the message.  This way nothing is missing from output, and we get a more complete `errors.Wrap` trail preserving underlying types, stack traces, etc.
