### PR TITLE
gps: Adaptively clean dirty git repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 BUG FIXES:
 
 * Releases targeting Windows now have a `.exe` suffix (#1291).
+* Adaptively recover from dirty and corrupted git repositories in cache (#1279).
 
 IMPROVEMENTS:
 

--- a/internal/gps/manager_test.go
+++ b/internal/gps/manager_test.go
@@ -259,12 +259,6 @@ func TestSourceInit(t *testing.T) {
 
 	os.Stat(filepath.Join(cpath, "metadata", "github.com", "sdboyer", "gpkt", "cache.json"))
 
-	// TODO(sdboyer) disabled until we get caching working
-	//_, err = os.Stat(filepath.Join(cpath, "metadata", "github.com", "sdboyer", "gpkt", "cache.json"))
-	//if err != nil {
-	//t.Error("Metadata cache json file does not exist in expected location")
-	//}
-
 	// Ensure source existence values are what we expect
 	var exists bool
 	exists, err = sm.SourceExists(id)

--- a/internal/gps/maybe_source.go
+++ b/internal/gps/maybe_source.go
@@ -108,7 +108,7 @@ func (m maybeGitSource) try(ctx context.Context, cachedir string, c singleSource
 		if err := superv.do(ctx, "git", ctValidateLocal, func(ctx context.Context) error {
 			// If repository already exists on disk, make a pass to be sure
 			// everything's clean.
-			return src.cleanup(ctx)
+			return src.ensureClean(ctx)
 		}); err != nil {
 			return nil, 0, err
 		}

--- a/internal/gps/maybe_source.go
+++ b/internal/gps/maybe_source.go
@@ -105,9 +105,11 @@ func (m maybeGitSource) try(ctx context.Context, cachedir string, c singleSource
 	if r.CheckLocal() {
 		state |= sourceExistsLocally
 
-		// If repository already exists on disk, make a pass to be sure
-		// everything's clean.
-		if err = src.cleanup(ctx); err != nil {
+		if err := superv.do(ctx, "git", ctValidateLocal, func(ctx context.Context) error {
+			// If repository already exists on disk, make a pass to be sure
+			// everything's clean.
+			return src.cleanup(ctx)
+		}); err != nil {
 			return nil, 0, err
 		}
 	}

--- a/internal/gps/maybe_source.go
+++ b/internal/gps/maybe_source.go
@@ -100,13 +100,19 @@ func (m maybeGitSource) try(ctx context.Context, cachedir string, c singleSource
 		return nil, 0, err
 	}
 
-	c.setVersionMap(vl)
 	state := sourceIsSetUp | sourceExistsUpstream | sourceHasLatestVersionList
 
 	if r.CheckLocal() {
 		state |= sourceExistsLocally
+
+		// If repository already exists on disk, make a pass to be sure
+		// everything's clean.
+		if err = src.cleanup(ctx); err != nil {
+			return nil, 0, err
+		}
 	}
 
+	c.setVersionMap(vl)
 	return src, state, nil
 }
 

--- a/internal/gps/source_manager.go
+++ b/internal/gps/source_manager.go
@@ -738,6 +738,7 @@ const (
 	ctSourceInit
 	ctSourceFetch
 	ctExportTree
+	ctValidateLocal
 )
 
 func (ct callType) String() string {

--- a/internal/gps/vcs_source.go
+++ b/internal/gps/vcs_source.go
@@ -124,8 +124,8 @@ type gitSource struct {
 }
 
 // ensureClean sees to it that a git repository is clean and in working order,
-// or returns an error if it can't.
-func (s *gitSource) cleanup(ctx context.Context) error {
+// or returns an error if the adaptive recovery attempts fail.
+func (s *gitSource) ensureClean(ctx context.Context) error {
 	r := s.repo.(*gitRepo)
 	cmd := commandContext(
 		ctx,

--- a/internal/gps/vcs_source_test.go
+++ b/internal/gps/vcs_source_test.go
@@ -697,11 +697,10 @@ func TestGitSourceAdaptiveCleanup(t *testing.T) {
 
 	// Create a file that git will see as untracked.
 	untrackedPath := filepath.Join(repodir, "untrackedfile")
-	f, err := os.Create(untrackedPath)
+	err = ioutil.WriteFile(untrackedPath, []byte("foo"), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}
-	f.Close()
 
 	mkSM()
 	err = sm.SyncSourceFor(id)

--- a/internal/gps/vcs_source_test.go
+++ b/internal/gps/vcs_source_test.go
@@ -7,6 +7,7 @@ package gps
 import (
 	"context"
 	"io/ioutil"
+	"log"
 	"net/url"
 	"os"
 	"os/exec"
@@ -645,6 +646,101 @@ func TestGitSourceListVersionsNoDupes(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestGitSourceAdaptiveCleanup(t *testing.T) {
+	t.Parallel()
+
+	// This test is slowish, skip it on -short
+	if testing.Short() {
+		t.Skip("Skipping git adaptive failure recovery test in short mode")
+	}
+	requiresBins(t, "git")
+
+	cpath, err := ioutil.TempDir("", "smcache")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %s", err)
+	}
+
+	var sm *SourceMgr
+	mkSM := func() {
+		// If sm is already set, make sure it's released, then create a new one.
+		if sm != nil {
+			sm.Release()
+		}
+
+		var err error
+		sm, err = NewSourceManager(SourceManagerConfig{
+			Cachedir: cpath,
+			Logger:   log.New(test.Writer{TB: t}, "", 0),
+		})
+		if err != nil {
+			t.Fatalf("Unexpected error on SourceManager creation: %s", err)
+		}
+	}
+
+	mkSM()
+	id := mkPI("github.com/sdboyer/gpkt")
+	err = sm.SyncSourceFor(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repodir := filepath.Join(sm.cachedir, "sources", "https---github.com-sdboyer-gpkt")
+	if _, err := os.Stat(repodir); err != nil {
+		if os.IsNotExist(err) {
+			t.Fatalf("expected location for repodir did not exist: %q", repodir)
+		} else {
+			t.Fatal(err)
+		}
+	}
+
+	// Create a file that git will see as untracked.
+	untrackedPath := filepath.Join(repodir, "untrackedfile")
+	f, err := os.Create(untrackedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	mkSM()
+	err = sm.SyncSourceFor(id)
+	if err != nil {
+		t.Fatalf("choked after adding dummy file: %q", err)
+	}
+
+	if _, err := os.Stat(untrackedPath); err == nil {
+		t.Fatal("untracked file still existed after cleanup should've been triggered")
+	}
+
+	// Remove a file that we know exists, which `git status` checks should catch.
+	readmePath := filepath.Join(repodir, "README.md")
+	os.Remove(readmePath)
+
+	mkSM()
+	err = sm.SyncSourceFor(id)
+	if err != nil {
+		t.Fatalf("choked after removing known file: %q", err)
+	}
+
+	if _, err := os.Stat(readmePath); err != nil {
+		t.Fatal("README was still absent after cleanup should've been triggered")
+	}
+
+	// Remove .git/objects directory, which should make git bite it.
+	err = os.RemoveAll(filepath.Join(repodir, ".git", "objects"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mkSM()
+	err = sm.SyncSourceFor(id)
+	if err != nil {
+		t.Fatalf("choked after removing .git/objects directory: %q", err)
+	}
+
+	sm.Release()
+	os.RemoveAll(cpath)
 }
 
 func Test_bzrSource_exportRevisionTo_removeVcsFiles(t *testing.T) {


### PR DESCRIPTION
### What does this do / why do we need it?

Instead of forcing the user to clean up dirty git repositories, we can
take at least basic steps to doing it ourselves - or, if we detect
problems, instructing the user to fix it.

The overhead introduced here is a `git status` call, which will be
non-negligible on larger repos, but it's probably worth it for the
resilient behavior.

Eventually, once we get to #534, we'll want to issue a warning when we undertake a cleanup.

This needs tests. Also, let's delay merging this until after the next release so that it can percolate on tip for a while.

Might want to also refactor `maybeGitSource.try()` to do this check earlier, and `os.RemoveAll()` then try again if it doesn't work.

### What should your reviewer look out for in this PR?

Possible failure modes. It'd be great if this attempt at making things better didn't inadvertently make things worse!

### Do you need help or clarification on anything?

### Which issue(s) does this PR fix?

fixes #1016
fixes #618 