### PR TITLE
gps: fine grained source transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ BUG FIXES:
 
 IMPROVEMENTS:
 
+* Reduce network access by trusting local source information and only pulling
+from upstream when necessary ([#1250](https://github.com/golang/dep/pull/1250)).
+
 # v0.4.1
 
 BUG FIXES:

--- a/gps/deduce.go
+++ b/gps/deduce.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"sync"
 
-	radix "github.com/armon/go-radix"
+	"github.com/armon/go-radix"
 	"github.com/pkg/errors"
 )
 
@@ -104,7 +104,7 @@ type pathDeducer interface {
 	// So the return of the above string would be
 	// "github.com/some-user/some-package"
 	deduceRoot(string) (string, error)
-	deduceSource(string, *url.URL) (maybeSource, error)
+	deduceSource(string, *url.URL) (maybeSources, error)
 }
 
 type githubDeducer struct {
@@ -120,7 +120,7 @@ func (m githubDeducer) deduceRoot(path string) (string, error) {
 	return "github.com" + v[2], nil
 }
 
-func (m githubDeducer) deduceSource(path string, u *url.URL) (maybeSource, error) {
+func (m githubDeducer) deduceSource(path string, u *url.URL) (maybeSources, error) {
 	v := m.regexp.FindStringSubmatch(path)
 	if v == nil {
 		return nil, fmt.Errorf("%s is not a valid path for a source on github.com", path)
@@ -138,7 +138,7 @@ func (m githubDeducer) deduceSource(path string, u *url.URL) (maybeSource, error
 		if u.Scheme == "ssh" {
 			u.User = url.User("git")
 		}
-		return maybeGitSource{url: u}, nil
+		return maybeSources{maybeGitSource{url: u}}, nil
 	}
 
 	mb := make(maybeSources, len(gitSchemes))
@@ -167,7 +167,7 @@ func (m bitbucketDeducer) deduceRoot(path string) (string, error) {
 	return "bitbucket.org" + v[2], nil
 }
 
-func (m bitbucketDeducer) deduceSource(path string, u *url.URL) (maybeSource, error) {
+func (m bitbucketDeducer) deduceSource(path string, u *url.URL) (maybeSources, error) {
 	v := m.regexp.FindStringSubmatch(path)
 	if v == nil {
 		return nil, fmt.Errorf("%s is not a valid path for a source on bitbucket.org", path)
@@ -189,12 +189,12 @@ func (m bitbucketDeducer) deduceSource(path string, u *url.URL) (maybeSource, er
 				// superset of the hg schemes
 				return nil, fmt.Errorf("%s is not a valid scheme for accessing a git repository", u.Scheme)
 			}
-			return maybeGitSource{url: u}, nil
+			return maybeSources{maybeGitSource{url: u}}, nil
 		} else if ishg {
 			if !validhg {
 				return nil, fmt.Errorf("%s is not a valid scheme for accessing an hg repository", u.Scheme)
 			}
-			return maybeHgSource{url: u}, nil
+			return maybeSources{maybeHgSource{url: u}}, nil
 		} else if !validgit && !validhg {
 			return nil, fmt.Errorf("%s is not a valid scheme for accessing either a git or hg repository", u.Scheme)
 		}
@@ -265,7 +265,7 @@ func (m gopkginDeducer) parseAndValidatePath(p string) ([]string, error) {
 	return v, nil
 }
 
-func (m gopkginDeducer) deduceSource(p string, u *url.URL) (maybeSource, error) {
+func (m gopkginDeducer) deduceSource(p string, u *url.URL) (maybeSources, error) {
 	// Reuse root detection logic for initial validation
 	v, err := m.parseAndValidatePath(p)
 	if err != nil {
@@ -329,7 +329,7 @@ func (m launchpadDeducer) deduceRoot(path string) (string, error) {
 	return "launchpad.net" + v[2], nil
 }
 
-func (m launchpadDeducer) deduceSource(path string, u *url.URL) (maybeSource, error) {
+func (m launchpadDeducer) deduceSource(path string, u *url.URL) (maybeSources, error) {
 	v := m.regexp.FindStringSubmatch(path)
 	if v == nil {
 		return nil, fmt.Errorf("%s is not a valid path for a source on launchpad.net", path)
@@ -342,7 +342,7 @@ func (m launchpadDeducer) deduceSource(path string, u *url.URL) (maybeSource, er
 		if !validateVCSScheme(u.Scheme, "bzr") {
 			return nil, fmt.Errorf("%s is not a valid scheme for accessing a bzr repository", u.Scheme)
 		}
-		return maybeBzrSource{url: u}, nil
+		return maybeSources{maybeBzrSource{url: u}}, nil
 	}
 
 	mb := make(maybeSources, len(bzrSchemes))
@@ -369,7 +369,7 @@ func (m launchpadGitDeducer) deduceRoot(path string) (string, error) {
 	return "git.launchpad.net" + v[2], nil
 }
 
-func (m launchpadGitDeducer) deduceSource(path string, u *url.URL) (maybeSource, error) {
+func (m launchpadGitDeducer) deduceSource(path string, u *url.URL) (maybeSources, error) {
 	v := m.regexp.FindStringSubmatch(path)
 	if v == nil {
 		return nil, fmt.Errorf("%s is not a valid path for a source on git.launchpad.net", path)
@@ -382,7 +382,7 @@ func (m launchpadGitDeducer) deduceSource(path string, u *url.URL) (maybeSource,
 		if !validateVCSScheme(u.Scheme, "git") {
 			return nil, fmt.Errorf("%s is not a valid scheme for accessing a git repository", u.Scheme)
 		}
-		return maybeGitSource{url: u}, nil
+		return maybeSources{maybeGitSource{url: u}}, nil
 	}
 
 	mb := make(maybeSources, len(gitSchemes))
@@ -408,7 +408,7 @@ func (m jazzDeducer) deduceRoot(path string) (string, error) {
 	return "hub.jazz.net" + v[2], nil
 }
 
-func (m jazzDeducer) deduceSource(path string, u *url.URL) (maybeSource, error) {
+func (m jazzDeducer) deduceSource(path string, u *url.URL) (maybeSources, error) {
 	v := m.regexp.FindStringSubmatch(path)
 	if v == nil {
 		return nil, fmt.Errorf("%s is not a valid path for a source on hub.jazz.net", path)
@@ -422,7 +422,7 @@ func (m jazzDeducer) deduceSource(path string, u *url.URL) (maybeSource, error) 
 		u.Scheme = "https"
 		fallthrough
 	case "https":
-		return maybeGitSource{url: u}, nil
+		return maybeSources{maybeGitSource{url: u}}, nil
 	default:
 		return nil, fmt.Errorf("IBM's jazz hub only supports https, %s is not allowed", u.String())
 	}
@@ -441,7 +441,7 @@ func (m apacheDeducer) deduceRoot(path string) (string, error) {
 	return "git.apache.org" + v[2], nil
 }
 
-func (m apacheDeducer) deduceSource(path string, u *url.URL) (maybeSource, error) {
+func (m apacheDeducer) deduceSource(path string, u *url.URL) (maybeSources, error) {
 	v := m.regexp.FindStringSubmatch(path)
 	if v == nil {
 		return nil, fmt.Errorf("%s is not a valid path for a source on git.apache.org", path)
@@ -454,7 +454,7 @@ func (m apacheDeducer) deduceSource(path string, u *url.URL) (maybeSource, error
 		if !validateVCSScheme(u.Scheme, "git") {
 			return nil, fmt.Errorf("%s is not a valid scheme for accessing a git repository", u.Scheme)
 		}
-		return maybeGitSource{url: u}, nil
+		return maybeSources{maybeGitSource{url: u}}, nil
 	}
 
 	mb := make(maybeSources, len(gitSchemes))
@@ -480,7 +480,7 @@ func (m vcsExtensionDeducer) deduceRoot(path string) (string, error) {
 	return v[1], nil
 }
 
-func (m vcsExtensionDeducer) deduceSource(path string, u *url.URL) (maybeSource, error) {
+func (m vcsExtensionDeducer) deduceSource(path string, u *url.URL) (maybeSources, error) {
 	v := m.regexp.FindStringSubmatch(path)
 	if v == nil {
 		return nil, fmt.Errorf("%s contains no vcs extension hints for matching", path)
@@ -500,11 +500,11 @@ func (m vcsExtensionDeducer) deduceSource(path string, u *url.URL) (maybeSource,
 
 			switch v[4] {
 			case "git":
-				return maybeGitSource{url: u}, nil
+				return maybeSources{maybeGitSource{url: u}}, nil
 			case "bzr":
-				return maybeBzrSource{url: u}, nil
+				return maybeSources{maybeBzrSource{url: u}}, nil
 			case "hg":
-				return maybeHgSource{url: u}, nil
+				return maybeSources{maybeHgSource{url: u}}, nil
 			}
 		}
 
@@ -590,7 +590,7 @@ func (dc *deductionCoordinator) deduceRootPath(ctx context.Context, path string)
 	dc.mut.RUnlock()
 	if has && isPathPrefixOrEqual(prefix, path) {
 		switch d := data.(type) {
-		case maybeSource:
+		case maybeSources:
 			return pathDeduction{root: prefix, mb: d}, nil
 		case *httpMetadataDeducer:
 			// Multiple calls have come in for a similar path shape during
@@ -652,7 +652,7 @@ func (dc *deductionCoordinator) deduceRootPath(ctx context.Context, path string)
 // the source.
 type pathDeduction struct {
 	root string
-	mb   maybeSource
+	mb   maybeSources
 }
 
 var errNoKnownPathMatch = errors.New("no known path match")
@@ -759,11 +759,11 @@ func (hmd *httpMetadataDeducer) deduce(ctx context.Context, path string) (pathDe
 
 		switch vcs {
 		case "git":
-			pd.mb = maybeGitSource{url: repoURL}
+			pd.mb = maybeSources{maybeGitSource{url: repoURL}}
 		case "bzr":
-			pd.mb = maybeBzrSource{url: repoURL}
+			pd.mb = maybeSources{maybeBzrSource{url: repoURL}}
 		case "hg":
-			pd.mb = maybeHgSource{url: repoURL}
+			pd.mb = maybeSources{maybeHgSource{url: repoURL}}
 		default:
 			hmd.deduceErr = errors.Errorf("unsupported vcs type %s in go-get metadata from %s", vcs, path)
 			return

--- a/gps/deduce_test.go
+++ b/gps/deduce_test.go
@@ -18,7 +18,7 @@ type pathDeductionFixture struct {
 	in     string
 	root   string
 	rerr   error
-	mb     maybeSource
+	mb     maybeSources
 	srcerr error
 }
 
@@ -69,17 +69,23 @@ var pathDeductionFixtures = map[string][]pathDeductionFixture{
 		{
 			in:   "git@github.com:sdboyer/gps",
 			root: "github.com/sdboyer/gps",
-			mb:   maybeGitSource{url: mkurl("ssh://git@github.com/sdboyer/gps")},
+			mb: maybeSources{
+				maybeGitSource{url: mkurl("ssh://git@github.com/sdboyer/gps")},
+			},
 		},
 		{
 			in:   "https://github.com/sdboyer/gps",
 			root: "github.com/sdboyer/gps",
-			mb:   maybeGitSource{url: mkurl("https://github.com/sdboyer/gps")},
+			mb: maybeSources{
+				maybeGitSource{url: mkurl("https://github.com/sdboyer/gps")},
+			},
 		},
 		{
 			in:   "https://github.com/sdboyer/gps/foo/bar",
 			root: "github.com/sdboyer/gps",
-			mb:   maybeGitSource{url: mkurl("https://github.com/sdboyer/gps")},
+			mb: maybeSources{
+				maybeGitSource{url: mkurl("https://github.com/sdboyer/gps")},
+			},
 		},
 		{
 			in:   "github.com/sdboyer-/gps/foo",
@@ -163,6 +169,7 @@ var pathDeductionFixtures = map[string][]pathDeductionFixture{
 			in:   "gopkg.in/yaml.v1/foo/bar",
 			root: "gopkg.in/yaml.v1",
 			mb: maybeSources{
+
 				maybeGopkginSource{opath: "gopkg.in/yaml.v1", url: mkurl("https://github.com/go-yaml/yaml"), major: 1},
 				maybeGopkginSource{opath: "gopkg.in/yaml.v1", url: mkurl("http://github.com/go-yaml/yaml"), major: 1},
 			},
@@ -186,12 +193,16 @@ var pathDeductionFixtures = map[string][]pathDeductionFixture{
 		{
 			in:   "hub.jazz.net/git/user1/pkgname",
 			root: "hub.jazz.net/git/user1/pkgname",
-			mb:   maybeGitSource{url: mkurl("https://hub.jazz.net/git/user1/pkgname")},
+			mb: maybeSources{
+				maybeGitSource{url: mkurl("https://hub.jazz.net/git/user1/pkgname")},
+			},
 		},
 		{
 			in:   "hub.jazz.net/git/user1/pkgname/submodule/submodule/submodule",
 			root: "hub.jazz.net/git/user1/pkgname",
-			mb:   maybeGitSource{url: mkurl("https://hub.jazz.net/git/user1/pkgname")},
+			mb: maybeSources{
+				maybeGitSource{url: mkurl("https://hub.jazz.net/git/user1/pkgname")},
+			},
 		},
 		{
 			in:   "hub.jazz.net/someotherprefix",
@@ -218,7 +229,9 @@ var pathDeductionFixtures = map[string][]pathDeductionFixture{
 		{
 			in:   "hub.jazz.net/git/user1/pkg.name",
 			root: "hub.jazz.net/git/user1/pkg.name",
-			mb:   maybeGitSource{url: mkurl("https://hub.jazz.net/git/user1/pkg.name")},
+			mb: maybeSources{
+				maybeGitSource{url: mkurl("https://hub.jazz.net/git/user1/pkg.name")},
+			},
 		},
 		// User names cannot have uppercase letters
 		{
@@ -275,7 +288,9 @@ var pathDeductionFixtures = map[string][]pathDeductionFixture{
 		{
 			in:   "git@bitbucket.org:sdboyer/reporoot.git",
 			root: "bitbucket.org/sdboyer/reporoot.git",
-			mb:   maybeGitSource{url: mkurl("ssh://git@bitbucket.org/sdboyer/reporoot.git")},
+			mb: maybeSources{
+				maybeGitSource{url: mkurl("ssh://git@bitbucket.org/sdboyer/reporoot.git")},
+			},
 		},
 		{
 			in:   "bitbucket.org/sdboyer/reporoot.hg",
@@ -289,7 +304,9 @@ var pathDeductionFixtures = map[string][]pathDeductionFixture{
 		{
 			in:   "hg@bitbucket.org:sdboyer/reporoot",
 			root: "bitbucket.org/sdboyer/reporoot",
-			mb:   maybeHgSource{url: mkurl("ssh://hg@bitbucket.org/sdboyer/reporoot")},
+			mb: maybeSources{
+				maybeHgSource{url: mkurl("ssh://hg@bitbucket.org/sdboyer/reporoot")},
+			},
 		},
 		{
 			in:     "git://bitbucket.org/sdboyer/reporoot.hg",
@@ -417,22 +434,30 @@ var pathDeductionFixtures = map[string][]pathDeductionFixture{
 		{
 			in:   "git@foobar.com:baz.git",
 			root: "foobar.com/baz.git",
-			mb:   maybeGitSource{url: mkurl("ssh://git@foobar.com/baz.git")},
+			mb: maybeSources{
+				maybeGitSource{url: mkurl("ssh://git@foobar.com/baz.git")},
+			},
 		},
 		{
 			in:   "bzr+ssh://foobar.com/baz.bzr",
 			root: "foobar.com/baz.bzr",
-			mb:   maybeBzrSource{url: mkurl("bzr+ssh://foobar.com/baz.bzr")},
+			mb: maybeSources{
+				maybeBzrSource{url: mkurl("bzr+ssh://foobar.com/baz.bzr")},
+			},
 		},
 		{
 			in:   "ssh://foobar.com/baz.bzr",
 			root: "foobar.com/baz.bzr",
-			mb:   maybeBzrSource{url: mkurl("ssh://foobar.com/baz.bzr")},
+			mb: maybeSources{
+				maybeBzrSource{url: mkurl("ssh://foobar.com/baz.bzr")},
+			},
 		},
 		{
 			in:   "https://foobar.com/baz.hg",
 			root: "foobar.com/baz.hg",
-			mb:   maybeHgSource{url: mkurl("https://foobar.com/baz.hg")},
+			mb: maybeSources{
+				maybeHgSource{url: mkurl("https://foobar.com/baz.hg")},
+			},
 		},
 		{
 			in:     "git://foobar.com/baz.hg",
@@ -457,17 +482,23 @@ var pathDeductionFixtures = map[string][]pathDeductionFixture{
 		{
 			in:   "golang.org/x/exp",
 			root: "golang.org/x/exp",
-			mb:   maybeGitSource{url: mkurl("https://go.googlesource.com/exp")},
+			mb: maybeSources{
+				maybeGitSource{url: mkurl("https://go.googlesource.com/exp")},
+			},
 		},
 		{
 			in:   "golang.org/x/exp/inotify",
 			root: "golang.org/x/exp",
-			mb:   maybeGitSource{url: mkurl("https://go.googlesource.com/exp")},
+			mb: maybeSources{
+				maybeGitSource{url: mkurl("https://go.googlesource.com/exp")},
+			},
 		},
 		{
 			in:   "golang.org/x/net/html",
 			root: "golang.org/x/net",
-			mb:   maybeGitSource{url: mkurl("https://go.googlesource.com/net")},
+			mb: maybeSources{
+				maybeGitSource{url: mkurl("https://go.googlesource.com/net")},
+			},
 		},
 	},
 }
@@ -501,28 +532,13 @@ func TestDeduceFromPath(t *testing.T) {
 				t.SkipNow()
 			}
 
-			var printmb func(mb maybeSource, t *testing.T) string
-			printmb = func(mb maybeSource, t *testing.T) string {
-				switch tmb := mb.(type) {
-				case maybeSources:
-					var buf bytes.Buffer
-					fmt.Fprintf(&buf, "%v maybeSources:", len(tmb))
-					for _, elem := range tmb {
-						fmt.Fprintf(&buf, "\n\t\t%s", printmb(elem, t))
-					}
-					return buf.String()
-				case maybeGitSource:
-					return fmt.Sprintf("%T: %s", tmb, ufmt(tmb.url))
-				case maybeBzrSource:
-					return fmt.Sprintf("%T: %s", tmb, ufmt(tmb.url))
-				case maybeHgSource:
-					return fmt.Sprintf("%T: %s", tmb, ufmt(tmb.url))
-				case maybeGopkginSource:
-					return fmt.Sprintf("%T: %s (v%v) %s ", tmb, tmb.opath, tmb.major, ufmt(tmb.url))
-				default:
-					t.Errorf("Unknown maybeSource type: %T", mb)
+			printmb := func(mb maybeSources) string {
+				var buf bytes.Buffer
+				fmt.Fprintf(&buf, "%v maybeSources:", len(mb))
+				for _, elem := range mb {
+					fmt.Fprintf(&buf, "\n\t\t%s", elem)
 				}
-				return ""
+				return buf.String()
 			}
 
 			for _, fix := range fixtures {
@@ -564,16 +580,11 @@ func TestDeduceFromPath(t *testing.T) {
 						}
 					} else if !reflect.DeepEqual(mb, fix.mb) {
 						if mb == nil {
-							t.Errorf("Deducer returned source maybes, but none expected:\n\t(GOT) (none)\n\t(WNT) %s", printmb(fix.mb, t))
+							t.Errorf("Deducer returned source maybes, but none expected:\n\t(GOT) (none)\n\t(WNT) %s", printmb(fix.mb))
 						} else if fix.mb == nil {
-							t.Errorf("Deducer returned source maybes, but none expected:\n\t(GOT) %s\n\t(WNT) (none)", printmb(mb, t))
+							t.Errorf("Deducer returned source maybes, but none expected:\n\t(GOT) %s\n\t(WNT) (none)", printmb(mb))
 						} else {
-							t.Errorf("Deducer did not return expected source:\n\t(GOT) %s\n\t(WNT) %s", printmb(mb, t), printmb(fix.mb, t))
-						}
-					} else {
-						gotURLs, wantURLs := mb.possibleURLs(), fix.mb.possibleURLs()
-						if !reflect.DeepEqual(gotURLs, wantURLs) {
-							t.Errorf("Deducer did not return expected source:\n\t(GOT) %s\n\t(WNT) %s", gotURLs, wantURLs)
+							t.Errorf("Deducer did not return expected source:\n\t(GOT) %s\n\t(WNT) %s", printmb(mb), printmb(fix.mb))
 						}
 					}
 				})
@@ -623,7 +634,12 @@ func TestVanityDeduction(t *testing.T) {
 					return
 				}
 
-				goturl, wanturl := pd.mb.(maybeGitSource).url.String(), fix.mb.(maybeGitSource).url.String()
+				if len(pd.mb) != 1 {
+					t.Errorf("Expected single maybeSource, but found: %d", len(pd.mb))
+					return
+				}
+
+				goturl, wanturl := pd.mb[0].(maybeGitSource).url.String(), fix.mb[0].(maybeGitSource).url.String()
 				if goturl != wanturl {
 					t.Errorf("Deduced repo ident does not match fixture:\n\t(GOT) %s\n\t(WNT) %s", goturl, wanturl)
 				}
@@ -662,18 +678,4 @@ func TestVanityDeductionSchemeMismatch(t *testing.T) {
 	if err == nil {
 		t.Error("should have errored on scheme mismatch between input and go-get metadata")
 	}
-}
-
-// borrow from stdlib
-// more useful string for debugging than fmt's struct printer
-func ufmt(u *url.URL) string {
-	var user, pass interface{}
-	if u.User != nil {
-		user = u.User.Username()
-		if p, ok := u.User.Password(); ok {
-			pass = p
-		}
-	}
-	return fmt.Sprintf("host=%q, path=%q, opaque=%q, scheme=%q, user=%#v, pass=%#v, rawpath=%q, rawq=%q, frag=%q",
-		u.Host, u.Path, u.Opaque, u.Scheme, user, pass, u.RawPath, u.RawQuery, u.Fragment)
 }

--- a/gps/error.go
+++ b/gps/error.go
@@ -1,0 +1,34 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gps
+
+import (
+	"bytes"
+	"fmt"
+)
+
+type errorSlice []error
+
+func (errs errorSlice) Error() string {
+	var buf bytes.Buffer
+	fmt.Fprintln(&buf)
+	for i, err := range errs {
+		fmt.Fprintf(&buf, "\t(%d) %s\n", i+1, err)
+	}
+	return buf.String()
+}
+
+func (errs errorSlice) Format(f fmt.State, c rune) {
+	fmt.Fprintln(f)
+	for i, err := range errs {
+		if ferr, ok := err.(fmt.Formatter); ok {
+			fmt.Fprintf(f, "\t(%d) ", i+1)
+			ferr.Format(f, c)
+			fmt.Fprint(f, "\n")
+		} else {
+			fmt.Fprintf(f, "\t(%d) %s\n", i+1, err)
+		}
+	}
+}

--- a/gps/manager_test.go
+++ b/gps/manager_test.go
@@ -376,24 +376,26 @@ func (f sourceCreationTestFixture) run(t *testing.T) {
 		t.Errorf("want %v gateways in the sources map, but got %v", f.srccount, len(sm.srcCoord.srcs))
 	}
 
-	var keys []string
-	for k := range sm.srcCoord.nameToURL {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
+	if t.Failed() {
+		var keys []string
+		for k := range sm.srcCoord.nameToURL {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
 
-	var buf bytes.Buffer
-	w := tabwriter.NewWriter(&buf, 0, 4, 2, ' ', 0)
-	fmt.Fprint(w, "NAME\tMAPPED URL\n")
-	for _, r := range keys {
-		fmt.Fprintf(w, "%s\t%s\n", r, sm.srcCoord.nameToURL[r])
-	}
-	w.Flush()
-	t.Log("\n", buf.String())
+		var buf bytes.Buffer
+		w := tabwriter.NewWriter(&buf, 0, 4, 2, ' ', 0)
+		fmt.Fprint(w, "NAME\tMAPPED URL\n")
+		for _, r := range keys {
+			fmt.Fprintf(w, "%s\t%s\n", r, sm.srcCoord.nameToURL[r])
+		}
+		w.Flush()
+		t.Log("\n", buf.String())
 
-	t.Log("SRC KEYS")
-	for k := range sm.srcCoord.srcs {
-		t.Log(k)
+		t.Log("SRC KEYS")
+		for k := range sm.srcCoord.srcs {
+			t.Log(k)
+		}
 	}
 }
 
@@ -420,9 +422,11 @@ func TestSourceCreationCounts(t *testing.T) {
 			roots: []ProjectIdentifier{
 				mkPI("gopkg.in/sdboyer/gpkt.v1"),
 				mkPI("github.com/sdboyer/gpkt"),
+				mkPI("http://github.com/sdboyer/gpkt"),
+				mkPI("https://github.com/sdboyer/gpkt"),
 			},
-			namecount: 4,
-			srccount:  2,
+			namecount: 5,
+			srccount:  3,
 		},
 		"case variance across path and URL-based access": {
 			roots: []ProjectIdentifier{
@@ -533,16 +537,14 @@ func TestFSCaseSensitivityConvergesSources(t *testing.T) {
 			}
 
 			path1 := sg1.src.(*gitSource).repo.LocalPath()
-			t.Log("path1:", path1)
 			stat1, err := os.Stat(path1)
 			if err != nil {
-				t.Fatal(err)
+				t.Fatal("path1:", path1, err)
 			}
 			path2 := sg2.src.(*gitSource).repo.LocalPath()
-			t.Log("path2:", path2)
 			stat2, err := os.Stat(path2)
 			if err != nil {
-				t.Fatal(err)
+				t.Fatal("path2:", path2, err)
 			}
 
 			same, count := os.SameFile(stat1, stat2), len(sm.srcCoord.srcs)

--- a/gps/maybe_source.go
+++ b/gps/maybe_source.go
@@ -5,14 +5,13 @@
 package gps
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"net/url"
+	"os"
 	"path/filepath"
 
 	"github.com/Masterminds/vcs"
-	"github.com/pkg/errors"
 )
 
 // A maybeSource represents a set of information that, given some
@@ -23,46 +22,18 @@ import (
 // * Allows control over when deduction logic triggers network activity
 // * Makes it easy to attempt multiple URLs for a given import path
 type maybeSource interface {
-	try(ctx context.Context, cachedir string, c singleSourceCache, superv *supervisor) (source, sourceState, error)
-	possibleURLs() []*url.URL
-}
-
-type errorSlice []error
-
-func (errs *errorSlice) Error() string {
-	var buf bytes.Buffer
-	for _, err := range *errs {
-		fmt.Fprintf(&buf, "\n\t%s", err)
-	}
-	return buf.String()
+	// try tries to set up a source and returns any *additional* sourceState.
+	try(ctx context.Context, cachedir string, superv *supervisor) (source, sourceState, error)
+	URL() *url.URL
+	fmt.Stringer
 }
 
 type maybeSources []maybeSource
 
-func (mbs maybeSources) try(ctx context.Context, cachedir string, c singleSourceCache, superv *supervisor) (source, sourceState, error) {
-	var errs errorSlice
-	for _, mb := range mbs {
-		src, state, err := mb.try(ctx, cachedir, c, superv)
-		if err == nil {
-			return src, state, nil
-		}
-		urls := ""
-		for _, url := range mb.possibleURLs() {
-			urls += url.String() + "\n"
-		}
-		errs = append(errs, errors.Wrapf(err, "failed to set up sources from the following URLs:\n%s", urls))
-	}
-
-	return nil, 0, errors.Wrap(&errs, "no valid source could be created")
-}
-
-// This really isn't generally intended to be used - the interface is for
-// maybeSources to be able to interrogate its members, not other things to
-// interrogate a maybeSources.
 func (mbs maybeSources) possibleURLs() []*url.URL {
-	urlslice := make([]*url.URL, 0, len(mbs))
-	for _, mb := range mbs {
-		urlslice = append(urlslice, mb.possibleURLs()...)
+	urlslice := make([]*url.URL, len(mbs))
+	for i, mb := range mbs {
+		urlslice[i] = mb.URL()
 	}
 	return urlslice
 }
@@ -76,50 +47,44 @@ type maybeGitSource struct {
 	url *url.URL
 }
 
-func (m maybeGitSource) try(ctx context.Context, cachedir string, c singleSourceCache, superv *supervisor) (source, sourceState, error) {
+func (m maybeGitSource) try(ctx context.Context, cachedir string, superv *supervisor) (source, sourceState, error) {
 	ustr := m.url.String()
+	path := sourceCachePath(cachedir, ustr)
 
-	r, err := newCtxRepo(vcs.Git, ustr, sourceCachePath(cachedir, ustr))
+	r, err := vcs.NewGitRepo(ustr, path)
 	if err != nil {
-		return nil, 0, unwrapVcsErr(err)
+		os.RemoveAll(path)
+		r, err = vcs.NewGitRepo(ustr, path)
+		if err != nil {
+			return nil, 0, unwrapVcsErr(err)
+		}
 	}
 
-	src := &gitSource{
-		baseVCSSource: baseVCSSource{
-			repo: r,
-		},
-	}
+	repo := &gitRepo{r}
 
-	// Pinging invokes the same action as calling listVersions, so just do that.
-	var vl []PairedVersion
-	if err := superv.do(ctx, "git:lv:maybe", ctListVersions, func(ctx context.Context) error {
-		var err error
-		vl, err = src.listVersions(ctx)
-		return errors.Wrapf(err, "remote repository at %s does not exist, or is inaccessible", ustr)
-	}); err != nil {
-		return nil, 0, err
-	}
-
-	state := sourceIsSetUp | sourceExistsUpstream | sourceHasLatestVersionList
-
+	var state sourceState
 	if r.CheckLocal() {
 		state |= sourceExistsLocally
-
 		if err := superv.do(ctx, "git", ctValidateLocal, func(ctx context.Context) error {
-			// If repository already exists on disk, make a pass to be sure
-			// everything's clean.
-			return src.ensureClean(ctx)
+			return repo.ensureClean(ctx)
 		}); err != nil {
 			return nil, 0, err
 		}
 	}
 
-	c.setVersionMap(vl)
-	return src, state, nil
+	return &gitSource{
+		baseVCSSource: baseVCSSource{
+			repo: repo,
+		},
+	}, state, nil
 }
 
-func (m maybeGitSource) possibleURLs() []*url.URL {
-	return []*url.URL{m.url}
+func (m maybeGitSource) URL() *url.URL {
+	return m.url
+}
+
+func (m maybeGitSource) String() string {
+	return fmt.Sprintf("%T: %s", m, ufmt(m.url))
 }
 
 type maybeGopkginSource struct {
@@ -136,7 +101,7 @@ type maybeGopkginSource struct {
 	unstable bool
 }
 
-func (m maybeGopkginSource) try(ctx context.Context, cachedir string, c singleSourceCache, superv *supervisor) (source, sourceState, error) {
+func (m maybeGopkginSource) try(ctx context.Context, cachedir string, superv *supervisor) (source, sourceState, error) {
 	// We don't actually need a fully consistent transform into the on-disk path
 	// - just something that's unique to the particular gopkg.in domain context.
 	// So, it's OK to just dumb-join the scheme with the path.
@@ -144,119 +109,138 @@ func (m maybeGopkginSource) try(ctx context.Context, cachedir string, c singleSo
 	path := sourceCachePath(cachedir, aliasURL)
 	ustr := m.url.String()
 
-	r, err := newCtxRepo(vcs.Git, ustr, path)
+	r, err := vcs.NewGitRepo(ustr, path)
 	if err != nil {
-		return nil, 0, unwrapVcsErr(err)
+		os.RemoveAll(path)
+		r, err = vcs.NewGitRepo(ustr, path)
+		if err != nil {
+			return nil, 0, unwrapVcsErr(err)
+		}
 	}
 
-	src := &gopkginSource{
+	repo := &gitRepo{r}
+
+	var state sourceState
+	if r.CheckLocal() {
+		state |= sourceExistsLocally
+		if err := superv.do(ctx, "git", ctValidateLocal, func(ctx context.Context) error {
+			return repo.ensureClean(ctx)
+		}); err != nil {
+			return nil, 0, err
+		}
+	}
+
+	return &gopkginSource{
 		gitSource: gitSource{
 			baseVCSSource: baseVCSSource{
-				repo: r,
+				repo: repo,
 			},
 		},
 		major:    m.major,
 		unstable: m.unstable,
 		aliasURL: aliasURL,
-	}
-
-	var vl []PairedVersion
-	if err := superv.do(ctx, "git:lv:maybe", ctListVersions, func(ctx context.Context) error {
-		var err error
-		vl, err = src.listVersions(ctx)
-		return errors.Wrapf(err, "remote repository at %s does not exist, or is inaccessible", ustr)
-	}); err != nil {
-		return nil, 0, err
-	}
-
-	c.setVersionMap(vl)
-	state := sourceIsSetUp | sourceExistsUpstream | sourceHasLatestVersionList
-
-	if r.CheckLocal() {
-		state |= sourceExistsLocally
-	}
-
-	return src, state, nil
+	}, state, nil
 }
 
-func (m maybeGopkginSource) possibleURLs() []*url.URL {
-	return []*url.URL{m.url}
+func (m maybeGopkginSource) URL() *url.URL {
+	return &url.URL{
+		Scheme: m.url.Scheme,
+		Path:   m.opath,
+	}
+}
+
+func (m maybeGopkginSource) String() string {
+	return fmt.Sprintf("%T: %s (v%v) %s ", m, m.opath, m.major, ufmt(m.url))
 }
 
 type maybeBzrSource struct {
 	url *url.URL
 }
 
-func (m maybeBzrSource) try(ctx context.Context, cachedir string, c singleSourceCache, superv *supervisor) (source, sourceState, error) {
+func (m maybeBzrSource) try(ctx context.Context, cachedir string, superv *supervisor) (source, sourceState, error) {
 	ustr := m.url.String()
+	path := sourceCachePath(cachedir, ustr)
 
-	r, err := newCtxRepo(vcs.Bzr, ustr, sourceCachePath(cachedir, ustr))
+	r, err := vcs.NewBzrRepo(ustr, path)
 	if err != nil {
-		return nil, 0, unwrapVcsErr(err)
-	}
-
-	if err := superv.do(ctx, "bzr:ping", ctSourcePing, func(ctx context.Context) error {
-		if !r.Ping() {
-			return fmt.Errorf("remote repository at %s does not exist, or is inaccessible", ustr)
+		os.RemoveAll(path)
+		r, err = vcs.NewBzrRepo(ustr, path)
+		if err != nil {
+			return nil, 0, unwrapVcsErr(err)
 		}
-		return nil
-	}); err != nil {
-		return nil, 0, err
 	}
 
-	state := sourceIsSetUp | sourceExistsUpstream
+	repo := &bzrRepo{r}
+
+	var state sourceState
 	if r.CheckLocal() {
 		state |= sourceExistsLocally
 	}
 
-	src := &bzrSource{
+	return &bzrSource{
 		baseVCSSource: baseVCSSource{
-			repo: r,
+			repo: repo,
 		},
-	}
-
-	return src, state, nil
+	}, state, nil
 }
 
-func (m maybeBzrSource) possibleURLs() []*url.URL {
-	return []*url.URL{m.url}
+func (m maybeBzrSource) URL() *url.URL {
+	return m.url
+}
+
+func (m maybeBzrSource) String() string {
+	return fmt.Sprintf("%T: %s", m, ufmt(m.url))
 }
 
 type maybeHgSource struct {
 	url *url.URL
 }
 
-func (m maybeHgSource) try(ctx context.Context, cachedir string, c singleSourceCache, superv *supervisor) (source, sourceState, error) {
+func (m maybeHgSource) try(ctx context.Context, cachedir string, superv *supervisor) (source, sourceState, error) {
 	ustr := m.url.String()
+	path := sourceCachePath(cachedir, ustr)
 
-	r, err := newCtxRepo(vcs.Hg, ustr, sourceCachePath(cachedir, ustr))
+	r, err := vcs.NewHgRepo(ustr, path)
 	if err != nil {
-		return nil, 0, unwrapVcsErr(err)
-	}
-
-	if err := superv.do(ctx, "hg:ping", ctSourcePing, func(ctx context.Context) error {
-		if !r.Ping() {
-			return fmt.Errorf("remote repository at %s does not exist, or is inaccessible", ustr)
+		os.RemoveAll(path)
+		r, err = vcs.NewHgRepo(ustr, path)
+		if err != nil {
+			return nil, 0, unwrapVcsErr(err)
 		}
-		return nil
-	}); err != nil {
-		return nil, 0, err
 	}
 
-	state := sourceIsSetUp | sourceExistsUpstream
+	repo := &hgRepo{r}
+
+	var state sourceState
 	if r.CheckLocal() {
 		state |= sourceExistsLocally
 	}
 
-	src := &hgSource{
+	return &hgSource{
 		baseVCSSource: baseVCSSource{
-			repo: r,
+			repo: repo,
 		},
-	}
-
-	return src, state, nil
+	}, state, nil
 }
 
-func (m maybeHgSource) possibleURLs() []*url.URL {
-	return []*url.URL{m.url}
+func (m maybeHgSource) URL() *url.URL {
+	return m.url
+}
+
+func (m maybeHgSource) String() string {
+	return fmt.Sprintf("%T: %s", m, ufmt(m.url))
+}
+
+// borrow from stdlib
+// more useful string for debugging than fmt's struct printer
+func ufmt(u *url.URL) string {
+	var user, pass interface{}
+	if u.User != nil {
+		user = u.User.Username()
+		if p, ok := u.User.Password(); ok {
+			pass = p
+		}
+	}
+	return fmt.Sprintf("host=%q, path=%q, opaque=%q, scheme=%q, user=%#v, pass=%#v, rawpath=%q, rawq=%q, frag=%q",
+		u.Host, u.Path, u.Opaque, u.Scheme, user, pass, u.RawPath, u.RawQuery, u.Fragment)
 }

--- a/gps/maybe_source_test.go
+++ b/gps/maybe_source_test.go
@@ -1,0 +1,139 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gps
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"io"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Masterminds/vcs"
+)
+
+func TestMaybeGitSource_try(t *testing.T) {
+	t.Parallel()
+
+	tempDir, err := ioutil.TempDir("", "go-try-happy-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		err = os.RemoveAll(tempDir)
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	url, err := url.Parse(gitRemoteTestRepo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ms maybeSource = maybeGitSource{url: url}
+	_, err = ms.try(context.Background(), tempDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMaybeGitSource_try_recovery(t *testing.T) {
+	t.Parallel()
+
+	tempDir, err := ioutil.TempDir("", "go-try-recovery-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		err = os.RemoveAll(tempDir)
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	src := filepath.Join(cwd, "_testdata", "badrepo", "corrupt_dot_git_directory.tar")
+	f, err := os.Open(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	dest := filepath.Join(tempDir, ".git")
+	err = untar(dest, f)
+	if err != nil {
+		t.Fatalf("could not untar corrupt repo into temp folder: %v\n", err)
+	}
+
+	_, err = vcs.NewGitRepo(gitRemoteTestRepo, tempDir)
+	if err != nil {
+		if _, ok := err.(*vcs.LocalError); !ok {
+			t.Fatalf("expected a local error but got: %v\n", err)
+		}
+	} else {
+		t.Fatal("expected getVCSRepo to fail when pointing to a corrupt local path. It is possible that vcs.GitNewRepo updated to gracefully handle this test scenario. Check the return of vcs.GitNewRepo.")
+	}
+
+	url, err := url.Parse(gitRemoteTestRepo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ms maybeSource = maybeGitSource{url: url}
+	_, err = ms.try(context.Background(), tempDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func untar(dst string, r io.Reader) error {
+	gzr, err := gzip.NewReader(r)
+	if err != nil {
+		return err
+	}
+	defer gzr.Close()
+
+	tr := tar.NewReader(gzr)
+
+	for {
+		header, err := tr.Next()
+
+		switch {
+		case err == io.EOF:
+			return nil
+		case err != nil:
+			return err
+		case header == nil:
+			continue
+		}
+
+		target := filepath.Join(dst, header.Name)
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if _, err := os.Stat(target); err != nil {
+				if err := os.MkdirAll(target, 0755); err != nil {
+					return err
+				}
+			}
+		case tar.TypeReg:
+			f, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+
+			if _, err := io.Copy(f, tr); err != nil {
+				return err
+			}
+		}
+	}
+}

--- a/gps/pkgtree/pkgtree_test.go
+++ b/gps/pkgtree/pkgtree_test.go
@@ -2271,3 +2271,31 @@ func TestCanaryPackageTreeCopy(t *testing.T) {
 		t.Errorf("PackageTree.Copy is designed to work with an exact set of fields in the Package struct - make sure it (and this test) have been updated!\n\t(GOT):%s\n\t(WNT):%s", packageFields, packageRefl)
 	}
 }
+
+func TestPackageTreeCopy(t *testing.T) {
+	want := PackageTree{
+		ImportRoot: "ren",
+		Packages: map[string]PackageOrErr{
+			"ren": {
+				Err: &build.NoGoError{
+					Dir: "some/dir",
+				},
+			},
+			"ren/m1p": {
+				P: Package{
+					ImportPath:  "ren/m1p",
+					CommentPath: "",
+					Name:        "m1p",
+					Imports: []string{
+						"github.com/sdboyer/gps",
+						"sort",
+					},
+				},
+			},
+		},
+	}
+	got := want.Copy()
+	if !reflect.DeepEqual(want, got) {
+		t.Errorf("Did not get expected PackageOrErrs:\n\t(GOT): %+v\n\t(WNT): %+v", got, want)
+	}
+}

--- a/gps/source.go
+++ b/gps/source.go
@@ -5,6 +5,7 @@
 package gps
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"log"
@@ -21,34 +22,50 @@ import (
 type sourceState int32
 
 const (
-	sourceIsSetUp sourceState = 1 << iota
-	sourceExistsUpstream
+	// sourceExistsUpstream means the chosen source was verified upstream, during this execution.
+	sourceExistsUpstream sourceState = 1 << iota
+	// sourceExistsLocally means the repo was retrieved in the past.
 	sourceExistsLocally
+	// sourceHasLatestVersionList means the version list was refreshed within the cache window.
 	sourceHasLatestVersionList
+	// sourceHasLatestLocally means the repo was pulled fresh during this execution.
 	sourceHasLatestLocally
 )
 
-type srcReturnChans struct {
-	ret chan *sourceGateway
-	err chan error
+func (state sourceState) String() string {
+	var b bytes.Buffer
+	for _, s := range []struct {
+		sourceState
+		string
+	}{
+		{sourceExistsUpstream, "sourceExistsUpstream"},
+		{sourceExistsLocally, "sourceExistsLocally"},
+		{sourceHasLatestVersionList, "sourceHasLatestVersionList"},
+		{sourceHasLatestLocally, "sourceHasLatestLocally"},
+	} {
+		if state&s.sourceState > 0 {
+			if b.Len() > 0 {
+				b.WriteString("|")
+			}
+			b.WriteString(s.string)
+		}
+	}
+	return b.String()
 }
 
-func (rc srcReturnChans) awaitReturn() (sg *sourceGateway, err error) {
-	select {
-	case sg = <-rc.ret:
-	case err = <-rc.err:
-	}
-	return
+type srcReturn struct {
+	*sourceGateway
+	error
 }
 
 type sourceCoordinator struct {
 	supervisor *supervisor
-	srcmut     sync.RWMutex // guards srcs and nameToURL maps
+	deducer    deducer
+	srcmut     sync.RWMutex // guards srcs and srcIdx
 	srcs       map[string]*sourceGateway
 	nameToURL  map[string]string
 	psrcmut    sync.Mutex // guards protoSrcs map
-	protoSrcs  map[string][]srcReturnChans
-	deducer    deducer
+	protoSrcs  map[string][]chan srcReturn
 	cachedir   string
 	logger     *log.Logger
 }
@@ -61,7 +78,7 @@ func newSourceCoordinator(superv *supervisor, deducer deducer, cachedir string, 
 		logger:     logger,
 		srcs:       make(map[string]*sourceGateway),
 		nameToURL:  make(map[string]string),
-		protoSrcs:  make(map[string][]srcReturnChans),
+		protoSrcs:  make(map[string][]chan srcReturn),
 	}
 }
 
@@ -107,6 +124,7 @@ func (sc *sourceCoordinator) getSourceGatewayFor(ctx context.Context, id Project
 		// If the folded name differs from the input name, then there may
 		// already be an entry for it in the nameToURL map, so check again.
 		if url, has := sc.nameToURL[foldedNormalName]; has {
+			srcGate, has := sc.srcs[url]
 			// There was a match on the canonical folded variant. Upgrade to a
 			// write lock, so that future calls on this name don't need to
 			// burn cycles on folding.
@@ -118,8 +136,6 @@ func (sc *sourceCoordinator) getSourceGatewayFor(ctx context.Context, id Project
 			// words, these operations commute, so we can safely write here
 			// without checking again.
 			sc.nameToURL[normalizedName] = url
-
-			srcGate, has := sc.srcs[url]
 			sc.srcmut.Unlock()
 			if has {
 				return srcGate, nil
@@ -135,32 +151,22 @@ func (sc *sourceCoordinator) getSourceGatewayFor(ctx context.Context, id Project
 	if chans, has := sc.protoSrcs[foldedNormalName]; has {
 		// Another goroutine is already working on this normalizedName. Fold
 		// in with that work by attaching our return channels to the list.
-		rc := srcReturnChans{
-			ret: make(chan *sourceGateway, 1),
-			err: make(chan error, 1),
-		}
+		rc := make(chan srcReturn, 1)
 		sc.protoSrcs[foldedNormalName] = append(chans, rc)
 		sc.psrcmut.Unlock()
-		return rc.awaitReturn()
+		ret := <-rc
+		return ret.sourceGateway, ret.error
 	}
 
-	sc.protoSrcs[foldedNormalName] = []srcReturnChans{}
+	sc.protoSrcs[foldedNormalName] = []chan srcReturn{}
 	sc.psrcmut.Unlock()
 
 	doReturn := func(sg *sourceGateway, err error) {
+		ret := srcReturn{sourceGateway: sg, error: err}
 		sc.psrcmut.Lock()
-		if sg != nil {
-			for _, rc := range sc.protoSrcs[foldedNormalName] {
-				rc.ret <- sg
-			}
-		} else if err != nil {
-			for _, rc := range sc.protoSrcs[foldedNormalName] {
-				rc.err <- err
-			}
-		} else {
-			panic("sg and err both nil")
+		for _, rc := range sc.protoSrcs[foldedNormalName] {
+			rc <- ret
 		}
-
 		delete(sc.protoSrcs, foldedNormalName)
 		sc.psrcmut.Unlock()
 	}
@@ -178,7 +184,6 @@ func (sc *sourceCoordinator) getSourceGatewayFor(ctx context.Context, id Project
 	// sources map after the initial unlock, but before this goroutine got
 	// scheduled. Guard against that by checking the main sources map again
 	// and bailing out if we find an entry.
-	var srcGate *sourceGateway
 	sc.srcmut.RLock()
 	if url, has := sc.nameToURL[foldedNormalName]; has {
 		if srcGate, has := sc.srcs[url]; has {
@@ -190,36 +195,39 @@ func (sc *sourceCoordinator) getSourceGatewayFor(ctx context.Context, id Project
 	}
 	sc.srcmut.RUnlock()
 
-	srcGate = newSourceGateway(pd.mb, sc.supervisor, sc.cachedir)
-
-	// The normalized name is usually different from the source URL- e.g.
-	// github.com/sdboyer/gps vs. https://github.com/sdboyer/gps. But it's
-	// possible to arrive here with a full URL as the normalized name - and both
-	// paths *must* lead to the same sourceGateway instance in order to ensure
-	// disk access is correctly managed.
-	//
-	// Therefore, we now must query the sourceGateway to get the actual
-	// sourceURL it's operating on, and ensure it's *also* registered at
-	// that path in the map. This will cause it to actually initiate the
-	// maybeSource.try() behavior in order to settle on a URL.
-	url, err := srcGate.sourceURL(ctx)
-	if err != nil {
-		doReturn(nil, err)
-		return nil, err
-	}
-
-	// If the normalizedName and foldedNormalName differ, then we're pretty well
-	// guaranteed that returned URL will also need folding into canonical form.
-	var unfoldedURL string
-	if notFolded {
-		unfoldedURL = url
-		url = toFold(url)
-	}
-
-	// We know we have a working srcGateway at this point, and need to
-	// integrate it back into the main map.
 	sc.srcmut.Lock()
 	defer sc.srcmut.Unlock()
+
+	// Get or create a sourceGateway.
+	var srcGate *sourceGateway
+	var url, unfoldedURL string
+	var errs errorSlice
+	for _, m := range pd.mb {
+		url = m.URL().String()
+		if notFolded {
+			// If the normalizedName and foldedNormalName differ, then we're pretty well
+			// guaranteed that returned URL will also need folding into canonical form.
+			unfoldedURL = url
+			url = toFold(url)
+		}
+		if sg, has := sc.srcs[url]; has {
+			srcGate = sg
+			break
+		}
+
+		src, st, err := m.try(ctx, sc.cachedir, sc.supervisor)
+		if err == nil {
+			srcGate = newSourceGateway(st, src, sc.supervisor, sc.cachedir)
+			sc.srcs[url] = srcGate
+			break
+		}
+		errs = append(errs, err)
+	}
+	if srcGate == nil {
+		doReturn(nil, errs)
+		return nil, errs
+	}
+
 	// Record the name -> URL mapping, making sure that we also get the
 	// self-mapping.
 	sc.nameToURL[foldedNormalName] = url
@@ -234,13 +242,6 @@ func (sc *sourceCoordinator) getSourceGatewayFor(ctx context.Context, id Project
 		sc.nameToURL[unfoldedURL] = url
 	}
 
-	if sa, has := sc.srcs[url]; has {
-		// URL already had an entry in the main map; use that as the result.
-		doReturn(sa, nil)
-		return sa, nil
-	}
-
-	sc.srcs[url] = srcGate
 	doReturn(srcGate, nil)
 	return srcGate, nil
 }
@@ -249,7 +250,6 @@ func (sc *sourceCoordinator) getSourceGatewayFor(ctx context.Context, id Project
 // and caching them as needed.
 type sourceGateway struct {
 	cachedir string
-	maybe    maybeSource
 	srcState sourceState
 	src      source
 	cache    singleSourceCache
@@ -257,9 +257,10 @@ type sourceGateway struct {
 	suprvsr  *supervisor
 }
 
-func newSourceGateway(maybe maybeSource, superv *supervisor, cachedir string) *sourceGateway {
+func newSourceGateway(st sourceState, src source, superv *supervisor, cachedir string) *sourceGateway {
 	sg := &sourceGateway{
-		maybe:    maybe,
+		srcState: st,
+		src:      src,
 		cachedir: cachedir,
 		suprvsr:  superv,
 	}
@@ -270,41 +271,30 @@ func newSourceGateway(maybe maybeSource, superv *supervisor, cachedir string) *s
 
 func (sg *sourceGateway) syncLocal(ctx context.Context) error {
 	sg.mu.Lock()
-	defer sg.mu.Unlock()
-
-	_, err := sg.require(ctx, sourceIsSetUp|sourceExistsLocally|sourceHasLatestLocally)
+	err := sg.require(ctx, sourceExistsLocally|sourceHasLatestLocally)
+	sg.mu.Unlock()
 	return err
 }
 
-func (sg *sourceGateway) existsInCache(ctx context.Context) bool {
+func (sg *sourceGateway) existsInCache(ctx context.Context) error {
 	sg.mu.Lock()
-	defer sg.mu.Unlock()
-
-	_, err := sg.require(ctx, sourceIsSetUp|sourceExistsLocally)
-	if err != nil {
-		return false
-	}
-
-	return sg.srcState&sourceExistsLocally != 0
+	err := sg.require(ctx, sourceExistsLocally)
+	sg.mu.Unlock()
+	return err
 }
 
-func (sg *sourceGateway) existsUpstream(ctx context.Context) bool {
+func (sg *sourceGateway) existsUpstream(ctx context.Context) error {
 	sg.mu.Lock()
-	defer sg.mu.Unlock()
-
-	_, err := sg.require(ctx, sourceIsSetUp|sourceExistsUpstream)
-	if err != nil {
-		return false
-	}
-
-	return sg.srcState&sourceExistsUpstream != 0
+	err := sg.require(ctx, sourceExistsUpstream)
+	sg.mu.Unlock()
+	return err
 }
 
 func (sg *sourceGateway) exportVersionTo(ctx context.Context, v Version, to string) error {
 	sg.mu.Lock()
 	defer sg.mu.Unlock()
 
-	_, err := sg.require(ctx, sourceIsSetUp|sourceExistsLocally)
+	err := sg.require(ctx, sourceExistsLocally)
 	if err != nil {
 		return err
 	}
@@ -325,7 +315,7 @@ func (sg *sourceGateway) exportVersionTo(ctx context.Context, v Version, to stri
 	// TODO(sdboyer) It'd be better if we could check the error to see if this
 	// actually was the cause of the problem.
 	if err != nil && sg.srcState&sourceHasLatestLocally == 0 {
-		if _, err = sg.require(ctx, sourceHasLatestLocally); err == nil {
+		if err = sg.require(ctx, sourceHasLatestLocally); err == nil {
 			err = sg.suprvsr.do(ctx, sg.src.upstreamURL(), ctExportTree, func(ctx context.Context) error {
 				return sg.src.exportRevisionTo(ctx, r, to)
 			})
@@ -349,7 +339,7 @@ func (sg *sourceGateway) getManifestAndLock(ctx context.Context, pr ProjectRoot,
 		return m, l, nil
 	}
 
-	_, err = sg.require(ctx, sourceIsSetUp|sourceExistsLocally)
+	err = sg.require(ctx, sourceExistsLocally)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -369,7 +359,7 @@ func (sg *sourceGateway) getManifestAndLock(ctx context.Context, pr ProjectRoot,
 	if err != nil && sg.srcState&sourceHasLatestLocally == 0 {
 		// TODO(sdboyer) we should warn/log/something in adaptive recovery
 		// situations like this
-		_, err = sg.require(ctx, sourceHasLatestLocally)
+		err = sg.require(ctx, sourceHasLatestLocally)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -388,8 +378,6 @@ func (sg *sourceGateway) getManifestAndLock(ctx context.Context, pr ProjectRoot,
 	return m, l, nil
 }
 
-// FIXME ProjectRoot input either needs to parameterize the cache, or be
-// incorporated on the fly on egress...?
 func (sg *sourceGateway) listPackages(ctx context.Context, pr ProjectRoot, v Version) (pkgtree.PackageTree, error) {
 	sg.mu.Lock()
 	defer sg.mu.Unlock()
@@ -399,12 +387,12 @@ func (sg *sourceGateway) listPackages(ctx context.Context, pr ProjectRoot, v Ver
 		return pkgtree.PackageTree{}, err
 	}
 
-	ptree, has := sg.cache.getPackageTree(r)
+	ptree, has := sg.cache.getPackageTree(r, pr)
 	if has {
 		return ptree, nil
 	}
 
-	_, err = sg.require(ctx, sourceIsSetUp|sourceExistsLocally)
+	err = sg.require(ctx, sourceExistsLocally)
 	if err != nil {
 		return pkgtree.PackageTree{}, err
 	}
@@ -424,7 +412,7 @@ func (sg *sourceGateway) listPackages(ctx context.Context, pr ProjectRoot, v Ver
 	if err != nil && sg.srcState&sourceHasLatestLocally == 0 {
 		// TODO(sdboyer) we should warn/log/something in adaptive recovery
 		// situations like this
-		_, err = sg.require(ctx, sourceHasLatestLocally)
+		err = sg.require(ctx, sourceHasLatestLocally)
 		if err != nil {
 			return pkgtree.PackageTree{}, err
 		}
@@ -443,6 +431,7 @@ func (sg *sourceGateway) listPackages(ctx context.Context, pr ProjectRoot, v Ver
 	return ptree, nil
 }
 
+// caller must hold sg.mu.
 func (sg *sourceGateway) convertToRevision(ctx context.Context, v Version) (Revision, error) {
 	// When looking up by Version, there are four states that may have
 	// differing opinions about version->revision mappings:
@@ -470,7 +459,7 @@ func (sg *sourceGateway) convertToRevision(ctx context.Context, v Version) (Revi
 
 	// The version list is out of date; it's possible this version might
 	// show up after loading it.
-	_, err := sg.require(ctx, sourceIsSetUp|sourceHasLatestVersionList)
+	err := sg.require(ctx, sourceHasLatestVersionList)
 	if err != nil {
 		return "", err
 	}
@@ -487,10 +476,11 @@ func (sg *sourceGateway) listVersions(ctx context.Context) ([]PairedVersion, err
 	sg.mu.Lock()
 	defer sg.mu.Unlock()
 
-	// TODO(sdboyer) The problem here is that sourceExistsUpstream may not be
-	// sufficient (e.g. bzr, hg), but we don't want to force local b/c git
-	// doesn't need it
-	_, err := sg.require(ctx, sourceIsSetUp|sourceExistsUpstream|sourceHasLatestVersionList)
+	if pvs, ok := sg.cache.getAllVersions(); ok {
+		return pvs, nil
+	}
+
+	err := sg.require(ctx, sourceHasLatestVersionList)
 	if err != nil {
 		return nil, err
 	}
@@ -504,7 +494,7 @@ func (sg *sourceGateway) revisionPresentIn(ctx context.Context, r Revision) (boo
 	sg.mu.Lock()
 	defer sg.mu.Unlock()
 
-	_, err := sg.require(ctx, sourceIsSetUp|sourceExistsLocally)
+	err := sg.require(ctx, sourceExistsLocally)
 	if err != nil {
 		return false, err
 	}
@@ -524,24 +514,12 @@ func (sg *sourceGateway) disambiguateRevision(ctx context.Context, r Revision) (
 	sg.mu.Lock()
 	defer sg.mu.Unlock()
 
-	_, err := sg.require(ctx, sourceIsSetUp|sourceExistsLocally)
+	err := sg.require(ctx, sourceExistsLocally)
 	if err != nil {
 		return "", err
 	}
 
 	return sg.src.disambiguateRevision(ctx, r)
-}
-
-func (sg *sourceGateway) sourceURL(ctx context.Context) (string, error) {
-	sg.mu.Lock()
-	defer sg.mu.Unlock()
-
-	_, err := sg.require(ctx, sourceIsSetUp)
-	if err != nil {
-		return "", err
-	}
-
-	return sg.src.upstreamURL(), nil
 }
 
 // createSingleSourceCache creates a singleSourceCache instance for use by
@@ -552,56 +530,84 @@ func (sg *sourceGateway) createSingleSourceCache() singleSourceCache {
 	return newMemoryCache()
 }
 
-func (sg *sourceGateway) require(ctx context.Context, wanted sourceState) (errState sourceState, err error) {
+// sourceExistsUpstream verifies that the source exists upstream and that the
+// upstreamURL has not changed and returns any additional sourceState, or an error.
+func (sg *sourceGateway) sourceExistsUpstream(ctx context.Context) (sourceState, error) {
+	if sg.src.existsCallsListVersions() {
+		return sg.loadLatestVersionList(ctx)
+	}
+	err := sg.suprvsr.do(ctx, sg.src.sourceType(), ctSourcePing, func(ctx context.Context) error {
+		if !sg.src.existsUpstream(ctx) {
+			return errors.Errorf("source does not exist upstream: %s: %s", sg.src.sourceType(), sg.src.upstreamURL())
+		}
+		return nil
+	})
+	return 0, err
+}
+
+// initLocal initializes the source locally and returns the resulting sourceState.
+func (sg *sourceGateway) initLocal(ctx context.Context) (sourceState, error) {
+	if err := sg.suprvsr.do(ctx, sg.src.sourceType(), ctSourceInit, func(ctx context.Context) error {
+		err := sg.src.initLocal(ctx)
+		return errors.Wrapf(err, "failed to fetch source for %s", sg.src.upstreamURL())
+	}); err != nil {
+		return 0, err
+	}
+	return sourceExistsUpstream | sourceExistsLocally | sourceHasLatestLocally, nil
+}
+
+// loadLatestVersionList loads the latest version list, possibly ensuring the source
+// exists locally first, and returns the resulting sourceState.
+func (sg *sourceGateway) loadLatestVersionList(ctx context.Context) (sourceState, error) {
+	var addlState sourceState
+	if sg.src.listVersionsRequiresLocal() && !sg.src.existsLocally(ctx) {
+		as, err := sg.initLocal(ctx)
+		if err != nil {
+			return 0, err
+		}
+		addlState |= as
+	}
+	var pvl []PairedVersion
+	if err := sg.suprvsr.do(ctx, sg.src.sourceType(), ctListVersions, func(ctx context.Context) error {
+		var err error
+		pvl, err = sg.src.listVersions(ctx)
+		return errors.Wrapf(err, "failed to list versions for %s", sg.src.upstreamURL())
+	}); err != nil {
+		return addlState, err
+	}
+	sg.cache.setVersionMap(pvl)
+	return addlState | sourceHasLatestVersionList, nil
+}
+
+// require ensures the sourceGateway has the wanted sourceState, fetching more
+// data if necessary. Returns an error if the state could not be reached.
+// caller must hold sg.mu
+func (sg *sourceGateway) require(ctx context.Context, wanted sourceState) (err error) {
 	todo := (^sg.srcState) & wanted
 	var flag sourceState = 1
 
 	for todo != 0 {
 		if todo&flag != 0 {
-			// Assign the currently visited bit to errState so that we can
-			// return easily later.
-			//
-			// Also set up addlState so that individual ops can easily attach
+			// Set up addlState so that individual ops can easily attach
 			// more states that were incidentally satisfied by the op.
-			errState = flag
 			var addlState sourceState
 
 			switch flag {
-			case sourceIsSetUp:
-				sg.src, addlState, err = sg.maybe.try(ctx, sg.cachedir, sg.cache, sg.suprvsr)
 			case sourceExistsUpstream:
-				err = sg.suprvsr.do(ctx, sg.src.sourceType(), ctSourcePing, func(ctx context.Context) error {
-					if !sg.src.existsUpstream(ctx) {
-						return fmt.Errorf("%s does not exist upstream", sg.src.upstreamURL())
-					}
-					return nil
-				})
+				addlState, err = sg.sourceExistsUpstream(ctx)
 			case sourceExistsLocally:
 				if !sg.src.existsLocally(ctx) {
-					err = sg.suprvsr.do(ctx, sg.src.sourceType(), ctSourceInit, func(ctx context.Context) error {
-						return sg.src.initLocal(ctx)
-					})
-
-					if err == nil {
-						addlState |= sourceHasLatestLocally
-					} else {
-						err = errors.Wrapf(err, "%s does not exist in the local cache and fetching failed", sg.src.upstreamURL())
-					}
+					addlState, err = sg.initLocal(ctx)
 				}
 			case sourceHasLatestVersionList:
-				var pvl []PairedVersion
-				err = sg.suprvsr.do(ctx, sg.src.sourceType(), ctListVersions, func(ctx context.Context) error {
-					pvl, err = sg.src.listVersions(ctx)
-					return err
-				})
-
-				if err == nil {
-					sg.cache.setVersionMap(pvl)
+				if _, ok := sg.cache.getAllVersions(); !ok {
+					addlState, err = sg.loadLatestVersionList(ctx)
 				}
 			case sourceHasLatestLocally:
 				err = sg.suprvsr.do(ctx, sg.src.sourceType(), ctSourceFetch, func(ctx context.Context) error {
 					return sg.src.updateLocal(ctx)
 				})
+				addlState = sourceExistsUpstream | sourceExistsLocally
 			}
 
 			if err != nil {
@@ -616,7 +622,7 @@ func (sg *sourceGateway) require(ctx context.Context, wanted sourceState) (errSt
 		flag <<= 1
 	}
 
-	return 0, nil
+	return nil
 }
 
 // source is an abstraction around the different underlying types (git, bzr, hg,
@@ -635,4 +641,10 @@ type source interface {
 	disambiguateRevision(context.Context, Revision) (Revision, error)
 	exportRevisionTo(context.Context, Revision, string) error
 	sourceType() string
+	// existsCallsListVersions returns true if calling existsUpstream actually lists
+	// versions underneath, meaning listVersions might as well be used instead.
+	existsCallsListVersions() bool
+	// listVersionsRequiresLocal returns true if calling listVersions first
+	// requires the source to exist locally.
+	listVersionsRequiresLocal() bool
 }

--- a/gps/source_cache_bolt_encode.go
+++ b/gps/source_cache_bolt_encode.go
@@ -334,6 +334,7 @@ func cacheGetLock(b *bolt.Bucket) (*safeLock, error) {
 }
 
 // cachePutPackageOrError stores the pkgtree.PackageOrErr as fields in the bolt.Bucket.
+// Package.ImportPath is ignored.
 func cachePutPackageOrErr(b *bolt.Bucket, poe pkgtree.PackageOrErr) error {
 	if poe.Err != nil {
 		err := b.Put(cacheKeyError, []byte(poe.Err.Error()))

--- a/gps/source_cache_bolt_test.go
+++ b/gps/source_cache_bolt_test.go
@@ -7,6 +7,7 @@ package gps
 import (
 	"io/ioutil"
 	"log"
+	"path"
 	"testing"
 	"time"
 
@@ -65,9 +66,19 @@ func TestBoltCacheTimeout(t *testing.T) {
 	ptree := pkgtree.PackageTree{
 		ImportRoot: root,
 		Packages: map[string]pkgtree.PackageOrErr{
-			"simple": {
+			root: {
 				P: pkgtree.Package{
-					ImportPath:  "simple",
+					ImportPath:  root,
+					CommentPath: "comment",
+					Name:        "test",
+					Imports: []string{
+						"sort",
+					},
+				},
+			},
+			path.Join(root, "simple"): {
+				P: pkgtree.Package{
+					ImportPath:  path.Join(root, "simple"),
 					CommentPath: "comment",
 					Name:        "simple",
 					Imports: []string{
@@ -76,9 +87,9 @@ func TestBoltCacheTimeout(t *testing.T) {
 					},
 				},
 			},
-			"m1p": {
+			path.Join(root, "m1p"): {
 				P: pkgtree.Package{
-					ImportPath:  "m1p",
+					ImportPath:  path.Join(root, "m1p"),
 					CommentPath: "",
 					Name:        "m1p",
 					Imports: []string{
@@ -113,7 +124,7 @@ func TestBoltCacheTimeout(t *testing.T) {
 			t.Errorf("lock differences:\n\t %#v", dl)
 		}
 
-		got, ok := c.getPackageTree(rev)
+		got, ok := c.getPackageTree(rev, root)
 		if !ok {
 			t.Errorf("no package tree found:\n\t(WNT): %#v", ptree)
 		}
@@ -155,7 +166,7 @@ func TestBoltCacheTimeout(t *testing.T) {
 			t.Errorf("lock differences:\n\t %#v", dl)
 		}
 
-		gotPtree, ok := c.getPackageTree(rev)
+		gotPtree, ok := c.getPackageTree(rev, root)
 		if !ok {
 			t.Errorf("no package tree found:\n\t(WNT): %#v", ptree)
 		}
@@ -188,7 +199,7 @@ func TestBoltCacheTimeout(t *testing.T) {
 			t.Errorf("lock differences:\n\t %#v", dl)
 		}
 
-		got, ok := c.getPackageTree(rev)
+		got, ok := c.getPackageTree(rev, root)
 		if !ok {
 			t.Errorf("no package tree found:\n\t(WNT): %#v", ptree)
 		}
@@ -231,9 +242,9 @@ func TestBoltCacheTimeout(t *testing.T) {
 	newPtree := pkgtree.PackageTree{
 		ImportRoot: root,
 		Packages: map[string]pkgtree.PackageOrErr{
-			"simple": {
+			path.Join(root, "simple"): {
 				P: pkgtree.Package{
-					ImportPath:  "simple",
+					ImportPath:  path.Join(root, "simple"),
 					CommentPath: "newcomment",
 					Name:        "simple",
 					Imports: []string{
@@ -242,9 +253,9 @@ func TestBoltCacheTimeout(t *testing.T) {
 					},
 				},
 			},
-			"m1p": {
+			path.Join(root, "m1p"): {
 				P: pkgtree.Package{
-					ImportPath:  "m1p",
+					ImportPath:  path.Join(root, "m1p"),
 					CommentPath: "",
 					Name:        "m1p",
 					Imports: []string{
@@ -276,7 +287,7 @@ func TestBoltCacheTimeout(t *testing.T) {
 			t.Errorf("lock differences:\n\t %#v", dl)
 		}
 
-		got, ok := c.getPackageTree(rev)
+		got, ok := c.getPackageTree(rev, root)
 		if !ok {
 			t.Errorf("no package tree found:\n\t(WNT): %#v", newPtree)
 		}

--- a/gps/source_cache_multi.go
+++ b/gps/source_cache_multi.go
@@ -43,13 +43,13 @@ func (c *multiCache) setPackageTree(r Revision, ptree pkgtree.PackageTree) {
 	c.disk.setPackageTree(r, ptree)
 }
 
-func (c *multiCache) getPackageTree(r Revision) (pkgtree.PackageTree, bool) {
-	ptree, ok := c.mem.getPackageTree(r)
+func (c *multiCache) getPackageTree(r Revision, pr ProjectRoot) (pkgtree.PackageTree, bool) {
+	ptree, ok := c.mem.getPackageTree(r, pr)
 	if ok {
 		return ptree, true
 	}
 
-	ptree, ok = c.disk.getPackageTree(r)
+	ptree, ok = c.disk.getPackageTree(r, pr)
 	if ok {
 		c.mem.setPackageTree(r, ptree)
 		return ptree, true

--- a/gps/source_manager.go
+++ b/gps/source_manager.go
@@ -492,7 +492,13 @@ func (sm *SourceMgr) SourceExists(id ProjectIdentifier) (bool, error) {
 	}
 
 	ctx := context.TODO()
-	return srcg.existsInCache(ctx) || srcg.existsUpstream(ctx), nil
+	if err := srcg.existsInCache(ctx); err == nil {
+		return true, nil
+	}
+	if err := srcg.existsUpstream(ctx); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // SyncSourceFor will ensure that all local caches and information about a

--- a/gps/source_test.go
+++ b/gps/source_test.go
@@ -186,6 +186,6 @@ func testSourceGateway(t *testing.T) {
 	}
 
 	// Run test twice so that we cover both the existing and non-existing case.
-	t.Run("empty", do(0))
+	t.Run("empty", do(sourceExistsUpstream|sourceHasLatestVersionList))
 	t.Run("exists", do(sourceExistsLocally))
 }

--- a/gps/vcs_source.go
+++ b/gps/vcs_source.go
@@ -111,6 +111,18 @@ func (bs *baseVCSSource) updateLocal(ctx context.Context) error {
 	return nil
 }
 
+func (bs *baseVCSSource) maybeClean(ctx context.Context) error {
+	ec, ok := bs.repo.(ensureCleaner)
+	if !ok {
+		return nil
+	}
+
+	if err := ec.ensureClean(ctx); err != nil {
+		return unwrapVcsErr(err)
+	}
+	return nil
+}
+
 func (bs *baseVCSSource) listPackages(ctx context.Context, pr ProjectRoot, r Revision) (ptree pkgtree.PackageTree, err error) {
 	err = bs.repo.updateVersion(ctx, r.String())
 

--- a/gps/vcs_source_test.go
+++ b/gps/vcs_source_test.go
@@ -67,14 +67,9 @@ func testGitSourceInteractions(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	superv := newSupervisor(ctx)
-	isrc, state, err := mb.try(ctx, cpath, superv)
+	isrc, err := mb.try(ctx, cpath)
 	if err != nil {
 		t.Fatalf("Unexpected error while setting up gitSource for test repo: %s", err)
-	}
-
-	if state != 0 {
-		t.Errorf("Expected return state to be %v, got %v", 0, state)
 	}
 
 	err = isrc.initLocal(ctx)
@@ -171,16 +166,10 @@ func testGopkginSourceInteractions(t *testing.T) {
 		}
 
 		ctx := context.Background()
-		superv := newSupervisor(ctx)
-		isrc, state, err := mb.try(ctx, cpath, superv)
+		isrc, err := mb.try(ctx, cpath)
 		if err != nil {
 			t.Errorf("Unexpected error while setting up gopkginSource for test repo: %s", err)
 			return
-		}
-
-		var wantstate sourceState
-		if state != wantstate {
-			t.Errorf("Expected return state to be %v, got %v", wantstate, state)
 		}
 
 		err = isrc.initLocal(ctx)
@@ -343,15 +332,9 @@ func testBzrSourceInteractions(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	superv := newSupervisor(ctx)
-	isrc, state, err := mb.try(ctx, cpath, superv)
+	isrc, err := mb.try(ctx, cpath)
 	if err != nil {
 		t.Fatalf("Unexpected error while setting up bzrSource for test repo: %s", err)
-	}
-
-	var wantstate sourceState
-	if state != wantstate {
-		t.Errorf("Expected return state to be %v, got %v", wantstate, state)
 	}
 
 	err = isrc.initLocal(ctx)
@@ -451,16 +434,10 @@ func testHgSourceInteractions(t *testing.T) {
 		}
 
 		ctx := context.Background()
-		superv := newSupervisor(ctx)
-		isrc, state, err := mb.try(ctx, cpath, superv)
+		isrc, err := mb.try(ctx, cpath)
 		if err != nil {
 			t.Errorf("Unexpected error while setting up hgSource for test repo: %s", err)
 			return
-		}
-
-		var wantstate sourceState
-		if state != wantstate {
-			t.Errorf("Expected return state to be %v, got %v", wantstate, state)
 		}
 
 		err = isrc.initLocal(ctx)
@@ -590,8 +567,7 @@ func TestGitSourceListVersionsNoHEAD(t *testing.T) {
 	mb := maybeGitSource{u}
 
 	ctx := context.Background()
-	superv := newSupervisor(ctx)
-	isrc, _, err := mb.try(ctx, cpath, superv)
+	isrc, err := mb.try(ctx, cpath)
 	if err != nil {
 		t.Fatalf("Unexpected error while setting up gitSource for test repo: %s", err)
 	}
@@ -647,15 +623,9 @@ func TestGitSourceListVersionsNoDupes(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	superv := newSupervisor(ctx)
-	src, state, err := mb.try(ctx, cpath, superv)
+	src, err := mb.try(ctx, cpath)
 	if err != nil {
 		t.Fatalf("Unexpected error while setting up gitSource for test repo: %s", err)
-	}
-
-	var wantstate sourceState
-	if state != wantstate {
-		t.Errorf("Expected return state to be %v, got %v", wantstate, state)
 	}
 
 	err = src.initLocal(ctx)
@@ -808,8 +778,7 @@ func Test_bzrSource_exportRevisionTo_removeVcsFiles(t *testing.T) {
 	mb := maybeBzrSource{u}
 
 	ctx := context.Background()
-	superv := newSupervisor(ctx)
-	isrc, _, err := mb.try(ctx, cpath, superv)
+	isrc, err := mb.try(ctx, cpath)
 	if err != nil {
 		t.Fatalf("unexpected error while setting up hgSource for test repo: %s", err)
 	}
@@ -862,8 +831,7 @@ func Test_hgSource_exportRevisionTo_removeVcsFiles(t *testing.T) {
 	mb := maybeHgSource{u}
 
 	ctx := context.Background()
-	superv := newSupervisor(ctx)
-	isrc, _, err := mb.try(ctx, cpath, superv)
+	isrc, err := mb.try(ctx, cpath)
 	if err != nil {
 		t.Fatalf("unexpected error while setting up hgSource for test repo: %s", err)
 	}


### PR DESCRIPTION
### What does this do / why do we need it?

This PR contains a set of changes primarily motivated by making sourceGateway state transitions more fine grained and special cases explicit, so that the persistent cache can be fully leveraged when integrated.  From the changelog:

> Reduce network access by trusting local source information and only pulling from upstream when necessary

### What should your reviewer look out for in this PR?

~Should a note be added to the `CHANGELOG`?~ Did this.

### Which issue(s) does this PR fix?

Toward #431

Fixes #415 
