### PR TITLE
internal/gps: fix case mismatch error with multiple dependers

### DIFF
--- a/internal/gps/solve_failures.go
+++ b/internal/gps/solve_failures.go
@@ -84,7 +84,7 @@ func (e *caseMismatchFailure) Error() string {
 	var buf bytes.Buffer
 
 	str := "Could not introduce %s due to a case-only variation: it depends on %q, but %q was already established as the case variant for that project root by the following other dependers:\n"
-	fmt.Fprintf(&buf, str, e.goal.dep.Ident.ProjectRoot, e.current, a2vs(e.goal.depender))
+	fmt.Fprintf(&buf, str, a2vs(e.goal.depender), e.goal.dep.Ident.ProjectRoot, e.current)
 
 	for _, c := range e.failsib {
 		fmt.Fprintf(&buf, "\t%s\n", a2vs(c.depender))


### PR DESCRIPTION
### What does this do / why do we need it?

Fixes a bad error message added in dep 0.3.1.

Previously, errors like the following could occur:

  v0.4.2: Could not introduce github.com/sirupsen/logrus due to a case-only variation: it depends on "github.com/Sirupsen/logrus", but "github.com/evalphobia/logrus_sentry@v0.4.2" was already established as the case variant for that project root by the following other dependers:
  (root)
  github.com/docker/docker@8510adf8c856d6f0871650216a0e1d7e6ece46ee

This fix matches the correct behavior when there is only one depender earlier in
the function.

### What should your reviewer look out for in this PR?

Is there an opportunity to add a test for this? I didn't see one.

### Do you need help or clarification on anything?

No

### Which issue(s) does this PR fix?

I didn't file an issue but I did jot down a comment on the PR that introduced this issue: https://github.com/golang/dep/pull/1079#discussion_r141989727