### PR TITLE
gps: source cache: fix flaky bolt test

### DIFF
--- a/internal/gps/source_cache_bolt_test.go
+++ b/internal/gps/source_cache_bolt_test.go
@@ -139,11 +139,7 @@ func TestBoltCacheTimeout(t *testing.T) {
 
 	// Read with a later epoch. Expect no *timestamped* values, since all were < `after`.
 	{
-		after := time.Now()
-		if after.Unix() <= start.Unix() {
-			// Ensure a future timestamp.
-			after = start.Add(10 * time.Second)
-		}
+		after := start.Add(1000 * time.Hour)
 		bc, err = newBoltCache(cpath, after.Unix(), logger)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
### What does this do / why do we need it?

This PR aims to improve the flaky `TestBoltCacheTimeout`, which randomly fails on CI and for some people locally (I haven't actually reproduced it).  For the purpose of the failing test, we can just force a future timestamp.