### PR TITLE
Deparallelize tests

### DIFF
--- a/internal/gps/manager_test.go
+++ b/internal/gps/manager_test.go
@@ -139,7 +139,6 @@ func TestSourceInit(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping project manager init test in short mode")
 	}
-	t.Parallel()
 
 	cpath, err := ioutil.TempDir("", "smcache")
 	if err != nil {
@@ -281,7 +280,6 @@ func TestDefaultBranchAssignment(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping default branch assignment test in short mode")
 	}
-	t.Parallel()
 
 	sm, clean := mkNaiveSM(t)
 	defer clean()
@@ -407,7 +405,6 @@ func TestSourceCreationCounts(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
 	}
-	t.Parallel()
 
 	fixtures := map[string]sourceCreationTestFixture{
 		"gopkgin uniqueness": {
@@ -450,7 +447,6 @@ func TestGetSources(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping source setup test in short mode")
 	}
-	t.Parallel()
 	requiresBins(t, "git", "hg", "bzr")
 
 	sm, clean := mkNaiveSM(t)
@@ -517,7 +513,6 @@ func TestFSCaseSensitivityConvergesSources(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
 	}
-	t.Parallel()
 
 	f := func(name string, pi1, pi2 ProjectIdentifier) {
 		t.Run(name, func(t *testing.T) {
@@ -576,7 +571,6 @@ func TestGetInfoListVersionsOrdering(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
 	}
-	t.Parallel()
 
 	sm, clean := mkNaiveSM(t)
 	defer clean()
@@ -681,7 +675,6 @@ func TestMultiFetchThreadsafe(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
 	}
-	t.Parallel()
 
 	projects := []ProjectIdentifier{
 		mkPI("github.com/sdboyer/gps"),
@@ -789,7 +782,6 @@ func TestListVersionsRacey(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
 	}
-	t.Parallel()
 
 	sm, clean := mkNaiveSM(t)
 	defer clean()
@@ -945,7 +937,6 @@ func TestUnreachableSource(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
 	}
-	t.Parallel()
 
 	sm, clean := mkNaiveSM(t)
 	defer clean()

--- a/internal/gps/source_cache_bolt_test.go
+++ b/internal/gps/source_cache_bolt_test.go
@@ -15,8 +15,6 @@ import (
 )
 
 func TestBoltCacheTimeout(t *testing.T) {
-	t.Parallel()
-
 	const root = "example.com/test"
 	cpath, err := ioutil.TempDir("", "singlesourcecache")
 	if err != nil {

--- a/internal/gps/source_cache_test.go
+++ b/internal/gps/source_cache_test.go
@@ -18,8 +18,6 @@ import (
 )
 
 func Test_singleSourceCache(t *testing.T) {
-	t.Parallel()
-
 	newMem := func(*testing.T, string, string) (singleSourceCache, func() error) {
 		return newMemoryCache(), func() error { return nil }
 	}
@@ -72,8 +70,6 @@ type singleSourceCacheTest struct {
 // run tests singleSourceCache methods of caches returned by test.newCache.
 // For test.persistent caches, test.newCache is periodically called mid-test to ensure persistence.
 func (test singleSourceCacheTest) run(t *testing.T) {
-	t.Parallel()
-
 	const root = "example.com/test"
 	cpath, err := ioutil.TempDir("", "singlesourcecache")
 	if err != nil {

--- a/internal/gps/vcs_source_test.go
+++ b/internal/gps/vcs_source_test.go
@@ -21,7 +21,6 @@ import (
 
 // Parent test that executes all the slow vcs interaction tests in parallel.
 func TestSlowVcs(t *testing.T) {
-	t.Parallel()
 	t.Run("write-deptree", testWriteDepTree)
 	t.Run("source-gateway", testSourceGateway)
 	t.Run("bzr-repo", testBzrRepo)

--- a/internal/gps/vcs_version_test.go
+++ b/internal/gps/vcs_version_test.go
@@ -17,7 +17,6 @@ func TestVCSVersion(t *testing.T) {
 	}
 
 	h := test.NewHelper(t)
-	h.Parallel()
 	defer h.Cleanup()
 	requiresBins(t, "git")
 


### PR DESCRIPTION
Revert the test parallelizations, as appveyor doesn't seem to be able to handle it.

i really want us to be able to do these things, but these are causing other PRs to erroneously fail just...all the time. really need that local repo swap-in solution. 🤔 