### PR TITLE
Add Github to known_hosts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ jobs:
       go: tip
     - <<: *simple-test
       os: osx
-      osx_image: xcode7.3
       go: 1.9.x
       install:
         # brew takes horribly long to update itself despite the above caching
@@ -74,3 +73,5 @@ jobs:
             repo: golang/dep
             branch: master
             tags: true
+addons:
+  ssh_known_hosts: github.com


### PR DESCRIPTION
### What does this do / why do we need it?

This commit manually instructs Travis to add `github.com` to `~/.ssh/known_hosts`. It looks like this was not added to the new build images.

### What should your reviewer look out for in this PR?

Builds should pass on newer Travis builds.

### Which issue(s) does this PR fix?

fixes #1428 