### PR TITLE
ctx: improve "not under GOPATH" errors

### DIFF
--- a/context.go
+++ b/context.go
@@ -223,7 +223,7 @@ func (c *Ctx) detectGOPATH(path string) (string, error) {
 			return gp, nil
 		}
 	}
-	return "", errors.Errorf("%s is not within a known GOPATH", path)
+	return "", errors.Errorf("%s is not within a known GOPATH/src", path)
 }
 
 // ImportForAbs returns the import path for an absolute project path by trimming the
@@ -244,7 +244,7 @@ func (c *Ctx) ImportForAbs(path string) (string, error) {
 		return filepath.ToSlash(path[len(srcprefix):]), nil
 	}
 
-	return "", errors.Errorf("%s not in GOPATH", path)
+	return "", errors.Errorf("%s is not within any GOPATH/src", path)
 }
 
 // AbsForImport returns the absolute path for the project root


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].
-->

### What does this do / why do we need it?

The error when code isn't "in" a GOPATH is a bit confusing, as what we really mean is "not under `GOPATH/src`". this updates those errors to reflect that.

### What should your reviewer look out for in this PR?

wording - it's always fun

### Do you need help or clarification on anything?

nope

### Which issue(s) does this PR fix?

fixes #1182 