### PR TITLE
CONTRIBUTING.md: Document need to run dep prune

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,11 @@ All submissions, including submissions by project members, require review. We
 use GitHub pull requests for this purpose. Consult [GitHub Help] for more
 information on using pull requests.
 
+We check `dep`'s own `vendor` directory into git. For any PR to `dep` where you're
+updating `Gopkg.toml`, make sure to run `dep ensure` and
+([for now](https://github.com/golang/dep/issues/944)) `dep prune` and commit all
+changes to `vendor`.
+
 [GitHub Help]: https://help.github.com/articles/about-pull-requests/
 
 ## Contributor License Agreement


### PR DESCRIPTION
### What does this do / why do we need it?

Updates the contributing docs.

It's confusing that when preparing a PR that updates dependencies, you suddenly get a lot of untracked files.

### What should your reviewer look out for in this PR?

Make sure I'm not wrong.

### Do you need help or clarification on anything?

No.

### Which issue(s) does this PR fix?

None.