### PR TITLE
Opt for more safety on whether to regenerate vendor

### DIFF
--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -283,7 +283,7 @@ func (cmd *ensureCommand) runDefault(ctx *dep.Ctx, args []string, p *dep.Project
 		return errors.Wrap(err, "ensure Solve()")
 	}
 
-	vendorBehavior := dep.VendorOnChanged
+	vendorBehavior := dep.VendorAlways
 	if cmd.noVendor {
 		vendorBehavior = dep.VendorNever
 	}
@@ -378,7 +378,7 @@ func (cmd *ensureCommand) runUpdate(ctx *dep.Ctx, args []string, p *dep.Project,
 		return errors.Wrap(err, "ensure Solve()")
 	}
 
-	sw, err := dep.NewSafeWriter(nil, p.Lock, dep.LockFromSolution(solution), dep.VendorOnChanged)
+	sw, err := dep.NewSafeWriter(nil, p.Lock, dep.LockFromSolution(solution), dep.VendorAlways)
 	if err != nil {
 		return err
 	}
@@ -678,7 +678,7 @@ func (cmd *ensureCommand) runAdd(ctx *dep.Ctx, args []string, p *dep.Project, sm
 	}
 	sort.Strings(reqlist)
 
-	sw, err := dep.NewSafeWriter(nil, p.Lock, dep.LockFromSolution(solution), dep.VendorOnChanged)
+	sw, err := dep.NewSafeWriter(nil, p.Lock, dep.LockFromSolution(solution), dep.VendorAlways)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### What does this do / why do we need it?

We were guessing that, if the Gopkg.lock hadn't changed, that vendor
also didn't need to change. However, that missed cases where manual
modifications had been made to vendor. It's not terribly common, but it
still violates the sync model to get this wrong.

/cc @ibrasho this is ensure, so i'll leave this for you to decide on and merge

### What should your reviewer look out for in this PR?

### Do you need help or clarification on anything?

### Which issue(s) does this PR fix?

fixes #1276
