### PR TITLE
Skip empty constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ IMPROVEMENTS:
 * Log as dependencies are pre-fetched during dep init ([#1176](https://github.com/golang/dep/pull/1176)).
 * Make the gps package importable ([#1349](https://github.com/golang/dep/pull/1349)).
 * Improve file copy performance by not forcing a file sync (PR #1408).
+* Skip empty constraints during import ([#1414](https://github.com/golang/dep/pull/1349))
 
 # v0.3.2
 

--- a/cmd/dep/testdata/harness_tests/init/glide/case1/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/init/glide/case1/final/Gopkg.lock
@@ -21,6 +21,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7efcfca7f138c3579d22b4ef788294649c734ea630124fb8fbb47acf8770b086"
+  inputs-digest = "def34af0f7cd619e1601eb68bdabf399c9b36a79c2081306adefa0ced03d182b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/dep/testdata/harness_tests/init/glide/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/glide/case1/final/Gopkg.toml
@@ -1,8 +1,5 @@
 ignored = ["github.com/golang/notexist/samples","github.com/sdboyer/dep-test"]
 
 [[constraint]]
-  name = "github.com/carolynvs/deptest-subpkg"
-
-[[constraint]]
   name = "github.com/sdboyer/deptestdos"
   version = "2.0.0"

--- a/cmd/dep/testdata/harness_tests/init/gvt/case1/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/init/gvt/case1/final/Gopkg.lock
@@ -23,6 +23,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "9ee70d58a0bc986cfb1d57a351786e9cf1bfc2ca763ce17f601a6529aebe65d1"
+  inputs-digest = "d1681978cbca0e845950451461e0d69b58c5e896d9fd10ec5c159a4db3175161"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/dep/testdata/harness_tests/init/gvt/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/gvt/case1/final/Gopkg.toml
@@ -5,6 +5,7 @@
 
 [[constraint]]
   name = "github.com/sdboyer/deptestdos"
+  version = "2.0.0"
 
 [[constraint]]
   branch = "v2"

--- a/internal/importers/base/importer.go
+++ b/internal/importers/base/importer.go
@@ -251,11 +251,18 @@ func (i *Importer) ImportPackages(packages []ImportedPackage, defaultConstraintF
 			pc.Constraint = gps.Any()
 		}
 
-		i.Manifest.Constraints[pc.Ident.ProjectRoot] = gps.ProjectProperties{
-			Source:     pc.Ident.Source,
-			Constraint: pc.Constraint,
+		// Add constraint to manifest that is not empty (has a branch, version or source)
+		if !gps.IsAny(pc.Constraint) || pc.Ident.Source != "" {
+			i.Manifest.Constraints[pc.Ident.ProjectRoot] = gps.ProjectProperties{
+				Source:     pc.Ident.Source,
+				Constraint: pc.Constraint,
+			}
+			fb.NewConstraintFeedback(pc, fb.DepTypeImported).LogFeedback(i.Logger)
+		} else {
+			if i.Verbose {
+				i.Logger.Printf("  Skipping import of %v because its constraint is empty.\n", pc.Ident)
+			}
 		}
-		fb.NewConstraintFeedback(pc, fb.DepTypeImported).LogFeedback(i.Logger)
 
 		if version != nil {
 			lp := gps.NewLockedProject(pc.Ident, version, nil)

--- a/internal/importers/base/importer_test.go
+++ b/internal/importers/base/importer_test.go
@@ -146,11 +146,10 @@ func TestBaseImporter_ImportProjects(t *testing.T) {
 		importertest.TestCase
 		projects []ImportedPackage
 	}{
-		"tag constraints are ignored": {
+		"tag constraints are skipped": {
 			importertest.TestCase{
-				WantConstraint: "*",
-				WantVersion:    importertest.Beta1Tag,
-				WantRevision:   importertest.Beta1Rev,
+				WantVersion:  importertest.Beta1Tag,
+				WantRevision: importertest.Beta1Rev,
 			},
 			[]ImportedPackage{
 				{
@@ -162,9 +161,8 @@ func TestBaseImporter_ImportProjects(t *testing.T) {
 		},
 		"tag lock hints Lock to tagged revision": {
 			importertest.TestCase{
-				WantConstraint: "*",
-				WantVersion:    importertest.Beta1Tag,
-				WantRevision:   importertest.Beta1Rev,
+				WantVersion:  importertest.Beta1Tag,
+				WantRevision: importertest.Beta1Rev,
 			},
 			[]ImportedPackage{
 				{
@@ -175,8 +173,7 @@ func TestBaseImporter_ImportProjects(t *testing.T) {
 		},
 		"untagged revision ignores range constraint": {
 			importertest.TestCase{
-				WantConstraint: "*",
-				WantRevision:   importertest.UntaggedRev,
+				WantRevision: importertest.UntaggedRev,
 			},
 			[]ImportedPackage{
 				{
@@ -270,11 +267,10 @@ func TestBaseImporter_ImportProjects(t *testing.T) {
 				},
 			},
 		},
-		"Revision constraints are ignored": {
+		"Revision constraints are skipped": {
 			importertest.TestCase{
-				WantConstraint: "*",
-				WantVersion:    importertest.V1Tag,
-				WantRevision:   importertest.V1Rev,
+				WantVersion:  importertest.V1Tag,
+				WantRevision: importertest.V1Rev,
 			},
 			[]ImportedPackage{
 				{
@@ -298,11 +294,10 @@ func TestBaseImporter_ImportProjects(t *testing.T) {
 				},
 			},
 		},
-		"Non-matching semver constraint is ignored": {
+		"Non-matching semver constraint is skipped": {
 			importertest.TestCase{
-				WantConstraint: "*",
-				WantVersion:    importertest.V1Tag,
-				WantRevision:   importertest.V1Rev,
+				WantVersion:  importertest.V1Tag,
+				WantRevision: importertest.V1Rev,
 			},
 			[]ImportedPackage{
 				{
@@ -312,10 +307,9 @@ func TestBaseImporter_ImportProjects(t *testing.T) {
 				},
 			},
 		},
-		"git describe constraint is ignored": {
+		"git describe constraint is skipped": {
 			importertest.TestCase{
-				WantConstraint: "*",
-				WantRevision:   importertest.UntaggedRev,
+				WantRevision: importertest.UntaggedRev,
 			},
 			[]ImportedPackage{
 				{
@@ -342,10 +336,9 @@ func TestBaseImporter_ImportProjects(t *testing.T) {
 				},
 			},
 		},
-		"ignore duplicate packages": {
+		"skip duplicate packages": {
 			importertest.TestCase{
-				WantConstraint: "*",
-				WantRevision:   importertest.UntaggedRev,
+				WantRevision: importertest.UntaggedRev,
 			},
 			[]ImportedPackage{
 				{
@@ -360,8 +353,8 @@ func TestBaseImporter_ImportProjects(t *testing.T) {
 		},
 		"skip empty lock hints": {
 			importertest.TestCase{
-				WantConstraint: "*",
-				WantRevision:   "",
+				WantRevision: "",
+				WantWarning:  "constraint is empty",
 			},
 			[]ImportedPackage{
 				{
@@ -382,10 +375,10 @@ func TestBaseImporter_ImportProjects(t *testing.T) {
 				},
 			},
 		},
-		"ignore default source": {
+		"skip default source": {
 			importertest.TestCase{
-				WantConstraint: "*",
 				WantSourceRepo: "",
+				WantWarning:    "constraint is empty",
 			},
 			[]ImportedPackage{
 				{
@@ -394,9 +387,8 @@ func TestBaseImporter_ImportProjects(t *testing.T) {
 				},
 			},
 		},
-		"ignore vendored source": {
+		"skip vendored source": {
 			importertest.TestCase{
-				WantConstraint: "*",
 				WantSourceRepo: "",
 				WantWarning:    "vendored sources aren't supported",
 			},

--- a/internal/importers/glide/importer_test.go
+++ b/internal/importers/glide/importer_test.go
@@ -138,8 +138,7 @@ func TestGlideConfig_Convert(t *testing.T) {
 				}},
 			glideLock{},
 			importertest.TestCase{
-				WantConstraint: "*",
-				WantWarning:    "specified an os",
+				WantWarning: "specified an os",
 			},
 		},
 		"warn unused arch field": {
@@ -152,8 +151,7 @@ func TestGlideConfig_Convert(t *testing.T) {
 				}},
 			glideLock{},
 			importertest.TestCase{
-				WantConstraint: "*",
-				WantWarning:    "specified an arch",
+				WantWarning: "specified an arch",
 			},
 		},
 	}

--- a/internal/importers/glide/testdata/golden.txt
+++ b/internal/importers/glide/testdata/golden.txt
@@ -4,5 +4,4 @@ Converting from glide.yaml and glide.lock...
   Trying v0.8.1 (3f4c3be) as initial lock for imported dep github.com/sdboyer/deptest
   Using ^2.0.0 as initial constraint for imported dep github.com/sdboyer/deptestdos
   Trying v2.0.0 (5c60720) as initial lock for imported dep github.com/sdboyer/deptestdos
-  Using * as initial constraint for imported dep github.com/golang/lint
   Trying * (cb00e56) as initial lock for imported dep github.com/golang/lint

--- a/internal/importers/govendor/importer_test.go
+++ b/internal/importers/govendor/importer_test.go
@@ -133,7 +133,7 @@ func TestGovendorConfig_Convert(t *testing.T) {
 				},
 			},
 			importertest.TestCase{
-				WantConstraint: "*",
+				WantWarning: "constraint is empty",
 			},
 		},
 	}

--- a/internal/importers/gvt/importer_test.go
+++ b/internal/importers/gvt/importer_test.go
@@ -56,9 +56,8 @@ func TestGvtConfig_Convert(t *testing.T) {
 		},
 		"package with HEAD branch": {
 			importertest.TestCase{
-				WantConstraint: "*",
-				WantRevision:   importertest.V1Rev,
-				WantVersion:    importertest.V1Tag,
+				WantRevision: importertest.V1Rev,
+				WantVersion:  importertest.V1Tag,
 			},
 			gvtManifest{
 				Deps: []gvtPkg{

--- a/internal/importers/gvt/testdata/golden.txt
+++ b/internal/importers/gvt/testdata/golden.txt
@@ -1,6 +1,5 @@
 Detected gb/gvt configuration files...
 Converting from vendor/manifest ...
-  Using * as initial constraint for imported dep github.com/sdboyer/deptest
   Trying v0.8.1 (3f4c3be) as initial lock for imported dep github.com/sdboyer/deptest
   Using ^2.0.0 as initial constraint for imported dep github.com/sdboyer/deptestdos
   Trying v2.0.0 (5c60720) as initial lock for imported dep github.com/sdboyer/deptestdos


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

### What does this do / why do we need it?

This PR changes how empty constraints are handled. 

An empty constraint is defined as having no branch, version, revision or source other than default. 

If this is the case, the import is skipped and an entry is **not** added to manifest, nor is it added to the lock.

### What should your reviewer look out for in this PR?

Assuming that the logic in `internal/importers/base/importer.go` is sufficient, changes to the tests (specifically `tag lock hints Lock to tagged revision`).

### Do you need help or clarification on anything?

Do we also want to omit the lock entry?

### Which issue(s) does this PR fix?

fixes #1373
