### PR TITLE
Disable parallel importer tests

### DIFF
--- a/cmd/dep/base_importer_test.go
+++ b/cmd/dep/base_importer_test.go
@@ -396,8 +396,6 @@ func TestBaseImporter_ImportProjects(t *testing.T) {
 		name := name
 		tc := tc
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
 			err := tc.Exec(t, func(logger *log.Logger, sm gps.SourceManager) (*dep.Manifest, *dep.Lock, error) {
 				i := newBaseImporter(logger, true, sm)
 				convertErr := i.importPackages(tc.projects, tc.defaultConstraintFromLock)
@@ -426,6 +424,7 @@ type convertTestCase struct {
 func (tc convertTestCase) Exec(t *testing.T, convert func(logger *log.Logger, sm gps.SourceManager) (*dep.Manifest, *dep.Lock, error)) error {
 	h := test.NewHelper(t)
 	defer h.Cleanup()
+	h.Parallel()
 
 	ctx := newTestContext(h)
 	sm, err := ctx.SourceManager()

--- a/cmd/dep/base_importer_test.go
+++ b/cmd/dep/base_importer_test.go
@@ -142,7 +142,9 @@ func TestBaseImporter_LookupVersionForLockedProject(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			h := test.NewHelper(t)
 			defer h.Cleanup()
-			h.Parallel()
+			// Disable parallel tests until we can resolve this error on the Windows builds:
+			// "remote repository at https://github.com/carolynvs/deptest-importers does not exist, or is inaccessible"
+			//h.Parallel()
 
 			ctx := newTestContext(h)
 			sm, err := ctx.SourceManager()
@@ -424,7 +426,9 @@ type convertTestCase struct {
 func (tc convertTestCase) Exec(t *testing.T, convert func(logger *log.Logger, sm gps.SourceManager) (*dep.Manifest, *dep.Lock, error)) error {
 	h := test.NewHelper(t)
 	defer h.Cleanup()
-	h.Parallel()
+	// Disable parallel tests until we can resolve this error on the Windows builds:
+	// "remote repository at https://github.com/carolynvs/deptest-importers does not exist, or is inaccessible"
+	//h.Parallel()
 
 	ctx := newTestContext(h)
 	sm, err := ctx.SourceManager()

--- a/cmd/dep/glide_importer_test.go
+++ b/cmd/dep/glide_importer_test.go
@@ -176,8 +176,6 @@ func TestGlideConfig_Convert(t *testing.T) {
 		name := name
 		testCase := testCase
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
 			err := testCase.Exec(t, func(logger *log.Logger, sm gps.SourceManager) (*dep.Manifest, *dep.Lock, error) {
 				g := newGlideImporter(logger, true, sm)
 				g.glideConfig = testCase.yaml

--- a/cmd/dep/godep_importer_test.go
+++ b/cmd/dep/godep_importer_test.go
@@ -80,8 +80,6 @@ func TestGodepConfig_Convert(t *testing.T) {
 		name := name
 		testCase := testCase
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
 			err := testCase.Exec(t, func(logger *log.Logger, sm gps.SourceManager) (*dep.Manifest, *dep.Lock, error) {
 				g := newGodepImporter(logger, true, sm)
 				g.json = testCase.json

--- a/cmd/dep/gopath_scanner_test.go
+++ b/cmd/dep/gopath_scanner_test.go
@@ -17,9 +17,10 @@ const testProject1 string = "github.com/sdboyer/deptest"
 const testProject2 string = "github.com/sdboyer/deptestdos"
 
 func TestGopathScanner_OverlayManifestConstraints(t *testing.T) {
-	t.Parallel()
-
 	h := test.NewHelper(t)
+	h.Parallel()
+	defer h.Cleanup()
+
 	ctx := newTestContext(h)
 
 	pi1 := gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot(testProject1)}
@@ -69,9 +70,10 @@ func TestGopathScanner_OverlayManifestConstraints(t *testing.T) {
 }
 
 func TestGopathScanner_OverlayLockProjects(t *testing.T) {
-	t.Parallel()
-
 	h := test.NewHelper(t)
+	h.Parallel()
+	defer h.Cleanup()
+
 	ctx := newTestContext(h)
 
 	rootM := dep.NewManifest()

--- a/cmd/dep/govend_importer_test.go
+++ b/cmd/dep/govend_importer_test.go
@@ -67,8 +67,6 @@ func TestGovendConfig_Convert(t *testing.T) {
 		name := name
 		testCase := testCase
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
 			err := testCase.Exec(t, func(logger *log.Logger, sm gps.SourceManager) (*dep.Manifest, *dep.Lock, error) {
 				g := newGovendImporter(logger, true, sm)
 				g.yaml = testCase.yaml

--- a/cmd/dep/vndr_importer_test.go
+++ b/cmd/dep/vndr_importer_test.go
@@ -57,8 +57,6 @@ func TestVndrConfig_Convert(t *testing.T) {
 		name := name
 		testCase := testCase
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
 			err := testCase.Exec(t, func(logger *log.Logger, sm gps.SourceManager) (*dep.Manifest, *dep.Lock, error) {
 				g := newVndrImporter(logger, true, sm)
 				g.packages = testCase.packages


### PR DESCRIPTION
### What does this do / why do we need it?
The AppVeyor(Windows) build is failing with the following error and I can't figure out why.

```
remote repository at https://github.com/carolynvs/deptest-importers does not exist, or is inaccessible
```

I originally tried to fix this by making sure that each test had it's own separate GOPATH, and that they are all using `h.Parallel()`. I've left that in, even though it didn't fix the tests on Windows.

### What should your reviewer look out for in this PR?
Nope, just need to get the build working again. Since AppVeyor isn't kicking off right now for this repo, here's a link of the build passing on my branch:

https://ci.appveyor.com/project/carolynvs/dep/build/4

### Do you need help or clarification on anything?
Let's just get the build working again. If someone knows how to fix this, please jump in and submit a PR, making sure that the [AppVeyor build](https://ci.appveyor.com/project/golang/dep) passes (it isn't currently reporting back to GitHub).