### PR TITLE
status: make collectConstraints() concurrent

### DIFF
--- a/cmd/dep/status.go
+++ b/cmd/dep/status.go
@@ -734,10 +734,15 @@ func collectConstraints(ctx *dep.Ctx, p *dep.Project, sm gps.SourceManager) cons
 			// Iterate through the project constraints to get individual dependency
 			// project and constraint values.
 			for pr, pp := range pc {
-				constraintCollection[string(pr)] = append(
+				tempCC := append(
 					constraintCollection[string(pr)],
 					projectConstraint{proj.Ident().ProjectRoot, pp.Constraint},
 				)
+
+				// Sort the inner projectConstraint slice by Project string.
+				// Required for consistent returned value.
+				sort.Sort(byProject(tempCC))
+				constraintCollection[string(pr)] = tempCC
 			}
 		}(proj)
 	}
@@ -753,3 +758,9 @@ func collectConstraints(ctx *dep.Ctx, p *dep.Project, sm gps.SourceManager) cons
 
 	return constraintCollection
 }
+
+type byProject []projectConstraint
+
+func (p byProject) Len() int           { return len(p) }
+func (p byProject) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+func (p byProject) Less(i, j int) bool { return p[i].Project > p[j].Project }

--- a/cmd/dep/status_test.go
+++ b/cmd/dep/status_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"io/ioutil"
 	"log"
+	"path/filepath"
 	"reflect"
 	"testing"
 	"text/tabwriter"
@@ -299,45 +300,42 @@ func TestCollectConstraints(t *testing.T) {
 
 	cases := []struct {
 		name            string
-		project         dep.Project
+		lock            dep.Lock
 		wantConstraints constraintsCollection
+		wantErr         bool
 	}{
 		{
 			name: "without any constraints",
-			project: dep.Project{
-				Lock: &dep.Lock{
-					P: []gps.LockedProject{
-						gps.NewLockedProject(
-							gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot("github.com/sdboyer/deptest")},
-							gps.NewVersion("v1.0.0"),
-							[]string{"."},
-						),
-					},
+			lock: dep.Lock{
+				P: []gps.LockedProject{
+					gps.NewLockedProject(
+						gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot("github.com/sdboyer/deptest")},
+						gps.NewVersion("v1.0.0"),
+						[]string{"."},
+					),
 				},
 			},
 			wantConstraints: constraintsCollection{},
 		},
 		{
 			name: "with multiple constraints",
-			project: dep.Project{
-				Lock: &dep.Lock{
-					P: []gps.LockedProject{
-						gps.NewLockedProject(
-							gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot("github.com/sdboyer/deptest")},
-							gps.NewVersion("v1.0.0"),
-							[]string{"."},
-						),
-						gps.NewLockedProject(
-							gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot("github.com/darkowlzz/deptest-project-1")},
-							gps.NewVersion("v0.1.0"),
-							[]string{"."},
-						),
-						gps.NewLockedProject(
-							gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot("github.com/darkowlzz/deptest-project-2")},
-							gps.NewBranch("master").Pair(gps.Revision("824a8d56a4c6b2f4718824a98cd6d70d3dbd4c3e")),
-							[]string{"."},
-						),
-					},
+			lock: dep.Lock{
+				P: []gps.LockedProject{
+					gps.NewLockedProject(
+						gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot("github.com/sdboyer/deptest")},
+						gps.NewVersion("v1.0.0"),
+						[]string{"."},
+					),
+					gps.NewLockedProject(
+						gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot("github.com/darkowlzz/deptest-project-1")},
+						gps.NewVersion("v0.1.0"),
+						[]string{"."},
+					),
+					gps.NewLockedProject(
+						gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot("github.com/darkowlzz/deptest-project-2")},
+						gps.NewBranch("master").Pair(gps.Revision("824a8d56a4c6b2f4718824a98cd6d70d3dbd4c3e")),
+						[]string{"."},
+					),
 				},
 			},
 			wantConstraints: constraintsCollection{
@@ -355,20 +353,18 @@ func TestCollectConstraints(t *testing.T) {
 		},
 		{
 			name: "skip projects with invalid versions",
-			project: dep.Project{
-				Lock: &dep.Lock{
-					P: []gps.LockedProject{
-						gps.NewLockedProject(
-							gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot("github.com/darkowlzz/deptest-project-1")},
-							gps.NewVersion("v0.1.0"),
-							[]string{"."},
-						),
-						gps.NewLockedProject(
-							gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot("github.com/darkowlzz/deptest-project-2")},
-							gps.NewVersion("v1.0.0"),
-							[]string{"."},
-						),
-					},
+			lock: dep.Lock{
+				P: []gps.LockedProject{
+					gps.NewLockedProject(
+						gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot("github.com/darkowlzz/deptest-project-1")},
+						gps.NewVersion("v0.1.0"),
+						[]string{"."},
+					),
+					gps.NewLockedProject(
+						gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot("github.com/darkowlzz/deptest-project-2")},
+						gps.NewVersion("v1.0.0"),
+						[]string{"."},
+					),
 				},
 			},
 			wantConstraints: constraintsCollection{
@@ -376,6 +372,7 @@ func TestCollectConstraints(t *testing.T) {
 					{"github.com/darkowlzz/deptest-project-1", ver1},
 				},
 			},
