### PR TITLE
dep: Skip tool conversions in dep status

### DIFF
--- a/cmd/dep/status.go
+++ b/cmd/dep/status.go
@@ -693,7 +693,7 @@ func collectConstraints(ctx *dep.Ctx, p *dep.Project, sm gps.SourceManager) cons
 		ctx.Err.Println("Error getting direct deps:", err)
 	}
 	// Create a root analyzer.
-	rootAnalyzer := newRootAnalyzer(false, ctx, directDeps, sm)
+	rootAnalyzer := newRootAnalyzer(true, ctx, directDeps, sm)
 
 	// Iterate through the locked projects and collect constraints of all the projects.
 	for _, proj := range p.Lock.Projects() {


### PR DESCRIPTION
### What does this do / why do we need it?

collectConstraints(), used by `dep status`, was trying to do on-the-fly
conversions of existing tools. That needs to remain disabled until we
also turn it on for `dep init` and `dep ensure`.