### PR TITLE
gps: remove unused context.WithCancel

### DIFF
--- a/internal/gps/deduce.go
+++ b/internal/gps/deduce.go
@@ -575,8 +575,8 @@ func newDeductionCoordinator(superv *supervisor) *deductionCoordinator {
 // the root path and a list of maybeSources, which can be subsequently used to
 // create a handler that will manage the particular source.
 func (dc *deductionCoordinator) deduceRootPath(ctx context.Context, path string) (pathDeduction, error) {
-	if dc.suprvsr.getLifetimeContext().Err() != nil {
-		return pathDeduction{}, errors.New("deductionCoordinator has been terminated")
+	if err := dc.suprvsr.ctx.Err(); err != nil {
+		return pathDeduction{}, err
 	}
 
 	// First, check the rootxt to see if there's a prefix match - if so, we

--- a/internal/gps/source.go
+++ b/internal/gps/source.go
@@ -68,8 +68,8 @@ func newSourceCoordinator(superv *supervisor, deducer deducer, cachedir string, 
 func (sc *sourceCoordinator) close() {}
 
 func (sc *sourceCoordinator) getSourceGatewayFor(ctx context.Context, id ProjectIdentifier) (*sourceGateway, error) {
-	if sc.supervisor.getLifetimeContext().Err() != nil {
-		return nil, errors.New("sourceCoordinator has been terminated")
+	if err := sc.supervisor.ctx.Err(); err != nil {
+		return nil, err
 	}
 
 	normalizedName := id.normalizedSource()


### PR DESCRIPTION
Remove unnecessary getLifetimeContext method while I'm here.

<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].
-->

### What does this do / why do we need it?

Removes unnecessary code.

### What should your reviewer look out for in this PR?

Nothing, this is simple.

### Do you need help or clarification on anything?

No.

### Which issue(s) does this PR fix?

None.

<!--

fixes #
fixes #

-->
