### PR TITLE
Disable GOCACHE in test

### DIFF
--- a/cmd/dep/dep_test.go
+++ b/cmd/dep/dep_test.go
@@ -35,6 +35,9 @@ func TestMain(m *testing.M) {
 		os.Setenv("CCACHE_DIR", filepath.Join(home, ".ccache"))
 	}
 	os.Setenv("HOME", "/test-dep-home-does-not-exist")
+	if os.Getenv("GOCACHE") == "" {
+		os.Setenv("GOCACHE", "off") // because $HOME is gone
+	}
 
 	r := m.Run()
 


### PR DESCRIPTION
Trying to fix the breaking tests on go:tip due to the introduction of GOCACHE.

Refer: golang/go@5e35954
More info on GOCACHE: https://groups.google.com/forum/#!topic/golang-dev/qfa3mHN4ZPAs

Fixes #1368 