### PR TITLE
Add a sanity check for git ls-remote output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ BUG FIXES:
 * Releases targeting Windows now have a `.exe` suffix (#1291).
 * Adaptively recover from dirty and corrupted git repositories in cache (#1279).
 * Suppress git password prompts in more places (#1357).
+* Validate `git ls-remote` output and ignore all malformed lines (#1379)
 
 IMPROVEMENTS:
 


### PR DESCRIPTION
This should fix panics for cases where `git ls-remote` contains
unepxected lines (e.x. some extra warnings from ssh)

Related to #1379

### What does this do / why do we need it?
This should add some sanity checks for `git ls-remote` output.

### What should your reviewer look out for in this PR?

### Do you need help or clarification on anything?

### Which issue(s) does this PR fix?
fixes #1379 
fixes #1209

