### PR TITLE
Plumb context through solver

### DIFF
--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -280,8 +280,7 @@ func (cmd *ensureCommand) runDefault(ctx *dep.Ctx, args []string, p *dep.Project
 
 	solution, err := solver.Solve(context.TODO())
 	if err != nil {
-		handleAllTheFailuresOfTheWorld(err)
-		return errors.Wrap(err, "ensure Solve()")
+		return handleAllTheFailuresOfTheWorld(err)
 	}
 
 	vendorBehavior := dep.VendorOnChanged
@@ -375,8 +374,7 @@ func (cmd *ensureCommand) runUpdate(ctx *dep.Ctx, args []string, p *dep.Project,
 		// TODO(sdboyer) special handling for warning cases as described in spec
 		// - e.g., named projects did not upgrade even though newer versions
 		// were available.
-		handleAllTheFailuresOfTheWorld(err)
-		return errors.Wrap(err, "ensure Solve()")
+		return handleAllTheFailuresOfTheWorld(err)
 	}
 
 	sw, err := dep.NewSafeWriter(nil, p.Lock, dep.LockFromSolution(solution), dep.VendorOnChanged)
@@ -635,8 +633,7 @@ func (cmd *ensureCommand) runAdd(ctx *dep.Ctx, args []string, p *dep.Project, sm
 	solution, err := solver.Solve(context.TODO())
 	if err != nil {
 		// TODO(sdboyer) detect if the failure was specifically about some of the -add arguments
-		handleAllTheFailuresOfTheWorld(err)
-		return errors.Wrap(err, "ensure Solve()")
+		return handleAllTheFailuresOfTheWorld(err)
 	}
 
 	// Prep post-actions and feedback from adds.

--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"flag"
 	"fmt"
 	"go/build"
@@ -277,7 +278,7 @@ func (cmd *ensureCommand) runDefault(ctx *dep.Ctx, args []string, p *dep.Project
 		return errors.New("Gopkg.lock was not up to date")
 	}
 
-	solution, err := solver.Solve()
+	solution, err := solver.Solve(context.TODO())
 	if err != nil {
 		handleAllTheFailuresOfTheWorld(err)
 		return errors.Wrap(err, "ensure Solve()")
@@ -369,7 +370,7 @@ func (cmd *ensureCommand) runUpdate(ctx *dep.Ctx, args []string, p *dep.Project,
 	if err != nil {
 		return errors.Wrap(err, "fastpath solver prepare")
 	}
-	solution, err := solver.Solve()
+	solution, err := solver.Solve(context.TODO())
 	if err != nil {
 		// TODO(sdboyer) special handling for warning cases as described in spec
 		// - e.g., named projects did not upgrade even though newer versions
@@ -631,7 +632,7 @@ func (cmd *ensureCommand) runAdd(ctx *dep.Ctx, args []string, p *dep.Project, sm
 	if err != nil {
 		return errors.Wrap(err, "fastpath solver prepare")
 	}
-	solution, err := solver.Solve()
+	solution, err := solver.Solve(context.TODO())
 	if err != nil {
 		// TODO(sdboyer) detect if the failure was specifically about some of the -add arguments
 		handleAllTheFailuresOfTheWorld(err)

--- a/cmd/dep/init.go
+++ b/cmd/dep/init.go
@@ -249,7 +249,7 @@ func getDirectDependencies(sm gps.SourceManager, p *dep.Project) (pkgtree.Packag
 // in handling them and informing the user appropriately
 func handleAllTheFailuresOfTheWorld(err error) error {
 	switch errors.Cause(err) {
-	case context.Canceled, context.DeadlineExceeded, gps.SourceManagerIsReleased:
+	case context.Canceled, context.DeadlineExceeded, gps.ErrSourceManagerIsReleased:
 		return nil
 	}
 

--- a/cmd/dep/init.go
+++ b/cmd/dep/init.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"io/ioutil"
 	"log"
@@ -183,7 +184,7 @@ func (cmd *initCommand) Run(ctx *dep.Ctx, args []string) error {
 		return errors.Wrap(err, "prepare solver")
 	}
 
-	soln, err := s.Solve()
+	soln, err := s.Solve(context.TODO())
 	if err != nil {
 		handleAllTheFailuresOfTheWorld(err)
 		return err

--- a/cmd/dep/init.go
+++ b/cmd/dep/init.go
@@ -186,8 +186,7 @@ func (cmd *initCommand) Run(ctx *dep.Ctx, args []string) error {
 
 	soln, err := s.Solve(context.TODO())
 	if err != nil {
-		handleAllTheFailuresOfTheWorld(err)
-		return err
+		return handleAllTheFailuresOfTheWorld(err)
 	}
 	p.Lock = dep.LockFromSolution(soln)
 
@@ -248,5 +247,11 @@ func getDirectDependencies(sm gps.SourceManager, p *dep.Project) (pkgtree.Packag
 
 // TODO solve failures can be really creative - we need to be similarly creative
 // in handling them and informing the user appropriately
-func handleAllTheFailuresOfTheWorld(err error) {
+func handleAllTheFailuresOfTheWorld(err error) error {
+	switch errors.Cause(err) {
+	case context.Canceled, context.DeadlineExceeded, gps.SourceManagerIsReleased:
+		return nil
+	}
+
+	return errors.Wrap(err, "Solving failure")
 }

--- a/internal/gps/bridge.go
+++ b/internal/gps/bridge.go
@@ -71,7 +71,7 @@ type bridge struct {
 
 	// The cancellation context provided to the solver. Threading it through the
 	// various solver methods is needlessly verbose so long as we maintain the
-	// lifetime guarantees that a solver can only be run once, so we
+	// lifetime guarantees that a solver can only be run once.
 	ctx context.Context
 }
 

--- a/internal/gps/bridge.go
+++ b/internal/gps/bridge.go
@@ -5,7 +5,6 @@
 package gps
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -72,7 +71,8 @@ type bridge struct {
 	// The cancellation context provided to the solver. Threading it through the
 	// various solver methods is needlessly verbose so long as we maintain the
 	// lifetime guarantees that a solver can only be run once.
-	ctx context.Context
+	// TODO(sdboyer) uncomment this and thread it through SourceManager methods
+	//ctx context.Context
 }
 
 // mkBridge creates a bridge

--- a/internal/gps/bridge.go
+++ b/internal/gps/bridge.go
@@ -5,6 +5,7 @@
 package gps
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -67,6 +68,11 @@ type bridge struct {
 
 	// Whether to sort version lists for downgrade.
 	down bool
+
+	// The cancellation context provided to the solver. Threading it through the
+	// various solver methods is needlessly verbose so long as we maintain the
+	// lifetime guarantees that a solver can only be run once, so we
+	ctx context.Context
 }
 
 // mkBridge creates a bridge

--- a/internal/gps/manager_test.go
+++ b/internal/gps/manager_test.go
@@ -810,57 +810,57 @@ func TestErrAfterRelease(t *testing.T) {
 	_, err := sm.SourceExists(id)
 	if err == nil {
 		t.Errorf("SourceExists did not error after calling Release()")
-	} else if terr, ok := err.(smIsReleased); !ok {
-		t.Errorf("SourceExists errored after Release(), but with unexpected error: %T %s", terr, terr.Error())
+	} else if err != SourceManagerIsReleased {
+		t.Errorf("SourceExists errored after Release(), but with unexpected error: %T %s", err, err.Error())
 	}
 
 	err = sm.SyncSourceFor(id)
 	if err == nil {
 		t.Errorf("SyncSourceFor did not error after calling Release()")
-	} else if terr, ok := err.(smIsReleased); !ok {
-		t.Errorf("SyncSourceFor errored after Release(), but with unexpected error: %T %s", terr, terr.Error())
+	} else if err != SourceManagerIsReleased {
+		t.Errorf("SyncSourceFor errored after Release(), but with unexpected error: %T %s", err, err.Error())
 	}
 
 	_, err = sm.ListVersions(id)
 	if err == nil {
 		t.Errorf("ListVersions did not error after calling Release()")
-	} else if terr, ok := err.(smIsReleased); !ok {
-		t.Errorf("ListVersions errored after Release(), but with unexpected error: %T %s", terr, terr.Error())
+	} else if err != SourceManagerIsReleased {
+		t.Errorf("ListVersions errored after Release(), but with unexpected error: %T %s", err, err.Error())
 	}
 
 	_, err = sm.RevisionPresentIn(id, "")
 	if err == nil {
 		t.Errorf("RevisionPresentIn did not error after calling Release()")
-	} else if terr, ok := err.(smIsReleased); !ok {
-		t.Errorf("RevisionPresentIn errored after Release(), but with unexpected error: %T %s", terr, terr.Error())
+	} else if err != SourceManagerIsReleased {
+		t.Errorf("RevisionPresentIn errored after Release(), but with unexpected error: %T %s", err, err.Error())
 	}
 
 	_, err = sm.ListPackages(id, nil)
 	if err == nil {
 		t.Errorf("ListPackages did not error after calling Release()")
-	} else if terr, ok := err.(smIsReleased); !ok {
-		t.Errorf("ListPackages errored after Release(), but with unexpected error: %T %s", terr, terr.Error())
+	} else if err != SourceManagerIsReleased {
+		t.Errorf("ListPackages errored after Release(), but with unexpected error: %T %s", err, err.Error())
 	}
 
 	_, _, err = sm.GetManifestAndLock(id, nil, naiveAnalyzer{})
 	if err == nil {
 		t.Errorf("GetManifestAndLock did not error after calling Release()")
-	} else if terr, ok := err.(smIsReleased); !ok {
-		t.Errorf("GetManifestAndLock errored after Release(), but with unexpected error: %T %s", terr, terr.Error())
+	} else if err != SourceManagerIsReleased {
+		t.Errorf("GetManifestAndLock errored after Release(), but with unexpected error: %T %s", err, err.Error())
 	}
 
 	err = sm.ExportProject(context.Background(), id, nil, "")
 	if err == nil {
 		t.Errorf("ExportProject did not error after calling Release()")
-	} else if terr, ok := err.(smIsReleased); !ok {
-		t.Errorf("ExportProject errored after Release(), but with unexpected error: %T %s", terr, terr.Error())
+	} else if err != SourceManagerIsReleased {
+		t.Errorf("ExportProject errored after Release(), but with unexpected error: %T %s", err, err.Error())
 	}
 
 	_, err = sm.DeduceProjectRoot("")
 	if err == nil {
 		t.Errorf("DeduceProjectRoot did not error after calling Release()")
-	} else if terr, ok := err.(smIsReleased); !ok {
-		t.Errorf("DeduceProjectRoot errored after Release(), but with unexpected error: %T %s", terr, terr.Error())
+	} else if err != SourceManagerIsReleased {
+		t.Errorf("DeduceProjectRoot errored after Release(), but with unexpected error: %T %s", err, err.Error())
 	}
 }
 

--- a/internal/gps/manager_test.go
+++ b/internal/gps/manager_test.go
@@ -810,56 +810,56 @@ func TestErrAfterRelease(t *testing.T) {
 	_, err := sm.SourceExists(id)
 	if err == nil {
 		t.Errorf("SourceExists did not error after calling Release()")
-	} else if err != SourceManagerIsReleased {
+	} else if err != ErrSourceManagerIsReleased {
 		t.Errorf("SourceExists errored after Release(), but with unexpected error: %T %s", err, err.Error())
 	}
 
 	err = sm.SyncSourceFor(id)
 	if err == nil {
 		t.Errorf("SyncSourceFor did not error after calling Release()")
-	} else if err != SourceManagerIsReleased {
+	} else if err != ErrSourceManagerIsReleased {
 		t.Errorf("SyncSourceFor errored after Release(), but with unexpected error: %T %s", err, err.Error())
 	}
 
 	_, err = sm.ListVersions(id)
 	if err == nil {
 		t.Errorf("ListVersions did not error after calling Release()")
-	} else if err != SourceManagerIsReleased {
+	} else if err != ErrSourceManagerIsReleased {
 		t.Errorf("ListVersions errored after Release(), but with unexpected error: %T %s", err, err.Error())
 	}
 
 	_, err = sm.RevisionPresentIn(id, "")
 	if err == nil {
 		t.Errorf("RevisionPresentIn did not error after calling Release()")
-	} else if err != SourceManagerIsReleased {
+	} else if err != ErrSourceManagerIsReleased {
 		t.Errorf("RevisionPresentIn errored after Release(), but with unexpected error: %T %s", err, err.Error())
 	}
 
 	_, err = sm.ListPackages(id, nil)
 	if err == nil {
 		t.Errorf("ListPackages did not error after calling Release()")
-	} else if err != SourceManagerIsReleased {
+	} else if err != ErrSourceManagerIsReleased {
 		t.Errorf("ListPackages errored after Release(), but with unexpected error: %T %s", err, err.Error())
 	}
 
 	_, _, err = sm.GetManifestAndLock(id, nil, naiveAnalyzer{})
 	if err == nil {
 		t.Errorf("GetManifestAndLock did not error after calling Release()")
-	} else if err != SourceManagerIsReleased {
+	} else if err != ErrSourceManagerIsReleased {
 		t.Errorf("GetManifestAndLock errored after Release(), but with unexpected error: %T %s", err, err.Error())
 	}
 
 	err = sm.ExportProject(context.Background(), id, nil, "")
 	if err == nil {
 		t.Errorf("ExportProject did not error after calling Release()")
-	} else if err != SourceManagerIsReleased {
+	} else if err != ErrSourceManagerIsReleased {
 		t.Errorf("ExportProject errored after Release(), but with unexpected error: %T %s", err, err.Error())
 	}
 
 	_, err = sm.DeduceProjectRoot("")
 	if err == nil {
 		t.Errorf("DeduceProjectRoot did not error after calling Release()")
-	} else if err != SourceManagerIsReleased {
+	} else if err != ErrSourceManagerIsReleased {
 		t.Errorf("DeduceProjectRoot errored after Release(), but with unexpected error: %T %s", err, err.Error())
 	}
 }

--- a/internal/gps/solve_test.go
+++ b/internal/gps/solve_test.go
@@ -6,6 +6,7 @@ package gps
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"log"
 	"reflect"
@@ -35,7 +36,7 @@ func fixSolve(params SolveParameters, sm SourceManager, t *testing.T) (Solution,
 		return nil, err
 	}
 
-	return s.Solve()
+	return s.Solve(context.Background())
 }
 
 // Test all the basic table fixtures.

--- a/internal/gps/solver.go
+++ b/internal/gps/solver.go
@@ -1417,5 +1417,5 @@ func pa2lp(pa atom, pkgs map[string]struct{}) LockedProject {
 }
 
 func contextCanceledOrSMReleased(err error) bool {
-	return err == context.Canceled || err == context.DeadlineExceeded || err == SourceManagerIsReleased
+	return err == context.Canceled || err == context.DeadlineExceeded || err == ErrSourceManagerIsReleased
 }

--- a/internal/gps/solver.go
+++ b/internal/gps/solver.go
@@ -1077,7 +1077,9 @@ func (s *solver) backtrack(ctx context.Context) (bool, error) {
 				var err error
 				awp, proj, err = s.unselectLast()
 				if err != nil {
-					// Should only be possible if SourceManager was released
+					if !contextCanceledOrSMReleased(err) {
+						panic(fmt.Sprintf("canary - should only have been able to get a context cancellation or SM release, got %T %s", err, err))
+					}
 					return false, err
 				}
 				s.traceBacktrack(awp.bmi(), !proj)
@@ -1095,7 +1097,9 @@ func (s *solver) backtrack(ctx context.Context) (bool, error) {
 			var err error
 			awp, proj, err = s.unselectLast()
 			if err != nil {
-				// Should only be possible if SourceManager was released
+				if !contextCanceledOrSMReleased(err) {
+					panic(fmt.Sprintf("canary - should only have been able to get a context cancellation or SM release, got %T %s", err, err))
+				}
 				return false, err
 			}
 			s.traceBacktrack(awp.bmi(), !proj)
@@ -1118,7 +1122,9 @@ func (s *solver) backtrack(ctx context.Context) (bool, error) {
 				awp.a.v = q.current()
 				err := s.selectAtom(awp, false)
 				if err != nil {
-					// Only a released SourceManager should be able to cause this.
+					if !contextCanceledOrSMReleased(err) {
+						panic(fmt.Sprintf("canary - should only have been able to get a context cancellation or SM release, got %T %s", err, err))
+					}
 					return false, err
 				}
 				break

--- a/internal/gps/solver.go
+++ b/internal/gps/solver.go
@@ -1417,5 +1417,5 @@ func pa2lp(pa atom, pkgs map[string]struct{}) LockedProject {
 }
 
 func contextCanceledOrSMReleased(err error) bool {
-	return err == context.Canceled || err == context.DeadlineExceeded || err == smIsReleased{}
+	return err == context.Canceled || err == context.DeadlineExceeded || err == SourceManagerIsReleased
 }

--- a/internal/gps/solver.go
+++ b/internal/gps/solver.go
@@ -350,8 +350,7 @@ type Solver interface {
 	// Name returns a string identifying the particular solver backend.
 	//
 	// Different solvers likely have different invariants, and likely will not
-	// have identical possible result sets for any particular inputs; in some
-	// cases, they may even be disjoint.
+	// have the same result sets for any particular inputs.
 	Name() string
 
 	// Version returns an int indicating the version of the solver of the given

--- a/internal/gps/solver.go
+++ b/internal/gps/solver.go
@@ -584,7 +584,7 @@ func (s *solver) solve(ctx context.Context) (map[atom]map[string]struct{}, error
 				}
 				return nil, err
 			}
-			err = s.selectAtom(nawp, false)
+			err = s.selectAtom(nawp, true)
 			s.mtr.pop()
 			if err != nil {
 				// Only a released SourceManager should be able to cause this.

--- a/internal/gps/solver.go
+++ b/internal/gps/solver.go
@@ -439,7 +439,7 @@ func ValidateParams(params SolveParameters, sm SourceManager) error {
 // This is the entry point to the main gps workhorse.
 func (s *solver) Solve(ctx context.Context) (Solution, error) {
 	// Solving can only be run once per solver.
-	if atomic.LoadInt32(&s.hasrun) == 1 {
+	if !atomic.CompareAndSwapInt32(&s.hasrun, 0, 1) {
 		return nil, errors.New("solve method can only be run once per instance")
 	}
 	// Make sure the bridge has the context before we start.

--- a/internal/gps/source_manager.go
+++ b/internal/gps/source_manager.go
@@ -169,10 +169,10 @@ type SourceMgr struct {
 
 var _ SourceManager = &SourceMgr{}
 
-// SourceManagerIsReleased is the error returned by any SourceManager method
+// ErrSourceManagerIsReleased is the error returned by any SourceManager method
 // called after the SourceManager has been released, rendering its methods no
 // longer safe to call.
-var SourceManagerIsReleased error = fmt.Errorf("this SourceManager has been released, its methods can no longer be called")
+var ErrSourceManagerIsReleased error = fmt.Errorf("this SourceManager has been released, its methods can no longer be called")
 
 // SourceManagerConfig holds configuration information for creating SourceMgrs.
 type SourceManagerConfig struct {
@@ -405,7 +405,7 @@ func (sm *SourceMgr) Release() {
 // DeriveManifestAndLock() method.
 func (sm *SourceMgr) GetManifestAndLock(id ProjectIdentifier, v Version, an ProjectAnalyzer) (Manifest, Lock, error) {
 	if atomic.LoadInt32(&sm.releasing) == 1 {
-		return nil, nil, SourceManagerIsReleased
+		return nil, nil, ErrSourceManagerIsReleased
 	}
 
 	srcg, err := sm.srcCoord.getSourceGatewayFor(context.TODO(), id)
@@ -420,7 +420,7 @@ func (sm *SourceMgr) GetManifestAndLock(id ProjectIdentifier, v Version, an Proj
 // of the given ProjectIdentifier, at the given version.
 func (sm *SourceMgr) ListPackages(id ProjectIdentifier, v Version) (pkgtree.PackageTree, error) {
 	if atomic.LoadInt32(&sm.releasing) == 1 {
-		return pkgtree.PackageTree{}, SourceManagerIsReleased
+		return pkgtree.PackageTree{}, ErrSourceManagerIsReleased
 	}
 
 	srcg, err := sm.srcCoord.getSourceGatewayFor(context.TODO(), id)
@@ -445,7 +445,7 @@ func (sm *SourceMgr) ListPackages(id ProjectIdentifier, v Version) (pkgtree.Pack
 // went away), an error will be returned.
 func (sm *SourceMgr) ListVersions(id ProjectIdentifier) ([]PairedVersion, error) {
 	if atomic.LoadInt32(&sm.releasing) == 1 {
-		return nil, SourceManagerIsReleased
+		return nil, ErrSourceManagerIsReleased
 	}
 
 	srcg, err := sm.srcCoord.getSourceGatewayFor(context.TODO(), id)
@@ -461,7 +461,7 @@ func (sm *SourceMgr) ListVersions(id ProjectIdentifier) ([]PairedVersion, error)
 // repository.
 func (sm *SourceMgr) RevisionPresentIn(id ProjectIdentifier, r Revision) (bool, error) {
 	if atomic.LoadInt32(&sm.releasing) == 1 {
-		return false, SourceManagerIsReleased
+		return false, ErrSourceManagerIsReleased
 	}
 
 	srcg, err := sm.srcCoord.getSourceGatewayFor(context.TODO(), id)
@@ -477,7 +477,7 @@ func (sm *SourceMgr) RevisionPresentIn(id ProjectIdentifier, r Revision) (bool, 
 // for the provided ProjectIdentifier.
 func (sm *SourceMgr) SourceExists(id ProjectIdentifier) (bool, error) {
 	if atomic.LoadInt32(&sm.releasing) == 1 {
-		return false, SourceManagerIsReleased
+		return false, ErrSourceManagerIsReleased
 	}
 
 	srcg, err := sm.srcCoord.getSourceGatewayFor(context.TODO(), id)
@@ -495,7 +495,7 @@ func (sm *SourceMgr) SourceExists(id ProjectIdentifier) (bool, error) {
 // The primary use case for this is prefetching.
 func (sm *SourceMgr) SyncSourceFor(id ProjectIdentifier) error {
 	if atomic.LoadInt32(&sm.releasing) == 1 {
-		return SourceManagerIsReleased
+		return ErrSourceManagerIsReleased
 	}
 
 	srcg, err := sm.srcCoord.getSourceGatewayFor(context.TODO(), id)
@@ -510,7 +510,7 @@ func (sm *SourceMgr) SyncSourceFor(id ProjectIdentifier) error {
 // ProjectRoot, at the provided version, to the provided directory.
 func (sm *SourceMgr) ExportProject(ctx context.Context, id ProjectIdentifier, v Version, to string) error {
 	if atomic.LoadInt32(&sm.releasing) == 1 {
-		return SourceManagerIsReleased
+		return ErrSourceManagerIsReleased
 	}
 
 	srcg, err := sm.srcCoord.getSourceGatewayFor(ctx, id)
@@ -530,7 +530,7 @@ func (sm *SourceMgr) ExportProject(ctx context.Context, id ProjectIdentifier, v 
 // activity, as its behavior is well-structured)
 func (sm *SourceMgr) DeduceProjectRoot(ip string) (ProjectRoot, error) {
 	if atomic.LoadInt32(&sm.releasing) == 1 {
-		return "", SourceManagerIsReleased
+		return "", ErrSourceManagerIsReleased
 	}
 
 	pd, err := sm.deduceCoord.deduceRootPath(context.TODO(), ip)


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].
-->

### What does this do / why do we need it?

The solver itself needs to be able to take a context, so that it can abort. It also needs to be able to handle cases where its underlying `SourceManager` gets released. Strictly speaking, these two cases are separate, but it makes enough sense to deal with them in one PR, just because there's so many overlapping bits to think about.

### What should your reviewer look out for in this PR?

this rejiggers a bunch of stuff in the solver itself, and my preliminary passes have definitely produced test failures, so correctness concerns here.

### Which issue(s) does this PR fix?

it's work towards #160 and #423, but doesn't itself square those away entirely.

fixes #1060 