### PR TITLE
gps: avoid race condition in variable assignment

### DIFF
--- a/internal/gps/cmd_unix.go
+++ b/internal/gps/cmd_unix.go
@@ -51,12 +51,6 @@ func (c cmd) CombinedOutput() ([]byte, error) {
 		return nil, err
 	}
 
-	var t *time.Timer
-	defer func() {
-		if t != nil {
-			t.Stop()
-		}
-	}()
 	// Adapted from (*os/exec.Cmd).Start
 	waitDone := make(chan struct{})
 	defer close(waitDone)
@@ -68,7 +62,9 @@ func (c cmd) CombinedOutput() ([]byte, error) {
 				// immediately to hard kill.
 				c.cancel()
 			} else {
-				t = time.AfterFunc(time.Minute, c.cancel)
+				stopCancel := time.AfterFunc(time.Minute, c.cancel).Stop
+				<-waitDone
+				stopCancel()
 			}
 		case <-waitDone:
 		}


### PR DESCRIPTION
Instead, we use the existing `waitDone` channel to wait for the
command to return and then clean up the timer unconditionally. This
may hold the goroutine open for longer than strictly necessary, but
that seems harmless.

Closes #1194.

@jmank88 