### PR TITLE
dep: Use hidden tempdir for old vendor

### DIFF
--- a/txn_writer.go
+++ b/txn_writer.go
@@ -382,7 +382,7 @@ func (sw *SafeWriter) Write(root string, sm gps.SourceManager, examples bool, lo
 			if _, err := os.Stat(vendorbak); err == nil {
 				// If the adjacent dir already exists, bite the bullet and move
 				// to a proper tempdir.
-				vendorbak = filepath.Join(td, "vendor.orig")
+				vendorbak = filepath.Join(td, ".vendor.orig")
 			}
 
 			failerr = fs.RenameWithFallback(vpath, vendorbak)


### PR DESCRIPTION
### What does this do / why do we need it?

If the txn writer leaves a `vendor.orig` directory behind, subsequent runs will barf on it - #1304.

While there's more work to be done in making all of this safe in the event of a signal being sent to dep, this change at least means that if a signal is sent during the rename and a .vendor.orig directory is left behind, subsequent runs will treat its contents as ignored.

### What should your reviewer look out for in this PR?

### Do you need help or clarification on anything?

### Which issue(s) does this PR fix?

Fixes #1304