### PR TITLE
importers: parallelize tests

### DIFF
--- a/internal/importers/base/importer_test.go
+++ b/internal/importers/base/importer_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func TestBaseImporter_IsTag(t *testing.T) {
+	t.Parallel()
+
 	testcases := map[string]struct {
 		input     string
 		wantIsTag bool
@@ -51,10 +53,8 @@ func TestBaseImporter_IsTag(t *testing.T) {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
 			h := test.NewHelper(t)
+			h.Parallel()
 			defer h.Cleanup()
-			// Disable parallel tests until we can resolve this error on the Windows builds:
-			// "remote repository at https://github.com/carolynvs/deptest-importers does not exist, or is inaccessible"
-			//h.Parallel()
 
 			ctx := importertest.NewTestContext(h)
 			sm, err := ctx.SourceManager()
@@ -79,6 +79,8 @@ func TestBaseImporter_IsTag(t *testing.T) {
 }
 
 func TestBaseImporter_LookupVersionForLockedProject(t *testing.T) {
+	t.Parallel()
+
 	testcases := map[string]struct {
 		revision    gps.Revision
 		constraint  gps.Constraint
@@ -120,10 +122,8 @@ func TestBaseImporter_LookupVersionForLockedProject(t *testing.T) {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
 			h := test.NewHelper(t)
+			h.Parallel()
 			defer h.Cleanup()
-			// Disable parallel tests until we can resolve this error on the Windows builds:
-			// "remote repository at https://github.com/carolynvs/deptest-importers does not exist, or is inaccessible"
-			//h.Parallel()
 
 			ctx := importertest.NewTestContext(h)
 			sm, err := ctx.SourceManager()
@@ -143,6 +143,8 @@ func TestBaseImporter_LookupVersionForLockedProject(t *testing.T) {
 }
 
 func TestBaseImporter_ImportProjects(t *testing.T) {
+	t.Parallel()
+
 	testcases := map[string]struct {
 		importertest.TestCase
 		projects []ImportedPackage

--- a/internal/importers/importertest/testcase.go
+++ b/internal/importers/importertest/testcase.go
@@ -46,10 +46,8 @@ func NewTestContext(h *test.Helper) *dep.Ctx {
 // Execute and validate the test case.
 func (tc TestCase) Execute(t *testing.T, convert func(logger *log.Logger, sm gps.SourceManager) (*dep.Manifest, *dep.Lock)) error {
 	h := test.NewHelper(t)
+	h.Parallel()
 	defer h.Cleanup()
-	// Disable parallel tests until we can resolve this error on the Windows builds:
-	// "remote repository at https://github.com/carolynvs/deptest-importers does not exist, or is inaccessible"
-	//h.Parallel()
 
 	ctx := NewTestContext(h)
 	sm, err := ctx.SourceManager()


### PR DESCRIPTION
### What does this do / why do we need it?

This PR parallelizes some tests in the `internal/importers/base` pkg, reducing running time on my machine from `~11s` to `~3s`.  There are some additional `h.Parallel()` calls commented out, but I didn't see significant speedup from including them, so there's no sense in increasing the risk of `remote repository at .... does not exist, or is inaccessible` errors.