### PR TITLE
gps: fix unwrapVcsErr to handle nil causes

### DIFF
--- a/internal/gps/source_errors.go
+++ b/internal/gps/source_errors.go
@@ -13,14 +13,23 @@ import (
 // preserving the actual vcs command output and error, in addition to the message.
 // All other types pass through unchanged.
 func unwrapVcsErr(err error) error {
+	var cause error
+	var out, msg string
+
 	switch t := err.(type) {
 	case *vcs.LocalError:
-		cause, out, msg := t.Original(), t.Out(), t.Error()
-		return errors.Wrap(errors.Wrap(cause, out), msg)
+		cause, out, msg = t.Original(), t.Out(), t.Error()
 	case *vcs.RemoteError:
-		cause, out, msg := t.Original(), t.Out(), t.Error()
-		return errors.Wrap(errors.Wrap(cause, out), msg)
+		cause, out, msg = t.Original(), t.Out(), t.Error()
+
 	default:
 		return err
 	}
+
+	if cause == nil {
+		cause = errors.New(out)
+	} else {
+		cause = errors.Wrap(cause, out)
+	}
+	return errors.Wrap(cause, msg)
 }

--- a/internal/gps/source_errors_test.go
+++ b/internal/gps/source_errors_test.go
@@ -1,0 +1,30 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gps
+
+import (
+	"testing"
+
+	"github.com/Masterminds/vcs"
+)
+
+func TestUnwrapVcsErrNonNil(t *testing.T) {
+	for _, err := range []error{
+		vcs.NewRemoteError("msg", nil, "out"),
+		vcs.NewRemoteError("msg", nil, ""),
+		vcs.NewRemoteError("", nil, "out"),
+		vcs.NewRemoteError("", nil, ""),
+		vcs.NewLocalError("msg", nil, "out"),
+		vcs.NewLocalError("msg", nil, ""),
+		vcs.NewLocalError("", nil, "out"),
+		vcs.NewLocalError("", nil, ""),
+		&vcs.RemoteError{},
+		&vcs.LocalError{},
+	} {
+		if unwrapVcsErr(err) == nil {
+			t.Errorf("unexpected nil error unwrapping: %#v", err)
+		}
+	}
+}


### PR DESCRIPTION
### What does this do / why do we need it?

In #1121 I didn't anticipate that incoming vcs errors could have nil original errors, and the result is a nil return value: https://github.com/golang/dep/issues/1128#issuecomment-328268278
This PR adjusts `unwrapVcsErr` to recognize nil original errors, and wrap them differently.

### Which issue(s) does this PR fix?

Should fix -> #1128, but let's not close until confirmed.
