### PR TITLE
gps: parallelize many tests

### DIFF
--- a/internal/gps/manager_test.go
+++ b/internal/gps/manager_test.go
@@ -139,6 +139,7 @@ func TestSourceInit(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping project manager init test in short mode")
 	}
+	t.Parallel()
 
 	cpath, err := ioutil.TempDir("", "smcache")
 	if err != nil {
@@ -280,6 +281,7 @@ func TestDefaultBranchAssignment(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping default branch assignment test in short mode")
 	}
+	t.Parallel()
 
 	sm, clean := mkNaiveSM(t)
 	defer clean()
@@ -405,6 +407,7 @@ func TestSourceCreationCounts(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
 	}
+	t.Parallel()
 
 	fixtures := map[string]sourceCreationTestFixture{
 		"gopkgin uniqueness": {
@@ -447,6 +450,7 @@ func TestGetSources(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping source setup test in short mode")
 	}
+	t.Parallel()
 	requiresBins(t, "git", "hg", "bzr")
 
 	sm, clean := mkNaiveSM(t)
@@ -513,6 +517,7 @@ func TestFSCaseSensitivityConvergesSources(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
 	}
+	t.Parallel()
 
 	f := func(name string, pi1, pi2 ProjectIdentifier) {
 		t.Run(name, func(t *testing.T) {
@@ -571,6 +576,7 @@ func TestGetInfoListVersionsOrdering(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
 	}
+	t.Parallel()
 
 	sm, clean := mkNaiveSM(t)
 	defer clean()
@@ -675,6 +681,7 @@ func TestMultiFetchThreadsafe(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
 	}
+	t.Parallel()
 
 	projects := []ProjectIdentifier{
 		mkPI("github.com/sdboyer/gps"),
@@ -782,6 +789,7 @@ func TestListVersionsRacey(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
 	}
+	t.Parallel()
 
 	sm, clean := mkNaiveSM(t)
 	defer clean()
@@ -937,6 +945,7 @@ func TestUnreachableSource(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
 	}
+	t.Parallel()
 
 	sm, clean := mkNaiveSM(t)
 	defer clean()

--- a/internal/gps/source_cache_bolt_test.go
+++ b/internal/gps/source_cache_bolt_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestBoltCacheTimeout(t *testing.T) {
+	t.Parallel()
+
 	const root = "example.com/test"
 	cpath, err := ioutil.TempDir("", "singlesourcecache")
 	if err != nil {

--- a/internal/gps/source_cache_test.go
+++ b/internal/gps/source_cache_test.go
@@ -18,6 +18,8 @@ import (
 )
 
 func Test_singleSourceCache(t *testing.T) {
+	t.Parallel()
+
 	newMem := func(*testing.T, string, string) (singleSourceCache, func() error) {
 		return newMemoryCache(), func() error { return nil }
 	}
@@ -70,6 +72,8 @@ type singleSourceCacheTest struct {
 // run tests singleSourceCache methods of caches returned by test.newCache.
 // For test.persistent caches, test.newCache is periodically called mid-test to ensure persistence.
 func (test singleSourceCacheTest) run(t *testing.T) {
+	t.Parallel()
+
 	const root = "example.com/test"
 	cpath, err := ioutil.TempDir("", "singlesourcecache")
 	if err != nil {

--- a/internal/gps/vcs_source_test.go
+++ b/internal/gps/vcs_source_test.go
@@ -21,6 +21,7 @@ import (
 
 // Parent test that executes all the slow vcs interaction tests in parallel.
 func TestSlowVcs(t *testing.T) {
+	t.Parallel()
 	t.Run("write-deptree", testWriteDepTree)
 	t.Run("source-gateway", testSourceGateway)
 	t.Run("bzr-repo", testBzrRepo)

--- a/internal/gps/vcs_version_test.go
+++ b/internal/gps/vcs_version_test.go
@@ -17,6 +17,7 @@ func TestVCSVersion(t *testing.T) {
 	}
 
 	h := test.NewHelper(t)
+	h.Parallel()
 	defer h.Cleanup()
 	requiresBins(t, "git")
 


### PR DESCRIPTION
### What does this do / why do we need it?

This PR parallelizes a bunch of gps tests (I roughly targeted ones running `>100ms` and ignored `<100ms`), and reduces the running time of `go test ./internal/gps` on my machine from `~43s` to `~31s`.