+			wantErr: true,
 		},
 	}
 
@@ -396,12 +393,23 @@ func TestCollectConstraints(t *testing.T) {
 	h.Must(err)
 	defer sm.Release()
 
+	// Create new project and set root. Setting root is required for PackageList
+	// to run properly.
+	p := new(dep.Project)
+	p.SetRoot(filepath.Join(pwd, "src"))
+
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			gotConstraints := collectConstraints(ctx, &c.project, sm)
+			p.Lock = &c.lock
+			gotConstraints, err := collectConstraints(ctx, p, sm)
+			if len(err) > 0 && !c.wantErr {
+				t.Fatalf("unexpected errors while collecting constraints: %v", err)
+			} else if len(err) == 0 && c.wantErr {
+				t.Fatalf("expected errors while collecting constraints, but got none")
+			}
 
 			if !reflect.DeepEqual(gotConstraints, c.wantConstraints) {
-				t.Fatalf("Unexpected collected constraints: \n\t(GOT): %v\n\t(WNT): %v", gotConstraints, c.wantConstraints)
+				t.Fatalf("unexpected collected constraints: \n\t(GOT): %v\n\t(WNT): %v", gotConstraints, c.wantConstraints)
 			}
 		})
 	}

--- a/cmd/dep/status_test.go
+++ b/cmd/dep/status_test.go
@@ -341,15 +341,15 @@ func TestCollectConstraints(t *testing.T) {
 				},
 			},
 			wantConstraints: constraintsCollection{
-				"github.com/sdboyer/deptest": []projectConstraint{
-					{"github.com/darkowlzz/deptest-project-1", ver1},
-					{"github.com/darkowlzz/deptest-project-2", ver08},
-				},
 				"github.com/sdboyer/deptestdos": []projectConstraint{
 					{"github.com/darkowlzz/deptest-project-2", ver2},
 				},
 				"github.com/sdboyer/dep-test": []projectConstraint{
 					{"github.com/darkowlzz/deptest-project-2", ver1},
+				},
+				"github.com/sdboyer/deptest": []projectConstraint{
+					{"github.com/darkowlzz/deptest-project-2", ver08},
+					{"github.com/darkowlzz/deptest-project-1", ver1},
 				},
 			},
 		},


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

### What does this do / why do we need it?
It makes `collectConstraints()` concurrent. We need this to reduce the running time of status, which increased recently to ~30s due to introduction of `collectConstraints()`. This change brings the time down to ~5s.

Verbose output shows constraints collection progress:
```
$ dep status -v
Collecting project constraints:
(1/15) github.com/Masterminds/semver
(2/15) github.com/Masterminds/vcs
(3/15) github.com/armon/go-radix
(4/15) github.com/boltdb/bolt
....
(12/15) github.com/sdboyer/constext
(13/15) golang.org/x/net
(14/15) golang.org/x/sync
(15/15) golang.org/x/sys
Checking upstream projects:
(1/15) github.com/Masterminds/semver
(2/15) github.com/Masterminds/vcs
(3/15) github.com/armon/go-radix
(4/15) github.com/boltdb/bolt
....
```

### What should your reviewer look out for in this PR?
Concurrency implementation.

### Do you need help or clarification on anything?
Should we return errors in `collectConstraints()`? I didn't change the return signature initially while implementing but now I think maybe we should. With this change, any error in `collectConstraints()` won't affect status but would print the error only when in verbose mode.

<!--
### Which issue(s) does this PR fix?

fixes #
fixes #

-->
