### PR TITLE
dep: Permit no Go source for ensure -add

### DIFF
--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -190,7 +190,7 @@ func (cmd *ensureCommand) Run(ctx *dep.Ctx, args []string) error {
 		return err
 	}
 
-	if fatal, err := checkErrors(params.RootPackageTree.Packages, p.Manifest.IgnoredPackages()); err != nil {
+	if fatal, err := checkErrors(params.RootPackageTree.Packages, p.Manifest.IgnoredPackages(), cmd.add); err != nil {
 		if fatal {
 			return err
 		} else if ctx.Verbose {
@@ -769,7 +769,7 @@ func getProjectConstraint(arg string, sm gps.SourceManager) (gps.ProjectConstrai
 	return gps.ProjectConstraint{Ident: pi, Constraint: c}, arg, nil
 }
 
-func checkErrors(m map[string]pkgtree.PackageOrErr, ignore *pkgtree.IgnoredRuleset) (fatal bool, err error) {
+func checkErrors(m map[string]pkgtree.PackageOrErr, ignore *pkgtree.IgnoredRuleset, allowNoGo bool) (fatal bool, err error) {
 	var (
 		noGoErrors    int
 		pkgtreeErrors = make(pkgtreeErrs, 0, len(m))
@@ -788,6 +788,10 @@ func checkErrors(m map[string]pkgtree.PackageOrErr, ignore *pkgtree.IgnoredRules
 				pkgtreeErrors = append(pkgtreeErrors, poe.Err)
 			}
 		}
+	}
+
+	if allowNoGo {
+		noGoErrors = 0
 	}
 
 	// If pkgtree was empty or all dirs lacked any Go code, return an error.

--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -790,12 +790,8 @@ func checkErrors(m map[string]pkgtree.PackageOrErr, ignore *pkgtree.IgnoredRules
 		}
 	}
 
-	if allowNoGo {
-		noGoErrors = 0
-	}
-
-	// If pkgtree was empty or all dirs lacked any Go code, return an error.
-	if len(m) == 0 || len(m) == noGoErrors {
+	// If we don't allow no Go code and pkgtree was empty or all dirs lacked any Go code, return an error.
+	if !allowNoGo && (len(m) == 0 || len(m) == noGoErrors) {
 		return true, errors.New("no dirs contained any Go code")
 	}
 

--- a/cmd/dep/ensure_test.go
+++ b/cmd/dep/ensure_test.go
@@ -135,7 +135,7 @@ func TestCheckErrors(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			fatal, err := checkErrors(tc.pkgOrErrMap, nil)
+			fatal, err := checkErrors(tc.pkgOrErrMap, nil, false)
 			if tc.fatal != fatal {
 				t.Fatalf("expected fatal flag to be %T, got %T", tc.fatal, fatal)
 			}


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

### What does this do / why do we need it?

Allows a directory to contain no Go code when running `dep ensure -add`

### Do you need help or clarification on anything?

Is this the best way to do it? I feel like there may be a better way than setting `noGoErrors` to 0 - should I not increment `noGoErrors` if `allowNoGoErrors` is `true`? Or maybe change both of the `if` statements which depend on `noGoErrors` to check `allowNoGoErrors` too?

Does a new test need creating to cover this?

### Which issue(s) does this PR fix?

#1312: dep ensure -add should not depend on Go code

<!--

fixes #
fixes #

-->
