### PR TITLE
gps: include output in error

### DIFF
--- a/internal/gps/cmd.go
+++ b/internal/gps/cmd.go
@@ -1,0 +1,13 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gps
+
+func (c cmd) Args() []string {
+	return c.Cmd.Args
+}
+
+func (c cmd) SetDir(dir string) {
+	c.Cmd.Dir = dir
+}

--- a/internal/gps/cmd.go
+++ b/internal/gps/cmd.go
@@ -11,3 +11,7 @@ func (c cmd) Args() []string {
 func (c cmd) SetDir(dir string) {
 	c.Cmd.Dir = dir
 }
+
+func (c cmd) SetEnv(env []string) {
+	c.Cmd.Env = env
+}

--- a/internal/gps/cmd_unix.go
+++ b/internal/gps/cmd_unix.go
@@ -21,24 +21,16 @@ type cmd struct {
 	ctx context.Context
 	// cancel is called when the graceful shutdown timeout expires.
 	cancel context.CancelFunc
-	cmd    *exec.Cmd
+	Cmd    *exec.Cmd
 }
 
 func commandContext(ctx context.Context, name string, arg ...string) cmd {
 	// Grab the caller's context and pass a derived one to CommandContext.
 	c := cmd{ctx: ctx}
 	ctx, cancel := context.WithCancel(ctx)
-	c.cmd = exec.CommandContext(ctx, name, arg...)
+	c.Cmd = exec.CommandContext(ctx, name, arg...)
 	c.cancel = cancel
 	return c
-}
-
-func (c cmd) Args() []string {
-	return c.cmd.Args
-}
-
-func (c cmd) SetDir(dir string) {
-	c.cmd.Dir = dir
 }
 
 // CombinedOutput is like (*os/exec.Cmd).CombinedOutput except that it
@@ -46,16 +38,16 @@ func (c cmd) SetDir(dir string) {
 // the subprocess fails to exit after 1 minute.
 func (c cmd) CombinedOutput() ([]byte, error) {
 	// Adapted from (*os/exec.Cmd).CombinedOutput
-	if c.cmd.Stdout != nil {
+	if c.Cmd.Stdout != nil {
 		return nil, errors.New("exec: Stdout already set")
 	}
-	if c.cmd.Stderr != nil {
+	if c.Cmd.Stderr != nil {
 		return nil, errors.New("exec: Stderr already set")
 	}
 	var b bytes.Buffer
-	c.cmd.Stdout = &b
-	c.cmd.Stderr = &b
-	if err := c.cmd.Start(); err != nil {
+	c.Cmd.Stdout = &b
+	c.Cmd.Stderr = &b
+	if err := c.Cmd.Start(); err != nil {
 		return nil, err
 	}
 
@@ -71,7 +63,7 @@ func (c cmd) CombinedOutput() ([]byte, error) {
 	go func() {
 		select {
 		case <-c.ctx.Done():
-			if err := c.cmd.Process.Signal(os.Interrupt); err != nil {
+			if err := c.Cmd.Process.Signal(os.Interrupt); err != nil {
 				// If an error comes back from attempting to signal, proceed
 				// immediately to hard kill.
 				c.cancel()
@@ -82,7 +74,7 @@ func (c cmd) CombinedOutput() ([]byte, error) {
 		}
 	}()
 
-	if err := c.cmd.Wait(); err != nil {
+	if err := c.Cmd.Wait(); err != nil {
 		return nil, err
 	}
 	return b.Bytes(), nil

--- a/internal/gps/cmd_windows.go
+++ b/internal/gps/cmd_windows.go
@@ -16,11 +16,3 @@ type cmd struct {
 func commandContext(ctx context.Context, name string, arg ...string) cmd {
 	return cmd{Cmd: exec.CommandContext(ctx, name, arg...)}
 }
-
-func (c cmd) Args() []string {
-	return c.Cmd.Args
-}
-
-func (c cmd) SetDir(dir string) {
-	c.Cmd.Dir = dir
-}

--- a/internal/gps/vcs_source.go
+++ b/internal/gps/vcs_source.go
@@ -179,7 +179,7 @@ func (s *gitSource) listVersions(ctx context.Context) (vlist []PairedVersion, er
 	cmd.Env = append([]string{"GIT_ASKPASS=", "GIT_TERMINAL_PROMPT=0"}, os.Environ()...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, string(out))
 	}
 
 	all := bytes.Split(bytes.TrimSpace(out), []byte("\n"))


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].
-->

### What does this do / why do we need it?

Includes a command's stderr in the error string. I was seeing SSL errors with one of my dependencies, and the missing error information was quite annoying.

### What should your reviewer look out for in this PR?

Nothing special.

### Do you need help or clarification on anything?

No.

### Which issue(s) does this PR fix?

None.

<!--

fixes #
fixes #

-->
