### PR TITLE
Remove link of `board`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,7 @@ again.
 ### Issue management
 
 * We use [Zenhub](https://www.zenhub.com) to manage the queue, in addition to what we do with labels.
+  * You will need to install [ZenHub extension](https://www.zenhub.com/extension) to your browser to show the board.
   * Pipelines, and [the board](https://github.com/golang/dep#boards) are one thing we try to utilize:
     * **New Issues Pipeline**: When someone creates a new issue, it goes here first. Keep an eye out for issues that fall into your area. Add labels to them, and if it's something we should do, put it in the `Backlog` pipeline. If you aren't sure, throw it in the `Icebox`. It helps to sort this pipeline by date.
     * **Icebox Pipeline**: Issues that we aren't immediately closing but aren't really ready to be prioritized and started on. It's not a wontfix bucket, but a "not sure if we should/can fix right now" bucket.


### PR DESCRIPTION
### What does this do / why do we need it?

Updates the contributing docs. 
Because there seems to be no description about `board` in README.

### What should your reviewer look out for in this PR?

Make sure I'm not wrong.

### Do you need help or clarification on anything?

No.

### Which issue(s) does this PR fix?

None.

