### PR TITLE
Break context chain and move subprocesses into separate pgroups

### DIFF
--- a/internal/gps/cmd_unix.go
+++ b/internal/gps/cmd_unix.go
@@ -25,11 +25,15 @@ type cmd struct {
 }
 
 func commandContext(ctx context.Context, name string, arg ...string) cmd {
-	// Grab the caller's context and pass a derived one to CommandContext.
-	c := cmd{ctx: ctx}
-	ctx, cancel := context.WithCancel(ctx)
-	c.Cmd = exec.CommandContext(ctx, name, arg...)
-	c.cancel = cancel
+	// Create a one-off cancellable context for use by the CommandContext, in
+	// the event that we have to force a Process.Kill().
+	ctx2, cancel := context.WithCancel(context.Background())
+
+	c := cmd{
+		Cmd:    exec.CommandContext(ctx2, name, arg...),
+		cancel: cancel,
+		ctx:    ctx,
+	}
 	return c
 }
 

--- a/internal/gps/source_manager.go
+++ b/internal/gps/source_manager.go
@@ -741,6 +741,29 @@ const (
 	ctExportTree
 )
 
+func (ct callType) String() string {
+	switch ct {
+	case ctHTTPMetadata:
+		return "Retrieving go get metadata"
+	case ctListVersions:
+		return "Retrieving latest version list"
+	case ctGetManifestAndLock:
+		return "Reading manifest and lock data"
+	case ctListPackages:
+		return "Parsing PackageTree"
+	case ctSourcePing:
+		return "Checking for upstream existence"
+	case ctSourceInit:
+		return "Initializing local source cache"
+	case ctSourceFetch:
+		return "Fetching latest data into local source cache"
+	case ctExportTree:
+		return "Writing code tree out to disk"
+	default:
+		panic("unknown calltype")
+	}
+}
+
 // callInfo provides metadata about an ongoing call.
 type callInfo struct {
 	name string


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

### What does this do / why do we need it?

This has two parts - first, we break the context connection from the incoming ctx to a `cmd`, such that its cancellation does not immediately propagate to the `exec.ContextCommand`, resulting in an immediate `os.Process.Kill()` (which we want to avoid).

In testing this, though, i discovered that the signals sent via ctrl-C were still being processed immediately by the e.g. git subprocesses. So, after tearing my hair out for a while, I discovered that it's because ctrl-C from a terminal, by default, [sends the signal to everything in the process _group_, and (with default settings) our spawned subprocesses are placed in that same group](https://stackoverflow.com/a/35435038).

This is a bit of just rearranging deck chairs as it still has the same effect, but I prefer to be more explicit about our subprocess controls, if we can.

### What should your reviewer look out for in this PR?

The biggest question in my mind with this if this is indeed a portable use of `syscall` across everything that's `!windows`.

### Which issue(s) does this PR fix?

None unfortunately (I'd hoped this would fix our corruption problems), as this achieves the same outcomes, just with greater control.
