### PR TITLE
gps: Use refspec on git fetch to ensure tags prune

### DIFF
--- a/internal/gps/vcs_repo.go
+++ b/internal/gps/vcs_repo.go
@@ -111,6 +111,7 @@ func (r *gitRepo) fetch(ctx context.Context) error {
 		"--tags",
 		"--prune",
 		r.RemoteLocation,
+		"refs/tags/*:refs/tags/*",
 	)
 	cmd.SetDir(r.LocalPath())
 	if out, err := cmd.CombinedOutput(); err != nil {


### PR DESCRIPTION
### What does this do / why do we need it?

`git fetch --tags --prune` does not, annoyingly, actually prune tags.
For tags to actually be pruned, an explicit refspec has to be passed.
The only reason this hasn't affected us is because we always rely on git
ls-remote for enumerating versions, never what we happen to have on
local.

Needs tests - we should verify correct local pruning of both branches and tags. (this is one of those state change things that'd be waaaaay easier to test with a local repo framework)