### PR TITLE
renameByCopy: retry os.RemoveAll

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -190,7 +190,11 @@ func renameByCopy(src, dst string) error {
 		return errors.Wrapf(cerr, "rename fallback failed: cannot rename %s to %s", src, dst)
 	}
 
-	return errors.Wrapf(os.RemoveAll(src), "cannot delete %s", src)
+	rmerr := os.RemoveAll(src)
+	if rmerr != nil {
+		rmerr = os.RemoveAll(src)
+	}
+	return errors.Wrapf(rmerr, "cannot delete %s", src)
 }
 
 // IsCaseSensitiveFilesystem determines if the filesystem where dir


### PR DESCRIPTION

<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

### What does this do / why do we need it?

Was receiving this consistently, always with the same directory:

```
grouped write of manifest, lock and vendor:
     cannot delete /tmp/dep152972340/vendor:
     remove /tmp/dep152972340/vendor/golang.org/x/sys/unix:
     directory not empty
```

A simple retry corrected the issue, consistently.

This was on the Windows 10 Linux subsystem, FWIW, where `GOOS=linux/amd64`. `windows/amd64` and `linux/amd64` on TravisCI did not encounter this issue.

Maybe chalk this up to the Windows' Linux subsystem being beta.

If you want this patch I'll drop a comment about why there's a retry and update the CHANGELOG.

The confusing thing for me while debugging was the `defer os.RemoveAll(dir)` succeeded, so I could never find the files it said it couldn't delete; it was essentially retrying in the defer and succeeding.

Before:
```
jwhite@Jud-I7:/mnt/d/Projects/_go/src/github.com/nsqio/nsq$ dep ensure -v
Gopkg.lock was already in sync with imports and Gopkg.toml
(1/12) Wrote github.com/bitly/timer_metrics@afad1794bb13e2a094720aeb27c088aa64564895
(2/12) Wrote github.com/mreiferson/go-options@77551d20752b54535462404ad9d877ebdb26e53d
(3/12) Wrote github.com/nsqio/go-diskqueue@0681a1afee1245efa503b7543989fc26d8f268bc
(4/12) Wrote github.com/judwhite/go-svc@63c12402f579f0bdf022653c821a1aa5d7544f01
(5/12) Wrote github.com/bitly/go-hostpool@58b95b10d6ca26723a7f46017b348653b825a8d6
(6/12) Wrote github.com/julienschmidt/httprouter@6aacfd5ab513e34f7e64ea9627ab9670371b34e7
(7/12) Wrote github.com/bmizerany/perks@6cb9d9d729303ee2628580d9aec5db968da3a607
(8/12) Wrote github.com/golang/snappy@d9eb7a3d35ec988b8585d4a0068e462c27d28380
(9/12) Wrote github.com/blang/semver@9bf7bff48b0388cb75991e58c6df7d13e982f1f2
(10/12) Wrote github.com/BurntSushi/toml@2dff11163ee667d51dcc066660925a92ce138deb
(11/12) Wrote github.com/nsqio/go-nsq@a53d495e81424aaf7a7665a9d32a97715c40e953
(12/12) Wrote golang.org/x/sys@master
grouped write of manifest, lock and vendor: cannot delete /tmp/dep152972340/vendor: remove /tmp/dep152972340/vendor/golang.org/x/sys/unix: directory not empty
```

After:
```
jwhite@Jud-I7:/mnt/d/Projects/_go/src/github.com/nsqio/nsq$ dep ensure -v
Gopkg.lock was already in sync with imports and Gopkg.toml
(1/12) Wrote github.com/golang/snappy@d9eb7a3d35ec988b8585d4a0068e462c27d28380
(2/12) Wrote github.com/blang/semver@9bf7bff48b0388cb75991e58c6df7d13e982f1f2
(3/12) Wrote github.com/bitly/timer_metrics@afad1794bb13e2a094720aeb27c088aa64564895
(4/12) Wrote github.com/julienschmidt/httprouter@6aacfd5ab513e34f7e64ea9627ab9670371b34e7
(5/12) Wrote github.com/bitly/go-hostpool@58b95b10d6ca26723a7f46017b348653b825a8d6
(6/12) Wrote github.com/nsqio/go-diskqueue@0681a1afee1245efa503b7543989fc26d8f268bc
(7/12) Wrote github.com/bmizerany/perks@6cb9d9d729303ee2628580d9aec5db968da3a607
(8/12) Wrote github.com/mreiferson/go-options@77551d20752b54535462404ad9d877ebdb26e53d
(9/12) Wrote github.com/BurntSushi/toml@2dff11163ee667d51dcc066660925a92ce138deb
(10/12) Wrote github.com/nsqio/go-nsq@a53d495e81424aaf7a7665a9d32a97715c40e953
(11/12) Wrote github.com/judwhite/go-svc@63c12402f579f0bdf022653c821a1aa5d7544f01
(12/12) Wrote golang.org/x/sys@master
```

### What should your reviewer look out for in this PR?

Is there a less ugly way?

### Do you need help or clarification on anything?

See above 😄 

### Which issue(s) does this PR fix?

I went through the open issues. It's most closely related to #82, but not exactly.