### PR TITLE
gps: ./hack/lint.bash fixes

### DIFF
--- a/hack/lint.bash
+++ b/hack/lint.bash
@@ -9,4 +9,4 @@ set -e
 PKGS=$(go list ./... | grep -vF /vendor/)
 go vet $PKGS
 golint $PKGS
-megacheck -unused.exported -ignore github.com/golang/dep/internal/test/test.go:U1000 $PKGS
+megacheck -unused.exported -ignore "github.com/golang/dep/internal/test/test.go:U1000 github.com/golang/dep/internal/gps/prune.go:U1000" $PKGS

--- a/internal/gps/vcs_source.go
+++ b/internal/gps/vcs_source.go
@@ -376,11 +376,7 @@ func (s *bzrSource) exportRevisionTo(ctx context.Context, rev Revision, to strin
 		return err
 	}
 
-	if err := os.RemoveAll(filepath.Join(to, ".bzr")); err != nil {
-		return err
-	}
-
-	return nil
+	return os.RemoveAll(filepath.Join(to, ".bzr"))
 }
 
 func (s *bzrSource) listVersions(ctx context.Context) ([]PairedVersion, error) {
@@ -457,11 +453,7 @@ func (s *hgSource) exportRevisionTo(ctx context.Context, rev Revision, to string
 		return err
 	}
 
-	if err := os.RemoveAll(filepath.Join(to, ".hg")); err != nil {
-		return err
-	}
-
-	return nil
+	return os.RemoveAll(filepath.Join(to, ".hg"))
 }
 
 func (s *hgSource) listVersions(ctx context.Context) ([]PairedVersion, error) {


### PR DESCRIPTION
### What does this do / why do we need it?

This PR fixes `./hack/lint.bash` failures, by directly returning errors and ~removing~ ignoring unused functions/types from `prune.go`.

### Do you need help or clarification on anything?

Should the errors be wrapped?