### PR TITLE
testing: de-globalize discard loggers

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -17,9 +17,9 @@ import (
 	"github.com/golang/dep/internal/test"
 )
 
-var (
-	discardLogger = log.New(ioutil.Discard, "", 0)
-)
+func discardLogger() *log.Logger {
+	return log.New(ioutil.Discard, "", 0)
+}
 
 func TestCtx_ProjectImport(t *testing.T) {
 	h := test.NewHelper(t)
@@ -127,8 +127,8 @@ func TestLoadProject(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := &Ctx{
-				Out: discardLogger,
-				Err: discardLogger,
+				Out: discardLogger(),
+				Err: discardLogger(),
 			}
 
 			err := ctx.SetPaths(h.Path(tc.wd), h.Path("."))
@@ -200,8 +200,8 @@ func TestLoadProjectManifestParseError(t *testing.T) {
 	ctx := &Ctx{
 		GOPATH:     tg.Path("."),
 		WorkingDir: wd,
-		Out:        discardLogger,
-		Err:        discardLogger,
+		Out:        discardLogger(),
+		Err:        discardLogger(),
 	}
 
 	_, err = ctx.LoadProject()
@@ -231,8 +231,8 @@ func TestLoadProjectLockParseError(t *testing.T) {
 	ctx := &Ctx{
 		GOPATH:     tg.Path("."),
 		WorkingDir: wd,
-		Out:        discardLogger,
-		Err:        discardLogger,
+		Out:        discardLogger(),
+		Err:        discardLogger(),
 	}
 
 	_, err = ctx.LoadProject()

--- a/internal/gps/result_test.go
+++ b/internal/gps/result_test.go
@@ -15,7 +15,9 @@ import (
 	"github.com/golang/dep/internal/test"
 )
 
-var discardLogger = log.New(ioutil.Discard, "", 0)
+func discardLogger() *log.Logger {
+	return log.New(ioutil.Discard, "", 0)
+}
 
 var basicResult solution
 
@@ -95,12 +97,12 @@ func testWriteDepTree(t *testing.T) {
 	}
 
 	// nil lock/result should err immediately
-	err = WriteDepTree(tmp, nil, sm, true, discardLogger)
+	err = WriteDepTree(tmp, nil, sm, true, discardLogger())
 	if err == nil {
 		t.Errorf("Should error if nil lock is passed to WriteDepTree")
 	}
 
-	err = WriteDepTree(tmp, r, sm, true, discardLogger)
+	err = WriteDepTree(tmp, r, sm, true, discardLogger())
 	if err != nil {
 		t.Errorf("Unexpected error while creating vendor tree: %s", err)
 	}
@@ -143,6 +145,7 @@ func BenchmarkCreateVendorTree(b *testing.B) {
 	}
 
 	if clean {
+		logger := discardLogger()
 		b.ResetTimer()
 		b.StopTimer()
 		exp := path.Join(tmp, "export")
@@ -151,7 +154,7 @@ func BenchmarkCreateVendorTree(b *testing.B) {
 			// ease manual inspection
 			os.RemoveAll(exp)
 			b.StartTimer()
-			err = WriteDepTree(exp, r, sm, true, discardLogger)
+			err = WriteDepTree(exp, r, sm, true, logger)
 			b.StopTimer()
 			if err != nil {
 				b.Errorf("unexpected error after %v iterations: %s", i, err)

--- a/test_project_context_test.go
+++ b/test_project_context_test.go
@@ -39,8 +39,8 @@ func NewTestProjectContext(h *test.Helper, projectName string) *TestProjectConte
 	var err error
 	pc.Context = &Ctx{
 		GOPATH: pc.tempDir,
-		Out:    discardLogger,
-		Err:    discardLogger,
+		Out:    discardLogger(),
+		Err:    discardLogger(),
 	}
 	pc.SourceManager, err = pc.Context.SourceManager()
 	h.Must(errors.Wrap(err, "Unable to create a SourceManager"))

--- a/txn_writer_test.go
+++ b/txn_writer_test.go
@@ -26,7 +26,7 @@ func TestSafeWriter_BadInput_MissingRoot(t *testing.T) {
 	defer pc.Release()
 
 	sw, _ := NewSafeWriter(nil, nil, nil, VendorOnChanged)
-	err := sw.Write("", pc.SourceManager, true, discardLogger)
+	err := sw.Write("", pc.SourceManager, true, discardLogger())
 
 	if err == nil {
 		t.Fatal("should have errored without a root path, but did not")
@@ -44,7 +44,7 @@ func TestSafeWriter_BadInput_MissingSourceManager(t *testing.T) {
 	pc.Load()
 
 	sw, _ := NewSafeWriter(nil, nil, pc.Project.Lock, VendorAlways)
-	err := sw.Write(pc.Project.AbsRoot, nil, true, discardLogger)
+	err := sw.Write(pc.Project.AbsRoot, nil, true, discardLogger())
 
 	if err == nil {
 		t.Fatal("should have errored without a source manager when forceVendor is true, but did not")
@@ -92,7 +92,7 @@ func TestSafeWriter_BadInput_NonexistentRoot(t *testing.T) {
 	sw, _ := NewSafeWriter(nil, nil, nil, VendorOnChanged)
 
 	missingroot := filepath.Join(pc.Project.AbsRoot, "nonexistent")
-	err := sw.Write(missingroot, pc.SourceManager, true, discardLogger)
+	err := sw.Write(missingroot, pc.SourceManager, true, discardLogger())
 
 	if err == nil {
 		t.Fatal("should have errored with nonexistent dir for root path, but did not")
@@ -110,7 +110,7 @@ func TestSafeWriter_BadInput_RootIsFile(t *testing.T) {
 	sw, _ := NewSafeWriter(nil, nil, nil, VendorOnChanged)
 
 	fileroot := pc.CopyFile("fileroot", "txn_writer/badinput_fileroot")
-	err := sw.Write(fileroot, pc.SourceManager, true, discardLogger)
+	err := sw.Write(fileroot, pc.SourceManager, true, discardLogger())
 
 	if err == nil {
 		t.Fatal("should have errored when root path is a file, but did not")
@@ -145,7 +145,7 @@ func TestSafeWriter_Manifest(t *testing.T) {
 	}
 
 	// Write changes
-	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, discardLogger)
+	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, discardLogger())
 	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
 	// Verify file system changes
@@ -190,7 +190,7 @@ func TestSafeWriter_ManifestAndUnmodifiedLock(t *testing.T) {
 	}
 
 	// Write changes
-	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, discardLogger)
+	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, discardLogger())
 	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
 	// Verify file system changes
@@ -235,7 +235,7 @@ func TestSafeWriter_ManifestAndUnmodifiedLockWithForceVendor(t *testing.T) {
 	}
 
 	// Write changes
-	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, discardLogger)
+	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, discardLogger())
 	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
 	// Verify file system changes
@@ -285,7 +285,7 @@ func TestSafeWriter_ModifiedLock(t *testing.T) {
 	}
 
 	// Write changes
-	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, discardLogger)
+	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, discardLogger())
 	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
 	// Verify file system changes
@@ -335,7 +335,7 @@ func TestSafeWriter_ModifiedLockSkipVendor(t *testing.T) {
 	}
 
 	// Write changes
-	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, discardLogger)
+	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, discardLogger())
 	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
 	// Verify file system changes
@@ -363,7 +363,7 @@ func TestSafeWriter_ForceVendorWhenVendorAlreadyExists(t *testing.T) {
 	pc.Load()
 
 	sw, _ := NewSafeWriter(nil, pc.Project.Lock, pc.Project.Lock, VendorAlways)
-	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, discardLogger)
+	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, discardLogger())
 	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
 	// Verify prepared actions
@@ -381,7 +381,7 @@ func TestSafeWriter_ForceVendorWhenVendorAlreadyExists(t *testing.T) {
 		t.Fatal("Expected the payload to contain the vendor directory ")
 	}
 
-	err = sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, discardLogger)
+	err = sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, discardLogger())
 	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
 	// Verify file system changes
@@ -431,7 +431,7 @@ func TestSafeWriter_NewLock(t *testing.T) {
 	}
 
 	// Write changes
-	err = sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, discardLogger)
+	err = sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, discardLogger())
 	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
 	// Verify file system changes
@@ -478,7 +478,7 @@ func TestSafeWriter_NewLockSkipVendor(t *testing.T) {
 	}
 
 	// Write changes
-	err = sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, discardLogger)
+	err = sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, discardLogger())
 	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
 	// Verify file system changes
@@ -571,7 +571,7 @@ func TestSafeWriter_VendorDotGitPreservedWithForceVendor(t *testing.T) {
 		t.Fatal("Expected the payload to contain the vendor directory")
 	}
 
-	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, discardLogger)
+	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, discardLogger())
 	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
 	// Verify file system changes


### PR DESCRIPTION
### What does this do / why do we need it?

This change replaces global discard `Logger` variables with per-test instances.

We've developed a habit of using consolidated global vars to share `discardLogger`s between tests (`log.New(ioutil.Discard, "", 0)`).  This seems logical since calls are effectively no-ops, _but_ the internals of the `Logger` are still locking to serialize writes to `ioutil.Discard`, which creates unnecessary coupling and synchronization between tests that could otherwise be completely independent and/or parallel.