### PR TITLE
internal/fs: Don't Sync() destination file after copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ IMPROVEMENTS:
 
 * Log as dependencies are pre-fetched during dep init ([#1176](https://github.com/golang/dep/pull/1176)).
 * Make the gps package importable ([#1349](https://github.com/golang/dep/pull/1349)).
+* Improve file copy performance by not forcing a file sync (PR #1408).
 
 # v0.3.2
 

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -407,8 +407,7 @@ func CopyDir(src, dst string) error {
 // copyFile copies the contents of the file named src to the file named
 // by dst. The file will be created if it does not already exist. If the
 // destination file exists, all its contents will be replaced by the contents
-// of the source file. The file mode will be copied from the source and
-// the copied data is synced/flushed to stable storage.
+// of the source file. The file mode will be copied from the source.
 func copyFile(src, dst string) (err error) {
 	if sym, err := IsSymlink(src); err != nil {
 		return errors.Wrap(err, "symlink check failed")
@@ -442,13 +441,14 @@ func copyFile(src, dst string) (err error) {
 	if err != nil {
 		return
 	}
-	defer out.Close()
 
 	if _, err = io.Copy(out, in); err != nil {
+		out.Close()
 		return
 	}
 
-	if err = out.Sync(); err != nil {
+	// Check for write errors on Close
+	if err = out.Close(); err != nil {
 		return
 	}
 


### PR DESCRIPTION
When copying files, directly check for errors when closing
the destination file rather than using out.Sync() with
a deferred Close().

The out.Sync() call can be incredibly expensive on systems which
are I/O-heavy, yet may have more than ample memory and CPU
resources.  As part of a file copy, we only need to ensure that
errors writing and closing the file handle are checked and dealt
with, rather than forcing the entire copied file to physical storage.

Environments such as Continuous Integration servers and container
hosts are often I/O-heavy.  In such environments, this change
can make a significant difference - milliseconds vs minutes.

<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

### What does this do / why do we need it?
Avoid unnecessarily syncing newly copied files to physical storage.
A sync to physical disk imposes heavy latency on completing the file copy, and it is
exacerbated when it is done file-at-a-time.

Replacing the out.Sync() call with an error check on out.Close() can dramatically improve
latency on I/O-heavy machines, and actually improves error detection vs the out.Sync() call.

On a container host that I use for CI, this reduced a `dep` run from 6 minutes to 5 seconds.
(the host has copious RAM and CPU, but is heavily I/O bound)

### What should your reviewer look out for in this PR?

### Do you need help or clarification on anything?

### Which issue(s) does this PR fix?

<!--

fixes #
fixes #

-->
