### PR TITLE
gps: Insulate against .git as file

### DIFF
--- a/gps/source_test.go
+++ b/gps/source_test.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -36,6 +37,7 @@ func testSourceGateway(t *testing.T) {
 		os.RemoveAll(cachedir)
 		cancelFunc()
 	}()
+	os.Mkdir(filepath.Join(cachedir, "sources"), 0777)
 
 	do := func(wantstate sourceState) func(t *testing.T) {
 		return func(t *testing.T) {

--- a/gps/vcs_source_test.go
+++ b/gps/vcs_source_test.go
@@ -53,6 +53,7 @@ func testGitSourceInteractions(t *testing.T) {
 			t.Errorf("removeAll failed: %s", err)
 		}
 	}()
+	os.Mkdir(filepath.Join(cpath, "sources"), 0777)
 
 	n := "github.com/sdboyer/gpkt"
 	un := "https://" + n
@@ -149,6 +150,7 @@ func testGopkginSourceInteractions(t *testing.T) {
 			t.Errorf("removeAll failed: %s", err)
 		}
 	}()
+	os.Mkdir(filepath.Join(cpath, "sources"), 0777)
 
 	tfunc := func(opath, n string, major uint64, evl []Version) {
 		un := "https://" + opath
@@ -533,6 +535,8 @@ func TestGitSourceListVersionsNoHEAD(t *testing.T) {
 	defer h.Cleanup()
 	h.TempDir("smcache")
 	cpath := h.Path("smcache")
+	os.Mkdir(filepath.Join(cpath, "sources"), 0777)
+
 	h.TempDir("repo")
 	repoPath := h.Path("repo")
 
@@ -599,6 +603,7 @@ func TestGitSourceListVersionsNoDupes(t *testing.T) {
 			t.Errorf("removeAll failed: %s", err)
 		}
 	}()
+	os.Mkdir(filepath.Join(cpath, "sources"), 0777)
 
 	n := "github.com/carolynvs/deptest-importers"
 	un := "https://" + n


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

### What does this do / why do we need it?

`git ls-remote` was being run without a current working directory, which - for some versions of git - has the unfortunate side effect of still looking for a local `.git` in the cwd hierarchy, and failing if that .git is a file instead of a directory (as it might be if the user is working beneath a git submodule).

This relocates the call to somewhere safer, under gps' control, so that we've a better (though not foolproof) guarantee of not colliding with a `.git` file.

### Which issue(s) does this PR fix?

Fixes #1338.