### PR TITLE
Updated disjointConstraintFailure Error() to also display VersionType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ BUG FIXES:
 IMPROVEMENTS:
 
 * Log as dependencies are pre-fetched during dep init ([#1176](https://github.com/golang/dep/pull/1176)).
+* Made the disjoint constraint failure error message more descriptive (#TODO).
 
 # v0.3.2
 

--- a/internal/gps/solve_failures.go
+++ b/internal/gps/solve_failures.go
@@ -170,8 +170,8 @@ type disjointConstraintFailure struct {
 
 func (e *disjointConstraintFailure) Error() string {
 	if len(e.failsib) == 1 {
-		str := "Could not introduce %s, as it has a dependency on %s with constraint %s, which has no overlap with existing constraint %s from %s"
-		return fmt.Sprintf(str, a2vs(e.goal.depender), e.goal.dep.Ident, e.goal.dep.Constraint.String(), e.failsib[0].dep.Constraint.String(), a2vs(e.failsib[0].depender))
+		str := "Could not introduce %s, as it has a dependency on %s with constraint %s (%s), which has no overlap with existing constraint %s (%s) from %s"
+		return fmt.Sprintf(str, a2vs(e.goal.depender), e.goal.dep.Ident, e.goal.dep.Constraint.String(), e.goal.depender.v.Type(), e.failsib[0].dep.Constraint.String(), e.failsib[0].depender.v.Type(), a2vs(e.failsib[0].depender))
 	}
 
 	var buf bytes.Buffer
@@ -180,17 +180,17 @@ func (e *disjointConstraintFailure) Error() string {
 	if len(e.failsib) > 1 {
 		sibs = e.failsib
 
-		str := "Could not introduce %s, as it has a dependency on %s with constraint %s, which has no overlap with the following existing constraints:\n"
-		fmt.Fprintf(&buf, str, a2vs(e.goal.depender), e.goal.dep.Ident, e.goal.dep.Constraint.String())
+		str := "Could not introduce %s, as it has a dependency on %s with constraint %s (%s), which has no overlap with the following existing constraints:\n"
+		fmt.Fprintf(&buf, str, a2vs(e.goal.depender), e.goal.dep.Ident, e.goal.dep.Constraint.String(), e.goal.depender.v.Type())
 	} else {
 		sibs = e.nofailsib
 
-		str := "Could not introduce %s, as it has a dependency on %s with constraint %s, which does not overlap with the intersection of existing constraints from other currently selected packages:\n"
-		fmt.Fprintf(&buf, str, a2vs(e.goal.depender), e.goal.dep.Ident, e.goal.dep.Constraint.String())
+		str := "Could not introduce %s, as it has a dependency on %s with constraint %s (%s), which does not overlap with the intersection of existing constraints from other currently selected packages:\n"
+		fmt.Fprintf(&buf, str, a2vs(e.goal.depender), e.goal.dep.Ident, e.goal.dep.Constraint.String(), e.goal.depender.v.Type())
 	}
 
 	for _, c := range sibs {
-		fmt.Fprintf(&buf, "\t%s from %s\n", c.dep.Constraint.String(), a2vs(c.depender))
+		fmt.Fprintf(&buf, "\t%s (%s) from %s\n", c.dep.Constraint.String(), c.depender.v.Type(), a2vs(c.depender))
 	}
 
 	return buf.String()

--- a/internal/gps/version.go
+++ b/internal/gps/version.go
@@ -7,6 +7,7 @@ package gps
 import (
 	"fmt"
 	"sort"
+	"strconv"
 
 	"github.com/Masterminds/semver"
 	"github.com/golang/dep/internal/gps/internal/pb"
@@ -23,6 +24,17 @@ const (
 	IsSemver
 	IsBranch
 )
+
+func (vt VersionType) String() string {
+	name := []string{"revision", "version", "semver", "branch"}
+	i := uint8(vt)
+	switch {
+	case i <= uint8(IsBranch):
+		return name[i]
+	default:
+		return strconv.Itoa(int(i))
+	}
+}
 
 // Version represents one of the different types of versions used by gps.
 //


### PR DESCRIPTION
### What does this do / why do we need it?

If you have a matching version string (say "master" and "master") but they are of different VersionTypes (say "branch" and "revision"), you will get a really confusing error message.

This adds a String() method for version type and uses it to improve disjointConstraintFailure Error() to also show the VersionType so that if you hit the above you will get an actionable error message.

### What should your reviewer look out for in this PR?

Are there other places we should also update the error messaging?

### Which issue(s) does this PR fix?

Fixes https://github.com/golang/dep/issues/1343
