### PR TITLE
internal/fs: Remove symlink cycle from testdata

### DIFF
--- a/internal/fs/testdata/symlinks/dir-symlink
+++ b/internal/fs/testdata/symlinks/dir-symlink
@@ -1,1 +1,1 @@
-../../testdata
+../test.dir


### PR DESCRIPTION
### What does this do / why do we need it?
Some tools get unhappy with a symlink cycle, and the test is not
verifying anything related to the directory symlink being a cycle.


### What should your reviewer look out for in this PR?

Make sure tests pass on Windows.