### PR TITLE
fix error when GOPATH or project root is relative

### DIFF
--- a/context.go
+++ b/context.go
@@ -58,6 +58,10 @@ func (c *Ctx) SetPaths(wd string, GOPATHs ...string) error {
 		GOPATHs = filepath.SplitList(GOPATH)
 	}
 
+	for index, path := range GOPATHs {
+		GOPATHs[index] = filepath.Clean(path)
+	}
+
 	c.GOPATHs = append(c.GOPATHs, GOPATHs...)
 
 	return nil

--- a/project.go
+++ b/project.go
@@ -111,7 +111,7 @@ func (p *Project) SetRoot(root string) error {
 		return err
 	}
 
-	p.ResolvedAbsRoot, p.AbsRoot = rroot, root
+	p.ResolvedAbsRoot, p.AbsRoot = rroot, filepath.Clean(root)
 	return nil
 }
 


### PR DESCRIPTION
if relative path is set to GOPATH,such as “~/workspace/go/../go”, the project will not match prefix of GOPATH and report "are not within any known GOPATH" error.

try to fix this by filepath.Clean