### PR TITLE
List import support for gb/gvt in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 NEW FEATURES:
 
+* Add support for importing from [gvt](https://github.com/FiloSottile/gvt)
+and [gb](https://godoc.org/github.com/constabulary/gb/cmd/gb-vendor).
+(#1149)
 * Wildcard ignore support. (#1156)
 * Disable SourceManager lock by setting `DEPNOLOCK` environment variable.
 (#1206)


### PR DESCRIPTION
I forgot to add this in the PR directly but it's been merged and will be part of 0.3.2.