### PR TITLE
Restore output context to (git) errors

### DIFF
--- a/gps/cmd_unix.go
+++ b/gps/cmd_unix.go
@@ -77,8 +77,6 @@ func (c cmd) CombinedOutput() ([]byte, error) {
 		}
 	}()
 
-	if err := c.Cmd.Wait(); err != nil {
-		return nil, err
-	}
-	return b.Bytes(), nil
+	err := c.Cmd.Wait()
+	return b.Bytes(), err
 }


### PR DESCRIPTION
### What does this do / why do we need it?

All command errors current lack output context - stderr, stdout, anything. we basically only get exit codes, and it's very hard to know what's going on. This is the simplest possible thing that could work - just dump it all back into a string.

This is really gross, and i'm kind of ashamed of it, and we desperately need to get around to better nested error handling.