### PR TITLE
fix(status): concurrent BasicStatus creation

### DIFF
--- a/cmd/dep/status.go
+++ b/cmd/dep/status.go
@@ -43,6 +43,11 @@ print an extended status output for each dependency of the project.
 Status returns exit code zero if all dependencies are in a "good state".
 `
 
+const (
+	shortRev = iota
+	longRev  = iota
+)
+
 var (
 	errFailedUpdate     = errors.New("failed to fetch updates")
 	errFailedListPkg    = errors.New("failed to list packages")
@@ -104,7 +109,7 @@ func (out *tableOutput) BasicLine(bs *BasicStatus) {
 		bs.getConsolidatedConstraint(),
 		formatVersion(bs.Version),
 		formatVersion(bs.Revision),
-		bs.getConsolidatedLatest(),
+		bs.getConsolidatedLatest(shortRev),
 		bs.PackageCount,
 	)
 }
@@ -312,10 +317,15 @@ func (bs *BasicStatus) getConsolidatedVersion() string {
 	return version
 }
 
-func (bs *BasicStatus) getConsolidatedLatest() string {
+func (bs *BasicStatus) getConsolidatedLatest(revSize int) string {
 	latest := ""
 	if bs.Latest != nil {
-		latest = formatVersion(bs.Latest)
+		switch revSize {
+		case shortRev:
+			latest = formatVersion(bs.Latest)
+		case longRev:
+			latest = bs.Latest.String()
+		}
 	}
 
 	if bs.hasError {
@@ -330,8 +340,8 @@ func (bs *BasicStatus) marshalJSON() *rawStatus {
 		ProjectRoot:  bs.ProjectRoot,
 		Constraint:   bs.getConsolidatedConstraint(),
 		Version:      formatVersion(bs.Version),
-		Revision:     formatVersion(bs.Revision),
-		Latest:       bs.getConsolidatedLatest(),
+		Revision:     string(bs.Revision),
+		Latest:       bs.getConsolidatedLatest(longRev),
 		PackageCount: bs.PackageCount,
 	}
 }

--- a/cmd/dep/status.go
+++ b/cmd/dep/status.go
@@ -354,22 +354,24 @@ type MissingStatus struct {
 
 // errorStatus contains information about error and number of status failures.
 type errorStatus struct {
-	err   error
+	err error
+	// count is for counting errors due to which we don't fail completely, but
+	// return partial results with missing/unknown data.
 	count int
 }
 
-func runStatusAll(ctx *dep.Ctx, out outputter, p *dep.Project, sm gps.SourceManager) (bool, bool, errorStatus) {
-	var digestMismatch, hasMissingPkgs bool
-
+func runStatusAll(ctx *dep.Ctx, out outputter, p *dep.Project, sm gps.SourceManager) (digestMismatch bool, hasMissingPkgs bool, errStatus errorStatus) {
 	if p.Lock == nil {
-		return digestMismatch, hasMissingPkgs, errorStatus{err: errors.Errorf("no Gopkg.lock found. Run `dep ensure` to generate lock file")}
+		errStatus.err = errors.Errorf("no Gopkg.lock found. Run `dep ensure` to generate lock file")
+		return digestMismatch, hasMissingPkgs, errStatus
 	}
 
 	// While the network churns on ListVersions() requests, statically analyze
 	// code from the current project.
 	ptree, err := pkgtree.ListPackages(p.ResolvedAbsRoot, string(p.ImportRoot))
 	if err != nil {
-		return digestMismatch, hasMissingPkgs, errorStatus{err: errors.Wrapf(err, "analysis of local packages failed")}
+		errStatus.err = errors.Wrapf(err, "analysis of local packages failed")
+		return digestMismatch, hasMissingPkgs, errStatus
 	}
 
 	// Set up a solver in order to check the InputHash.
@@ -394,7 +396,8 @@ func runStatusAll(ctx *dep.Ctx, out outputter, p *dep.Project, sm gps.SourceMana
 
 	s, err := gps.Prepare(params, sm)
 	if err != nil {
-		return digestMismatch, hasMissingPkgs, errorStatus{err: errors.Wrapf(err, "could not set up solver for input hashing")}
+		errStatus.err = errors.Wrapf(err, "could not set up solver for input hashing")
+		return digestMismatch, hasMissingPkgs, errStatus
 	}
 
 	cm := collectConstraints(ptree, p, sm)
@@ -521,12 +524,9 @@ func runStatusAll(ctx *dep.Ctx, out outputter, p *dep.Project, sm gps.SourceMana
 		// Newline after printing the status progress output
 		logger.Println()
 
-		var statusError error
-		var errorCount int
-
 		// List Packages errors. This would happen only for dot output.
 		if len(errListPkgCh) > 0 {
-			statusError = errFailedListPkg
+			errStatus.err = errFailedListPkg
 			if ctx.Verbose {
 				for err := range errListPkgCh {
 					ctx.Err.Println(err.Error())
@@ -537,13 +537,15 @@ func runStatusAll(ctx *dep.Ctx, out outputter, p *dep.Project, sm gps.SourceMana
 
 		// List Version errors
 		if len(errListVerCh) > 0 {
-			if statusError == errFailedListPkg {
-				statusError = errMultipleFailures
+			if errStatus.err == nil {
+				errStatus.err = errFailedUpdate
 			} else {
-				statusError = errFailedUpdate
+				errStatus.err = errMultipleFailures
 			}
 
-			errorCount = len(errListVerCh)
+			// Count ListVersions error because we get partial results when
+			// this happens.
+			errStatus.count = len(errListVerCh)
 			if ctx.Verbose {
 				for err := range errListVerCh {
 					ctx.Err.Println(err.Error())
@@ -567,7 +569,7 @@ func runStatusAll(ctx *dep.Ctx, out outputter, p *dep.Project, sm gps.SourceMana
 
 		out.BasicFooter()
 
-		return digestMismatch, hasMissingPkgs, errorStatus{err: statusError, count: errorCount}
+		return digestMismatch, hasMissingPkgs, errStatus
 	}
 
 	// Hash digest mismatch may indicate that some deps are no longer

--- a/cmd/dep/status_test.go
+++ b/cmd/dep/status_test.go
@@ -235,7 +235,7 @@ func TestBasicStatusGetConsolidatedLatest(t *testing.T) {
 	testCases := []struct {
 		name        string
 		basicStatus BasicStatus
-		revSize     int
+		revSize     uint8
 		wantLatest  string
 	}{
 		{

--- a/cmd/dep/status_test.go
+++ b/cmd/dep/status_test.go
@@ -230,3 +230,60 @@ func TestBasicStatusGetConsolidatedVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestBasicStatusGetConsolidatedLatest(t *testing.T) {
+	testCases := []struct {
+		name        string
+		basicStatus BasicStatus
+		revSize     int
+		wantLatest  string
+	}{
+		{
+			name:        "empty BasicStatus",
+			basicStatus: BasicStatus{},
+			revSize:     shortRev,
+			wantLatest:  "",
+		},
+		{
+			name: "nil latest",
+			basicStatus: BasicStatus{
+				Latest: nil,
+			},
+			revSize:    shortRev,
+			wantLatest: "",
+		},
+		{
+			name: "with error",
+			basicStatus: BasicStatus{
+				hasError: true,
+			},
+			revSize:    shortRev,
+			wantLatest: "unknown",
+		},
+		{
+			name: "short latest",
+			basicStatus: BasicStatus{
+				Latest: gps.Revision("adummylonglongrevision"),
+			},
+			revSize:    shortRev,
+			wantLatest: "adummyl",
+		},
+		{
+			name: "long latest",
+			basicStatus: BasicStatus{
+				Latest: gps.Revision("adummylonglongrevision"),
+			},
+			revSize:    longRev,
+			wantLatest: "adummylonglongrevision",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotRev := tc.basicStatus.getConsolidatedLatest(tc.revSize)
+			if gotRev != tc.wantLatest {
+				t.Errorf("unexpected consolidated latest: \n\t(GOT) %v \n\t(WNT) %v", gotRev, tc.wantLatest)
+			}
+		})
+	}
+}

--- a/cmd/dep/status_test.go
+++ b/cmd/dep/status_test.go
@@ -85,6 +85,16 @@ func TestBasicLine(t *testing.T) {
 			wantJSONStatus:  []string{`"Revision":"revxyz"`, `"Constraint":"1.2.3"`, `"Version":"1.0.0"`},
 			wantTableStatus: []string{`github.com/foo/bar  1.2.3       1.0.0    revxyz            0`},
 		},
+		{
+			name: "BasicStatus with update error",
+			status: BasicStatus{
+				ProjectRoot: "github.com/foo/bar",
+				hasError:    true,
+			},
+			wantDotStatus:   []string{`[label="github.com/foo/bar"];`},
+			wantJSONStatus:  []string{`"Version":""`, `"Revision":""`, `"Latest":"unknown"`},
+			wantTableStatus: []string{`github.com/foo/bar                                 unknown  0`},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This change adds concurrent BasicStatus creation, maintaining the order
of status output.

<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].
-->

### What does this do / why do we need it?
It reduces the time taken by `status`.
Before:
```
real    0m16.092s
user    0m0.408s
sys    0m0.394s
```
After:
```
real    0m1.777s
user    0m0.411s
sys    0m0.339s
```

### What should your reviewer look out for in this PR?
Correctness of concurrency code.

### Do you need help or clarification on anything?
~Some help with the detected race condition.~

### Which issue(s) does this PR fix?

Related to https://github.com/golang/dep/issues/1008 , making status more verbose on failures.
<!--

fixes #
fixes #

-->
