### PR TITLE
[WIP] Feature to disable file locking when DEPNOLOCK set

### DIFF
--- a/cmd/dep/main.go
+++ b/cmd/dep/main.go
@@ -147,9 +147,10 @@ func (c *Config) Run() (exitCode int) {
 
 			// Set up dep context.
 			ctx := &dep.Ctx{
-				Out:     outLogger,
-				Err:     errLogger,
-				Verbose: *verbose,
+				Out:            outLogger,
+				Err:            errLogger,
+				Verbose:        *verbose,
+				DisableLocking: getEnv(c.Env, "DEPNOLOCK") != "",
 			}
 
 			GOPATHS := filepath.SplitList(getEnv(c.Env, "GOPATH"))

--- a/context.go
+++ b/context.go
@@ -34,11 +34,12 @@ import (
 //	}
 //
 type Ctx struct {
-	WorkingDir string      // Where to execute.
-	GOPATH     string      // Selected Go path, containing WorkingDir.
-	GOPATHs    []string    // Other Go paths.
-	Out, Err   *log.Logger // Required loggers.
-	Verbose    bool        // Enables more verbose logging.
+	WorkingDir     string      // Where to execute.
+	GOPATH         string      // Selected Go path, containing WorkingDir.
+	GOPATHs        []string    // Other Go paths.
+	Out, Err       *log.Logger // Required loggers.
+	Verbose        bool        // Enables more verbose logging.
+	DisableLocking bool        // When set, disables locking.
 }
 
 // SetPaths sets the WorkingDir and GOPATHs fields. If GOPATHs is empty, then
@@ -87,8 +88,9 @@ func defaultGOPATH() string {
 // initialized to log to the receiver's logger.
 func (c *Ctx) SourceManager() (*gps.SourceMgr, error) {
 	return gps.NewSourceManager(gps.SourceManagerConfig{
-		Cachedir: filepath.Join(c.GOPATH, "pkg", "dep"),
-		Logger:   c.Out,
+		Cachedir:       filepath.Join(c.GOPATH, "pkg", "dep"),
+		Logger:         c.Out,
+		DisableLocking: c.DisableLocking,
 	})
 }
 

--- a/context.go
+++ b/context.go
@@ -39,7 +39,7 @@ type Ctx struct {
 	GOPATHs        []string    // Other Go paths.
 	Out, Err       *log.Logger // Required loggers.
 	Verbose        bool        // Enables more verbose logging.
-	DisableLocking bool        // When set, disables locking.
+	DisableLocking bool        // When set, no lock file will be created to protect against simultaneous dep processes.
 }
 
 // SetPaths sets the WorkingDir and GOPATHs fields. If GOPATHs is empty, then

--- a/internal/gps/source_manager.go
+++ b/internal/gps/source_manager.go
@@ -28,11 +28,11 @@ import (
 // Used to compute a friendly filepath from a URL-shaped input.
 var sanitizer = strings.NewReplacer("-", "--", ":", "-", "/", "-", "+", "-")
 
-// A locker is responsible for preventing multiple instances of dep from interfereing
-// with one-another.
+// A locker is responsible for preventing multiple instances of dep from
+// interfering with one-another.
 //
-// Currently, anything that can either TryLock(), Unlock(), or GetOwner() satifies
-// that need.
+// Currently, anything that can either TryLock(), Unlock(), or GetOwner()
+// satifies that need.
 type locker interface {
 	TryLock() error
 	Unlock() error
@@ -179,7 +179,7 @@ var _ SourceManager = &SourceMgr{}
 type SourceManagerConfig struct {
 	Cachedir       string      // Where to store local instances of upstream sources.
 	Logger         *log.Logger // Optional info/warn logger. Discards if nil.
-	DisableLocking bool        // True if dep SourceManager shoud NOT lock.
+	DisableLocking bool        // True if the SourceManager should NOT use a lock file to protect the Cachedir from multiple processes.
 }
 
 // NewSourceManager produces an instance of gps's built-in SourceManager.

--- a/internal/gps/source_manager.go
+++ b/internal/gps/source_manager.go
@@ -39,7 +39,7 @@ type locker interface {
 	GetOwner() (*os.Process, error)
 }
 
-// A falselocker adheres to the locker inteface and it's purpose is to quietly
+// A falselocker adheres to the locker interface and its purpose is to quietly
 // fail to lock when the DEPNOLOCK environment variable is set.
 //
 // This allows dep to run on systems where file locking doesn't work --

--- a/internal/gps/source_manager.go
+++ b/internal/gps/source_manager.go
@@ -257,7 +257,7 @@ func NewSourceManager(c SourceManagerConfig) (*SourceMgr, error) {
 		// The first time this is evaluated, duration will be very large as lasttime is 0.
 		// Unless time travel is invented and someone travels back to the year 1, we should
 		// be ok.
-		if duration > 14*time.Second {
+		if duration > 15*time.Second {
 			fmt.Fprintf(os.Stderr, "waiting for lockfile %s: %s\n", glpath, err.Error())
 			lasttime = nowtime
 		}


### PR DESCRIPTION
* Add DisableLocking bool members to Ctx and gps.SourceManagerConfig structs.
  This effectively communicates DEPNOLOCK from the shell, to Ctx, to
  SourceManager.

  The member is named DisableLocking to make its zero-value useful.

* Add Locker interface which implements TryLock(), Unlock(), and GetOwner()
  which lockfile.Lockfile alredy adheres to.  This interface replaces the new
  type for the lf member of the SourceMgr struct.

* Add a FalseLocker type which adheres to the Locker interface which does
  nothing.

* Conditionally set the lf member of SourceMgr to either an instance of
  lockfile.Lockfile or FalseLocker depending on the value of
  SourceManagerConfig.DisableLocking.

<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].
-->

### What does this do / why do we need it?

This pull request adds functionality that checks the DEPNOLOCK environment variable to determine if session manager should attempt to lock against multiple instances of dep runing.

This seems to be a problem particularly when building with CI systems in a Vagrant or Docker type container that uses union mount type file systems.

This environment variable allows us to work around this locking issue in these kind of systems where we can be sure there aren't concurrent runs of dep.

### What should your reviewer look out for in this PR?

### Do you need help or clarification on anything?

I'm interested to know if this is a reasonable approach and I'm open to suggestions of alternate ways to achieve this.

### Which issue(s) does this PR fix?

fixes #947

<!--

fixes #
fixes #

-->
