### PR TITLE
Fix unresolved link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,9 +30,9 @@ Please read the [Contribution Guidelines](https://golang.org/doc/contribute.html
 before sending patches.
 
 The
-[help wanted](https://github.com/golang/dep/issues?q=is%3Aissue+is%3Aopen+label%3Ahelp wanted)
+[help wanted](https://github.com/golang/dep/issues?q=is%3Aissue+is%3Aopen+label%3A%22help%20wanted%22)
 label highlights issues that are well-suited for folks to jump in on. The
-[good first issue](https://github.com/golang/dep/issues?q=is%3Aissue+is%3Aopen+label%3Agood first issue)
+[good first issue](https://github.com/golang/dep/issues?q=is%3Aissue+is%3Aopen+label%3A%22good%20first%20issue%22)
 label further identifies issues that are particularly well-sized for newcomers.
 
 Unless otherwise noted, the `dep` source files are distributed under


### PR DESCRIPTION
### What does this do / why do we need it?
CONTRIBUTING.md cannot resolve below links.
<img width="983" alt="dep_contributing_md_at_master_ _golang_dep" src="https://user-images.githubusercontent.com/1883265/31665803-1727d8bc-b385-11e7-95a8-f752bbc7a905.png">


### What should your reviewer look out for in this PR?
Please confirm these are correct links on browser.
https://github.com/budougumi0617/dep/blob/fix-unresoleved-link-in-markdown/CONTRIBUTING.md

### Do you need help or clarification on anything?
Please tell me when I make a mistake

### Which issue(s) does this PR fix?
None.
