### PR TITLE
Build all packages before running linters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ jobs:
       os: linux
       go: 1.9.x
       script:
-        - go build -v ./cmd/dep
+        - go test -i ./...
         - ./hack/lint.bash
         - ./hack/validate-vendor.bash
         - ./hack/validate-licence.bash

--- a/cmd/dep/godep_importer_test.go
+++ b/cmd/dep/godep_importer_test.go
@@ -105,7 +105,7 @@ func TestGodepConfig_Import(t *testing.T) {
 	projectRoot := h.Path(testProjectRoot)
 	sm, err := gps.NewSourceManager(gps.SourceManagerConfig{
 		Cachedir: h.Path(cacheDir),
-		Logger:   log.New(test.Writer{t}, "", 0),
+		Logger:   log.New(test.Writer{TB: t}, "", 0),
 	})
 	h.Must(err)
 	defer sm.Release()

--- a/internal/gps/manager_test.go
+++ b/internal/gps/manager_test.go
@@ -45,7 +45,7 @@ func mkNaiveSM(t *testing.T) (*SourceMgr, func()) {
 
 	sm, err := NewSourceManager(SourceManagerConfig{
 		Cachedir: cpath,
-		Logger:   log.New(test.Writer{t}, "", 0),
+		Logger:   log.New(test.Writer{TB: t}, "", 0),
 	})
 	if err != nil {
 		t.Fatalf("Unexpected error on SourceManager creation: %s", err)
@@ -66,7 +66,7 @@ func remakeNaiveSM(osm *SourceMgr, t *testing.T) (*SourceMgr, func()) {
 
 	sm, err := NewSourceManager(SourceManagerConfig{
 		Cachedir: cpath,
-		Logger:   log.New(test.Writer{t}, "", 0),
+		Logger:   log.New(test.Writer{TB: t}, "", 0),
 	})
 	if err != nil {
 		t.Fatalf("unexpected error on SourceManager recreation: %s", err)
@@ -88,7 +88,7 @@ func TestSourceManagerInit(t *testing.T) {
 	}
 	cfg := SourceManagerConfig{
 		Cachedir: cpath,
-		Logger:   log.New(test.Writer{t}, "", 0),
+		Logger:   log.New(test.Writer{TB: t}, "", 0),
 	}
 
 	sm, err := NewSourceManager(cfg)
@@ -144,7 +144,7 @@ func TestSourceInit(t *testing.T) {
 
 	sm, err := NewSourceManager(SourceManagerConfig{
 		Cachedir: cpath,
-		Logger:   log.New(test.Writer{t}, "", 0),
+		Logger:   log.New(test.Writer{TB: t}, "", 0),
 	})
 	if err != nil {
 		t.Fatalf("Unexpected error on SourceManager creation: %s", err)

--- a/internal/gps/result_test.go
+++ b/internal/gps/result_test.go
@@ -126,7 +126,7 @@ func BenchmarkCreateVendorTree(b *testing.B) {
 	clean := true
 	sm, err := NewSourceManager(SourceManagerConfig{
 		Cachedir: path.Join(tmp, "cache"),
-		Logger:   log.New(test.Writer{b}, "", 0),
+		Logger:   log.New(test.Writer{TB: b}, "", 0),
 	})
 	if err != nil {
 		b.Errorf("failed to create SourceManager: %q", err)

--- a/internal/gps/solve_test.go
+++ b/internal/gps/solve_test.go
@@ -25,7 +25,7 @@ func fixSolve(params SolveParameters, sm SourceManager, t *testing.T) (Solution,
 	// Trace unconditionally; by passing the trace through t.Log(), the testing
 	// system will decide whether or not to actually show the output (based on
 	// -v, or selectively on test failure).
-	params.TraceLogger = log.New(test.Writer{t}, "", 0)
+	params.TraceLogger = log.New(test.Writer{TB: t}, "", 0)
 	// always return false, otherwise it would identify pretty much all of
 	// our fixtures as being stdlib and skip everything
 	params.stdLibFn = func(string) bool { return false }

--- a/internal/gps/solver_inputs_test.go
+++ b/internal/gps/solver_inputs_test.go
@@ -171,7 +171,7 @@ func TestValidateParams(t *testing.T) {
 	h.TempDir(cacheDir)
 	sm, err := NewSourceManager(SourceManagerConfig{
 		Cachedir: h.Path(cacheDir),
-		Logger:   log.New(test.Writer{t}, "", 0),
+		Logger:   log.New(test.Writer{TB: t}, "", 0),
 	})
 	h.Must(err)
 	defer sm.Release()

--- a/internal/gps/source_cache_bolt_test.go
+++ b/internal/gps/source_cache_bolt_test.go
@@ -21,7 +21,7 @@ func TestBoltCacheTimeout(t *testing.T) {
 		t.Fatalf("Failed to create temp cache dir: %s", err)
 	}
 	pi := ProjectIdentifier{ProjectRoot: root}
-	logger := log.New(test.Writer{t}, "", 0)
+	logger := log.New(test.Writer{TB: t}, "", 0)
 
 	start := time.Now()
 	bc, err := newBoltCache(cpath, start.Unix(), logger)

--- a/internal/gps/source_cache_test.go
+++ b/internal/gps/source_cache_test.go
@@ -25,7 +25,7 @@ func Test_singleSourceCache(t *testing.T) {
 	epoch := time.Now().Unix()
 	newBolt := func(t *testing.T, cachedir, root string) (singleSourceCache, func() error) {
 		pi := mkPI(root).normalize()
-		bc, err := newBoltCache(cachedir, epoch, log.New(test.Writer{t}, "", 0))
+		bc, err := newBoltCache(cachedir, epoch, log.New(test.Writer{TB: t}, "", 0))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/gps/source_manager_test.go
+++ b/internal/gps/source_manager_test.go
@@ -94,7 +94,7 @@ func TestSourceManager_InferConstraint(t *testing.T) {
 
 			sm, err := NewSourceManager(SourceManagerConfig{
 				Cachedir: h.Path(cacheDir),
-				Logger:   log.New(test.Writer{t}, "", 0),
+				Logger:   log.New(test.Writer{TB: t}, "", 0),
 			})
 			h.Must(err)
 

--- a/internal/gps/source_test.go
+++ b/internal/gps/source_test.go
@@ -40,7 +40,7 @@ func testSourceGateway(t *testing.T) {
 	do := func(wantstate sourceState) func(t *testing.T) {
 		return func(t *testing.T) {
 			superv := newSupervisor(ctx)
-			sc := newSourceCoordinator(superv, newDeductionCoordinator(superv), cachedir, log.New(test.Writer{t}, "", 0))
+			sc := newSourceCoordinator(superv, newDeductionCoordinator(superv), cachedir, log.New(test.Writer{TB: t}, "", 0))
 
 			id := mkPI("github.com/sdboyer/deptest")
 			sg, err := sc.getSourceGatewayFor(ctx, id)


### PR DESCRIPTION
`go vet`, in particular, is known for relying on the package cache
for code analysis.

<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].
-->

### What does this do / why do we need it?

On my local machine, `lint.bash` produces the following output:
```
cmd/dep/godep_importer_test.go:108: github.com/golang/dep/internal/test.Writer composite literal uses unkeyed fields
exit status 1
internal/gps/manager_test.go:48: github.com/golang/dep/internal/test.Writer composite literal uses unkeyed fields
internal/gps/manager_test.go:69: github.com/golang/dep/internal/test.Writer composite literal uses unkeyed fields
internal/gps/manager_test.go:91: github.com/golang/dep/internal/test.Writer composite literal uses unkeyed fields
internal/gps/manager_test.go:147: github.com/golang/dep/internal/test.Writer composite literal uses unkeyed fields
internal/gps/result_test.go:129: github.com/golang/dep/internal/test.Writer composite literal uses unkeyed fields
internal/gps/solve_test.go:28: github.com/golang/dep/internal/test.Writer composite literal uses unkeyed fields
internal/gps/solver_inputs_test.go:174: github.com/golang/dep/internal/test.Writer composite literal uses unkeyed fields
internal/gps/source_cache_bolt_test.go:24: github.com/golang/dep/internal/test.Writer composite literal uses unkeyed fields
internal/gps/source_cache_test.go:28: github.com/golang/dep/internal/test.Writer composite literal uses unkeyed fields
internal/gps/source_manager_test.go:97: github.com/golang/dep/internal/test.Writer composite literal uses unkeyed fields
internal/gps/source_test.go:43: github.com/golang/dep/internal/test.Writer composite literal uses unkeyed fields
exit status 1
```

I believe the missing call to `go test -i` is the reason we're not seeing these issues in travis.

### What should your reviewer look out for in this PR?

Nothing yet, but I'll probably amend this with the fixes once travis (hopefully) fails.

### Do you need help or clarification on anything?

No.

### Which issue(s) does this PR fix?

None.

<!--

fixes #
fixes #

-->
