### PR TITLE
gps: fix panic for gopkgin's implicit v0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ BUG FIXES:
 * Releases targeting Windows now have a `.exe` suffix (#1291).
 * Adaptively recover from dirty and corrupted git repositories in cache (#1279).
 * Suppress git password prompts in more places (#1357).
+* Support [gopkg.in version zero](http://labix.org/gopkg.in#VersionZero). Fixes potential panic when referencing v0 gopkg.in packages  ([#1243](https://github.com/golang/dep/pull/1243)).
 
 IMPROVEMENTS:
 

--- a/gps/vcs_source.go
+++ b/gps/vcs_source.go
@@ -384,23 +384,34 @@ func (s *gopkginSource) listVersions(ctx context.Context) ([]PairedVersion, erro
 	k := 0
 	var dbranch int // index of branch to be marked default
 	var bsv semver.Version
+	var defaultBranch PairedVersion
+	tryDefaultAsV0 := s.major == 0
 	for _, v := range ovlist {
 		// all git versions will always be paired
 		pv := v.(versionPair)
 		switch tv := pv.v.(type) {
 		case semVersion:
+			tryDefaultAsV0 = false
 			if tv.sv.Major() == s.major && !s.unstable {
 				vlist[k] = v
 				k++
 			}
 		case branchVersion:
+			if tv.isDefault && defaultBranch == nil {
+				defaultBranch = pv
+			}
+
 			// The semver lib isn't exactly the same as gopkg.in's logic, but
 			// it's close enough that it's probably fine to use. We can be more
 			// exact if real problems crop up.
 			sv, err := semver.NewVersion(tv.name)
-			if err != nil || sv.Major() != s.major {
-				// not a semver-shaped branch name at all, or not the same major
-				// version as specified in the import path constraint
+			if err != nil {
+				continue
+			}
+			tryDefaultAsV0 = false
+
+			if sv.Major() != s.major {
+				// not the same major version as specified in the import path constraint
 				continue
 			}
 
@@ -433,6 +444,12 @@ func (s *gopkginSource) listVersions(ctx context.Context) ([]PairedVersion, erro
 			name:      dbv.v.(branchVersion).name,
 			isDefault: true,
 		}.Pair(dbv.r)
+	}
+
+	// Treat the default branch as v0 only when no other semver branches/tags exist
+	// See http://labix.org/gopkg.in#VersionZero
+	if tryDefaultAsV0 && defaultBranch != nil {
+		vlist = append(vlist, defaultBranch)
 	}
 
 	return vlist, nil

--- a/gps/vcs_source_test.go
+++ b/gps/vcs_source_test.go
@@ -212,11 +212,11 @@ func testGopkginSourceInteractions(t *testing.T) {
 
 		vlist := hidePair(pvlist)
 		if len(vlist) != len(evl) {
-			t.Errorf("gopkgin test repo should've produced %v versions, got %v", len(evl), len(vlist))
+			t.Errorf("gopkgin test repo (%s) should've produced %v versions, got %v.\n%v", un, len(evl), len(vlist), vlist)
 		} else {
 			SortForUpgrade(vlist)
 			if !reflect.DeepEqual(vlist, evl) {
-				t.Errorf("Version list was not what we expected:\n\t(GOT): %s\n\t(WNT): %s", vlist, evl)
+				t.Errorf("Version list for %s was not what we expected:\n\t(GOT): %#v\n\t(WNT): %#v", un, vlist, evl)
 			}
 		}
 
@@ -232,7 +232,7 @@ func testGopkginSourceInteractions(t *testing.T) {
 		} else {
 			SortForUpgrade(vlist)
 			if !reflect.DeepEqual(vlist, evl) {
-				t.Errorf("Version list was not what we expected:\n\t(GOT): %s\n\t(WNT): %s", vlist, evl)
+				t.Errorf("Version list for %s was not what we expected:\n\t(GOT): %#v\n\t(WNT): %#v", un, vlist, evl)
 			}
 		}
 
@@ -247,7 +247,24 @@ func testGopkginSourceInteractions(t *testing.T) {
 
 	// simultaneously run for v1, v2, and v3 filters of the target repo
 	wg := &sync.WaitGroup{}
-	wg.Add(4)
+	wg.Add(6)
+
+	go func() {
+		// Treat master as v0 when no other branches/tags exist that match gopkg.in's rules
+		tfunc("gopkg.in/carolynvs/deptest-gopkgin-implicit-v0.v0", "github.com/carolynvs/deptest-gopkgin-implicit-v0", 0, []Version{
+			newDefaultBranch("notmaster").Pair(Revision("94ee631b9833cd805d15f50a52e0533124ec0292")),
+		})
+		wg.Done()
+	}()
+
+	go func() {
+		// Use the existing v0 branch for v0, not master
+		tfunc("gopkg.in/carolynvs/deptest-gopkgin-explicit-v0.v0", "github.com/carolynvs/deptest-gopkgin-explicit-v0", 0, []Version{
+			newDefaultBranch("v0").Pair(Revision("ec73e84554fb28f08dba630e48dbec868e77f734")),
+		})
+		wg.Done()
+	}()
+
 	go func() {
 		tfunc("gopkg.in/sdboyer/gpkt.v1", "github.com/sdboyer/gpkt", 1, []Version{
 			NewVersion("v1.1.0").Pair(Revision("b2cb48dda625f6640b34d9ffb664533359ac8b91")),


### PR DESCRIPTION
### What does this do / why do we need it?
When v0 is requested, and there are no semver branches/tags, fallback to the master branch.

See http://labix.org/gopkg.in#VersionZero

### What should your reviewer look out for in this PR?
Nope.

### Do you need help or clarification on anything?
Nope.

### Which issue(s) does this PR fix?
Fixes #933 
Fixes #776 