### PR TITLE
Skip broken vendor symlink rather than returning an error

### DIFF
--- a/internal/gps/strip_vendor.go
+++ b/internal/gps/strip_vendor.go
@@ -22,11 +22,7 @@ func stripVendor(path string, info os.FileInfo, err error) error {
 		}
 
 		if (info.Mode() & os.ModeSymlink) != 0 {
-			realInfo, err := os.Stat(path)
-			if err != nil {
-				return err
-			}
-			if realInfo.IsDir() {
+			if realInfo, err := os.Stat(path); err == nil && realInfo.IsDir() {
 				return os.Remove(path)
 			}
 		}

--- a/internal/gps/strip_vendor_nonwindows_test.go
+++ b/internal/gps/strip_vendor_nonwindows_test.go
@@ -82,6 +82,31 @@ func TestStripVendorSymlinks(t *testing.T) {
 		},
 	}))
 
+	t.Run("broken vendor symlink", stripVendorTestCase(fsTestCase{
+		before: filesystemState{
+			dirs: []fsPath{
+				{"package"},
+			},
+			links: []fsLink{
+				{
+					path: fsPath{"package", "vendor"},
+					to:   "nonexistence",
+				},
+			},
+		},
+		after: filesystemState{
+			dirs: []fsPath{
+				{"package"},
+			},
+			links: []fsLink{
+				{
+					path: fsPath{"package", "vendor"},
+					to:   "nonexistence",
+				},
+			},
+		},
+	}))
+
 	t.Run("chained symlinks", stripVendorTestCase(fsTestCase{
 		before: filesystemState{
 			dirs: []fsPath{

--- a/internal/gps/strip_vendor_windows.go
+++ b/internal/gps/strip_vendor_windows.go
@@ -31,11 +31,7 @@ func stripVendor(path string, info os.FileInfo, err error) error {
 				return filepath.SkipDir
 
 			case symlink:
-				realInfo, err := os.Stat(path)
-				if err != nil {
-					return err
-				}
-				if realInfo.IsDir() {
+				if realInfo, err := os.Stat(path); err == nil && realInfo.IsDir() {
 					return os.Remove(path)
 				}
 

--- a/internal/gps/strip_vendor_windows_test.go
+++ b/internal/gps/strip_vendor_windows_test.go
@@ -90,6 +90,31 @@ func TestStripVendorSymlinks(t *testing.T) {
 		},
 	}))
 
+	t.Run("broken vendor symlink", stripVendorTestCase(fsTestCase{
+		before: filesystemState{
+			dirs: []fsPath{
+				{"package"},
+			},
+			links: []fsLink{
+				{
+					path: fsPath{"package", "vendor"},
+					to:   "nonexistence",
+				},
+			},
+		},
+		after: filesystemState{
+			dirs: []fsPath{
+				{"package"},
+			},
+			links: []fsLink{
+				{
+					path: fsPath{"package", "vendor"},
+					to:   "nonexistence",
+				},
+			},
+		},
+	}))
+
 	t.Run("chained symlinks", stripVendorTestCase(fsTestCase{
 		// Curiously, if a symlink on windows points to *another* symlink which
 		// eventually points at a directory, we'll correctly remove that first


### PR DESCRIPTION
### What does this do / why do we need it?

Skip broken vendor symlink rather than returning an error

### What should your reviewer look out for in this PR?

When one of 3rd party packages has a broken vendor symlink, it fails whole `ensure` process.

Current logic behaves:
- remove a vendor symlink linked to a valid directory
- leave a vendor symlink linked to a valid file
- return error if a vendor symlink is broken (linked file doesn't exist)

I think this behavior is not intended and it seems to be that it's better to skip the check except the case it's linked to a valid directory as it's harmless rather than returning an error causing the whole process stop.

Expected/New behavior:
- remove a vendor symlink linked to a valid directory
- leave rest of the case(linked to a file or broken) as they are not harmful rather than returning an error

### Do you need help or clarification on anything?

no

### Which issue(s) does this PR fix?

This is a new behavior introduced in v0.3.1 with its improved type checking
Since this is a breaking change, some users migrating from 0.3.0 could experience this issue.
The main problem is that when this happens on some 3rd party libraries that you don't have the control, you just have to downgrade and use v0.3.0
