### PR TITLE
Replace import path 'Sirupsen/logrus' with 'sirupsen/logrus'

### DIFF
--- a/internal/gps/manager_test.go
+++ b/internal/gps/manager_test.go
@@ -539,7 +539,7 @@ func TestMultiFetchThreadsafe(t *testing.T) {
 		mkPI("gopkg.in/sdboyer/gpkt.v2"),
 		mkPI("github.com/Masterminds/VCSTestRepo"),
 		mkPI("github.com/go-yaml/yaml"),
-		mkPI("github.com/Sirupsen/logrus"),
+		mkPI("github.com/sirupsen/logrus"),
 		mkPI("github.com/Masterminds/semver"),
 		mkPI("github.com/Masterminds/vcs"),
 		//mkPI("bitbucket.org/sdboyer/withbm"),


### PR DESCRIPTION
Use the new canonical project URL (note the lowercase 's') for logrus to prevent duplicate checkouts & imports of logrus.

See: https://github.com/sirupsen/logrus/pull/384