### PR TITLE
Releases targeting Windows now have a `.exe` suffix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,8 +66,8 @@ jobs:
             - release/dep-linux-amd64.sha256
             - release/dep-darwin-amd64
             - release/dep-darwin-amd64.sha256
-            - release/dep-windows-amd64
-            - release/dep-windows-amd64.sha256
+            - release/dep-windows-amd64.exe
+            - release/dep-windows-amd64.exe.sha256
           skip_cleanup: true
           on:
             repo: golang/dep

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # v0.3.3 (Unreleased)
 
+BUG FIXES:
+
+* Releases targeting Windows now have a `.exe` suffix (#1291).
 
 # v0.3.2
 

--- a/hack/build-all.bash
+++ b/hack/build-all.bash
@@ -29,9 +29,13 @@ mkdir -p release
 
 for OS in ${DEP_BUILD_PLATFORMS[@]}; do
   for ARCH in ${DEP_BUILD_ARCHS[@]}; do
+    NAME="dep-$OS-$ARCH"
+    if [ "$OS" == "windows" ]; then
+      NAME="$NAME.exe"
+    fi
     echo "Building for $OS/$ARCH"
     GOARCH=$ARCH GOOS=$OS CGO_ENABLED=0 $GO_BUILD_CMD -ldflags "$GO_BUILD_LDFLAGS"\
-     -o "release/dep-$OS-$ARCH" ./cmd/dep/
-    shasum -a 256 "release/dep-$OS-$ARCH" > "release/dep-$OS-$ARCH".sha256
+     -o "release/$NAME" ./cmd/dep/
+    shasum -a 256 "release/$NAME" > "release/$NAME".sha256
   done
 done


### PR DESCRIPTION
### What does this do / why do we need it?

The [release](https://github.com/golang/dep/releases/tag/v0.3.2) tab on github has links to windows binaries. These links are named wrongly. After downloading, I have to rename `dep-windows-amd64` into `dep-windows-amd64.exe` in order to use the binary.

Releases targeting Windows should have a .exe suffix.

### Which issue(s) does this PR fix?

fixes  #1291