### PR TITLE
removed first empty line on the example file

### DIFF
--- a/testdata/txn_writer/expected_manifest.toml
+++ b/testdata/txn_writer/expected_manifest.toml
@@ -1,4 +1,3 @@
-
 # Gopkg.toml example
 #
 # Refer to https://github.com/golang/dep/blob/master/docs/Gopkg.toml.md

--- a/txn_writer.go
+++ b/txn_writer.go
@@ -21,8 +21,7 @@ import (
 // Example string to be written to the manifest file
 // if no dependencies are found in the project
 // during `dep init`
-var exampleTOML = []byte(`
-# Gopkg.toml example
+var exampleTOML = []byte(`# Gopkg.toml example
 #
 # Refer to https://github.com/golang/dep/blob/master/docs/Gopkg.toml.md
 # for detailed Gopkg.toml documentation.


### PR DESCRIPTION
### What does this do / why do we need it?

The Gopkg.toml file is always generated with an empty line as the first line.

It's not a big deal, but I find it kind of annoying, so I removed it.

### What should your reviewer look out for in this PR?

### Do you need help or clarification on anything?

Tests were very slow and failed on apparently unrelated things... if it fails here as well I might need to investigate it further.

### Which issue(s) does this PR fix?

<!--

fixes #
fixes #

-->
