### PR TITLE
Infer constraint from glide.lock

### DIFF
--- a/internal/importers/glide/importer.go
+++ b/internal/importers/glide/importer.go
@@ -183,7 +183,7 @@ func (g *Importer) convert(pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock, error)
 		packages = append(packages, ip)
 	}
 
-	err := g.ImportPackages(packages, false)
+	err := g.ImportPackages(packages, true)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "invalid glide configuration")
 	}


### PR DESCRIPTION
### What does this do / why do we need it?

Changes the Glide importer to [set constraints inferred from revisions](https://github.com/golang/dep/blob/13df556177b33fcfe1187343bd54837e48ec0b52/internal/importers/base/importer.go#L226), when a branch or tag is not supplied in the first place.

### Example usage:

In my example in #1387, this PR changes the output of the toml to:
```toml
[[constraint]]
  branch = "master"
  name = "github.com/blang/vfs"
```

The branch `master` is being inferred by [lookupVersionForLockedProject()](https://github.com/golang/dep/blob/13df556177b33fcfe1187343bd54837e48ec0b52/internal/importers/base/importer.go#L218) and being set by [line 226](https://github.com/golang/dep/blob/13df556177b33fcfe1187343bd54837e48ec0b52/internal/importers/base/importer.go#L226)

### What should your reviewer look out for in this PR?

Whether or not the flag `defaultConstraintFromLock` should be set to `false` for the Glide importer.

### Do you need help or clarification on anything?

Possibly. See above / #1387

### Which issue(s) does this PR fix?

Fixes #1387 