### PR TITLE
status: add validateFlags()

### DIFF
--- a/cmd/dep/status.go
+++ b/cmd/dep/status.go
@@ -62,26 +62,20 @@ func (cmd *statusCommand) LongHelp() string  { return statusLongHelp }
 func (cmd *statusCommand) Hidden() bool      { return false }
 
 func (cmd *statusCommand) Register(fs *flag.FlagSet) {
-	fs.BoolVar(&cmd.detailed, "detailed", false, "report more detailed status")
 	fs.BoolVar(&cmd.json, "json", false, "output in JSON format")
 	fs.StringVar(&cmd.template, "f", "", "output in text/template format")
 	fs.BoolVar(&cmd.dot, "dot", false, "output the dependency graph in GraphViz format")
 	fs.BoolVar(&cmd.old, "old", false, "only show out-of-date dependencies")
 	fs.BoolVar(&cmd.missing, "missing", false, "only show missing dependencies")
-	fs.BoolVar(&cmd.unused, "unused", false, "only show unused dependencies")
-	fs.BoolVar(&cmd.modified, "modified", false, "only show modified dependencies")
 }
 
 type statusCommand struct {
-	detailed bool
 	json     bool
 	template string
 	output   string
 	dot      bool
 	old      bool
 	missing  bool
-	unused   bool
-	modified bool
 }
 
 type outputter interface {
@@ -234,15 +228,9 @@ func (cmd *statusCommand) Run(ctx *dep.Ctx, args []string) error {
 	var buf bytes.Buffer
 	var out outputter
 	switch {
-	case cmd.modified:
-		return errors.Errorf("not implemented")
-	case cmd.unused:
-		return errors.Errorf("not implemented")
 	case cmd.missing:
 		return errors.Errorf("not implemented")
 	case cmd.old:
-		return errors.Errorf("not implemented")
-	case cmd.detailed:
 		return errors.Errorf("not implemented")
 	case cmd.json:
 		out = &jsonOutput{
@@ -309,24 +297,12 @@ func (cmd *statusCommand) validateFlags() error {
 	// Operating mode flags.
 	opModes := []string{}
 
-	if cmd.detailed {
-		opModes = append(opModes, "-detailed")
-	}
-
 	if cmd.old {
 		opModes = append(opModes, "-old")
 	}
 
 	if cmd.missing {
 		opModes = append(opModes, "-missing")
-	}
-
-	if cmd.unused {
-		opModes = append(opModes, "-unused")
-	}
-
-	if cmd.modified {
-		opModes = append(opModes, "-modified")
 	}
 
 	// Check if any other flags are passed with -dot.

--- a/cmd/dep/status_test.go
+++ b/cmd/dep/status_test.go
@@ -441,7 +441,7 @@ func TestValidateFlags(t *testing.T) {
 		},
 		{
 			name:    "single operating mode",
-			cmd:     statusCommand{unused: true},
+			cmd:     statusCommand{old: true},
 			wantErr: nil,
 		},
 		{


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

### What does this do / why do we need it?
Adds flags validation to status command. The validation is based on 2 types of flags:
Operating mode flags: ~-detailed, -modified,  -unused~, `-missing, -old`
Output format flags: `-json, -dot, -f`

`-dot` format flag is applicable only to the default status mode.

### What should your reviewer look out for in this PR?
Validation logic.

### Do you need help or clarification on anything?
No.

### Which issue(s) does this PR fix?

None. But preparing for the upcoming different status operating mode implementation.
<!--

fixes #
fixes #

-->
