### PR TITLE
gps: vcs: suppress git password prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ BUG FIXES:
 
 * Releases targeting Windows now have a `.exe` suffix (#1291).
 * Adaptively recover from dirty and corrupted git repositories in cache (#1279).
+* Suppress git password prompts in more places (#1357).
 
 IMPROVEMENTS:
 

--- a/gps/vcs_repo.go
+++ b/gps/vcs_repo.go
@@ -92,6 +92,8 @@ func (r *gitRepo) get(ctx context.Context) error {
 		r.Remote(),
 		r.LocalPath(),
 	)
+	// Ensure no prompting for PWs
+	cmd.SetEnv(append([]string{"GIT_ASKPASS=", "GIT_TERMINAL_PROMPT=0"}, os.Environ()...))
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return newVcsRemoteErrorOr(err, cmd.Args(), string(out),
 			"unable to get repository")
@@ -110,6 +112,8 @@ func (r *gitRepo) fetch(ctx context.Context) error {
 		r.RemoteLocation,
 	)
 	cmd.SetDir(r.LocalPath())
+	// Ensure no prompting for PWs
+	cmd.SetEnv(append([]string{"GIT_ASKPASS=", "GIT_TERMINAL_PROMPT=0"}, os.Environ()...))
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return newVcsRemoteErrorOr(err, cmd.Args(), string(out),
 			"unable to update repository")
@@ -142,6 +146,8 @@ func (r *gitRepo) defendAgainstSubmodules(ctx context.Context) error {
 			"--recursive",
 		)
 		cmd.SetDir(r.LocalPath())
+		// Ensure no prompting for PWs
+		cmd.SetEnv(append([]string{"GIT_ASKPASS=", "GIT_TERMINAL_PROMPT=0"}, os.Environ()...))
 		if out, err := cmd.CombinedOutput(); err != nil {
 			return newVcsLocalErrorOr(err, cmd.Args(), string(out),
 				"unexpected error while defensively updating submodules")

--- a/gps/vcs_source_test.go
+++ b/gps/vcs_source_test.go
@@ -525,7 +525,7 @@ func testHgSourceInteractions(t *testing.T) {
 }
 
 func TestGitSourceListVersionsNoHEAD(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	requiresBins(t, "git")
 
@@ -582,7 +582,7 @@ func TestGitSourceListVersionsNoHEAD(t *testing.T) {
 }
 
 func TestGitSourceListVersionsNoDupes(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	// This test is slowish, skip it on -short
 	if testing.Short() {
@@ -649,7 +649,7 @@ func TestGitSourceListVersionsNoDupes(t *testing.T) {
 }
 
 func TestGitSourceAdaptiveCleanup(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	// This test is slowish, skip it on -short
 	if testing.Short() {


### PR DESCRIPTION
### What does this do / why do we need it?

This change suppresses git password prompts in more places. Cherry picked from #1250 (https://github.com/golang/dep/pull/1250/commits/f1f0bac72043f48decc01e93c642b9900c2b0c98).
### Which issue(s) does this PR fix?

It might fix: #1356
