### PR TITLE
gps: skip hidden directories when looking for packages

### DIFF
--- a/internal/gps/pkgtree/pkgtree.go
+++ b/internal/gps/pkgtree/pkgtree.go
@@ -102,6 +102,11 @@ func ListPackages(fileRoot, importRoot string) (PackageTree, error) {
 			return filepath.SkipDir
 		}
 
+		// Skip hidden directories.
+		if fi.Name()[0] == '.' {
+			return filepath.SkipDir
+		}
+
 		{
 			// For Go 1.9 and earlier:
 			//


### PR DESCRIPTION
Stuff in hidden directories should stay hidden. In my case, I am using a special GOPATH and I don't want `dep` to look into it.