### PR TITLE
gps: remove unused gopkgin code

### DIFF
--- a/gps/deduce.go
+++ b/gps/deduce.go
@@ -12,11 +12,10 @@ import (
 	"net/url"
 	"path"
 	"regexp"
-	"strconv"
 	"strings"
 	"sync"
 
-	radix "github.com/armon/go-radix"
+	"github.com/armon/go-radix"
 	"github.com/pkg/errors"
 )
 
@@ -27,8 +26,6 @@ var (
 	svnSchemes     = []string{"https", "http", "svn", "svn+ssh"}
 	gopkginSchemes = []string{"https", "http"}
 )
-
-const gopkgUnstableSuffix = "-unstable"
 
 func validateVCSScheme(scheme, typ string) bool {
 	// everything allows plain ssh
@@ -286,29 +283,11 @@ func (m gopkginDeducer) deduceSource(p string, u *url.URL) (maybeSource, error) 
 		u.Path = path.Join(v[2], v[3])
 	}
 
-	unstable := false
-	majorStr := v[4]
-
-	if strings.HasSuffix(majorStr, gopkgUnstableSuffix) {
-		unstable = true
-		majorStr = strings.TrimSuffix(majorStr, gopkgUnstableSuffix)
-	}
-	major, err := strconv.ParseUint(majorStr[1:], 10, 64)
-	if err != nil {
-		// this should only be reachable if there's an error in the regex
-		return nil, fmt.Errorf("could not parse %q as a gopkg.in major version", majorStr[1:])
-	}
-
 	mb := make(maybeSources, len(gopkginSchemes))
 	for k, scheme := range gopkginSchemes {
 		u2 := *u
 		u2.Scheme = scheme
-		mb[k] = maybeGopkginSource{
-			opath:    v[1],
-			url:      &u2,
-			major:    major,
-			unstable: unstable,
-		}
+		mb[k] = maybeGitSource{url: &u2}
 	}
 
 	return mb, nil

--- a/gps/deduce_test.go
+++ b/gps/deduce_test.go
@@ -131,48 +131,48 @@ var pathDeductionFixtures = map[string][]pathDeductionFixture{
 			in:   "gopkg.in/sdboyer/gps.v0",
 			root: "gopkg.in/sdboyer/gps.v0",
 			mb: maybeSources{
-				maybeGopkginSource{opath: "gopkg.in/sdboyer/gps.v0", url: mkurl("https://github.com/sdboyer/gps"), major: 0},
-				maybeGopkginSource{opath: "gopkg.in/sdboyer/gps.v0", url: mkurl("http://github.com/sdboyer/gps"), major: 0},
+				maybeGitSource{url: mkurl("https://github.com/sdboyer/gps")},
+				maybeGitSource{url: mkurl("http://github.com/sdboyer/gps")},
 			},
 		},
 		{
 			in:   "gopkg.in/sdboyer/gps.v0/foo",
 			root: "gopkg.in/sdboyer/gps.v0",
 			mb: maybeSources{
-				maybeGopkginSource{opath: "gopkg.in/sdboyer/gps.v0", url: mkurl("https://github.com/sdboyer/gps"), major: 0},
-				maybeGopkginSource{opath: "gopkg.in/sdboyer/gps.v0", url: mkurl("http://github.com/sdboyer/gps"), major: 0},
+				maybeGitSource{url: mkurl("https://github.com/sdboyer/gps")},
+				maybeGitSource{url: mkurl("http://github.com/sdboyer/gps")},
 			},
 		},
 		{
 			in:   "gopkg.in/sdboyer/gps.v1/foo/bar",
 			root: "gopkg.in/sdboyer/gps.v1",
 			mb: maybeSources{
-				maybeGopkginSource{opath: "gopkg.in/sdboyer/gps.v1", url: mkurl("https://github.com/sdboyer/gps"), major: 1},
-				maybeGopkginSource{opath: "gopkg.in/sdboyer/gps.v1", url: mkurl("http://github.com/sdboyer/gps"), major: 1},
+				maybeGitSource{url: mkurl("https://github.com/sdboyer/gps")},
+				maybeGitSource{url: mkurl("http://github.com/sdboyer/gps")},
 			},
 		},
 		{
 			in:   "gopkg.in/yaml.v1",
 			root: "gopkg.in/yaml.v1",
 			mb: maybeSources{
-				maybeGopkginSource{opath: "gopkg.in/yaml.v1", url: mkurl("https://github.com/go-yaml/yaml"), major: 1},
-				maybeGopkginSource{opath: "gopkg.in/yaml.v1", url: mkurl("http://github.com/go-yaml/yaml"), major: 1},
+				maybeGitSource{url: mkurl("https://github.com/go-yaml/yaml")},
+				maybeGitSource{url: mkurl("http://github.com/go-yaml/yaml")},
 			},
 		},
 		{
 			in:   "gopkg.in/yaml.v1/foo/bar",
 			root: "gopkg.in/yaml.v1",
 			mb: maybeSources{
-				maybeGopkginSource{opath: "gopkg.in/yaml.v1", url: mkurl("https://github.com/go-yaml/yaml"), major: 1},
-				maybeGopkginSource{opath: "gopkg.in/yaml.v1", url: mkurl("http://github.com/go-yaml/yaml"), major: 1},
+				maybeGitSource{url: mkurl("https://github.com/go-yaml/yaml")},
+				maybeGitSource{url: mkurl("http://github.com/go-yaml/yaml")},
 			},
 		},
 		{
 			in:   "gopkg.in/inf.v0",
 			root: "gopkg.in/inf.v0",
 			mb: maybeSources{
-				maybeGopkginSource{opath: "gopkg.in/inf.v0", url: mkurl("https://github.com/go-inf/inf"), major: 0},
-				maybeGopkginSource{opath: "gopkg.in/inf.v0", url: mkurl("http://github.com/go-inf/inf"), major: 0},
+				maybeGitSource{url: mkurl("https://github.com/go-inf/inf")},
+				maybeGitSource{url: mkurl("http://github.com/go-inf/inf")},
 			},
 		},
 		{
@@ -517,8 +517,6 @@ func TestDeduceFromPath(t *testing.T) {
 					return fmt.Sprintf("%T: %s", tmb, ufmt(tmb.url))
 				case maybeHgSource:
 					return fmt.Sprintf("%T: %s", tmb, ufmt(tmb.url))
-				case maybeGopkginSource:
-					return fmt.Sprintf("%T: %s (v%v) %s ", tmb, tmb.opath, tmb.major, ufmt(tmb.url))
 				default:
 					t.Errorf("Unknown maybeSource type: %T", mb)
 				}

--- a/gps/manager_test.go
+++ b/gps/manager_test.go
@@ -376,24 +376,26 @@ func (f sourceCreationTestFixture) run(t *testing.T) {
 		t.Errorf("want %v gateways in the sources map, but got %v", f.srccount, len(sm.srcCoord.srcs))
 	}
 
-	var keys []string
-	for k := range sm.srcCoord.nameToURL {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
+	if t.Failed() {
+		var keys []string
+		for k := range sm.srcCoord.nameToURL {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
 
-	var buf bytes.Buffer
-	w := tabwriter.NewWriter(&buf, 0, 4, 2, ' ', 0)
-	fmt.Fprint(w, "NAME\tMAPPED URL\n")
-	for _, r := range keys {
-		fmt.Fprintf(w, "%s\t%s\n", r, sm.srcCoord.nameToURL[r])
-	}
-	w.Flush()
-	t.Log("\n", buf.String())
+		var buf bytes.Buffer
+		w := tabwriter.NewWriter(&buf, 0, 4, 2, ' ', 0)
+		fmt.Fprint(w, "NAME\tMAPPED URL\n")
+		for _, r := range keys {
+			fmt.Fprintf(w, "%s\t%s\n", r, sm.srcCoord.nameToURL[r])
+		}
+		w.Flush()
+		t.Log("\n", buf.String())
 
-	t.Log("SRC KEYS")
-	for k := range sm.srcCoord.srcs {
-		t.Log(k)
+		t.Log("SRC KEYS")
+		for k := range sm.srcCoord.srcs {
+			t.Log(k)
+		}
 	}
 }
 
@@ -407,22 +409,22 @@ func TestSourceCreationCounts(t *testing.T) {
 	}
 
 	fixtures := map[string]sourceCreationTestFixture{
-		"gopkgin uniqueness": {
+		"gopkgin merge": {
 			roots: []ProjectIdentifier{
 				mkPI("gopkg.in/sdboyer/gpkt.v1"),
 				mkPI("gopkg.in/sdboyer/gpkt.v2"),
 				mkPI("gopkg.in/sdboyer/gpkt.v3"),
 			},
-			namecount: 6,
-			srccount:  3,
+			namecount: 4,
+			srccount:  1,
 		},
-		"gopkgin separation from github": {
+		"gopkgin maps to github": {
 			roots: []ProjectIdentifier{
 				mkPI("gopkg.in/sdboyer/gpkt.v1"),
 				mkPI("github.com/sdboyer/gpkt"),
 			},
-			namecount: 4,
-			srccount:  2,
+			namecount: 3,
+			srccount:  1,
 		},
 		"case variance across path and URL-based access": {
 			roots: []ProjectIdentifier{

--- a/gps/vcs_source_test.go
+++ b/gps/vcs_source_test.go
@@ -13,8 +13,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
-	"strings"
-	"sync"
 	"testing"
 
 	"github.com/golang/dep/internal/test"
@@ -32,7 +30,6 @@ func TestSlowVcs(t *testing.T) {
 	t.Run("hg-source", testHgSourceInteractions)
 	t.Run("git-repo", testGitRepo)
 	t.Run("git-source", testGitSourceInteractions)
-	t.Run("gopkgin-source", testGopkginSourceInteractions)
 }
 
 func testGitSourceInteractions(t *testing.T) {
@@ -130,175 +127,6 @@ func testGitSourceInteractions(t *testing.T) {
 	} else if !is {
 		t.Errorf("Revision that should exist was not present on re-check")
 	}
-}
-
-func testGopkginSourceInteractions(t *testing.T) {
-	t.Parallel()
-
-	// This test is slowish, skip it on -short
-	if testing.Short() {
-		t.Skip("Skipping gopkg.in source version fetching test in short mode")
-	}
-	requiresBins(t, "git")
-
-	cpath, err := ioutil.TempDir("", "smcache")
-	if err != nil {
-		t.Errorf("Failed to create temp dir: %s", err)
-	}
-	defer func() {
-		if err := os.RemoveAll(cpath); err != nil {
-			t.Errorf("removeAll failed: %s", err)
-		}
-	}()
-	os.Mkdir(filepath.Join(cpath, "sources"), 0777)
-
-	tfunc := func(opath, n string, major uint64, evl []Version) {
-		un := "https://" + opath
-		u, err := url.Parse("https://" + n)
-		if err != nil {
-			t.Errorf("URL was bad, lolwut? errtext: %s", err)
-			return
-		}
-		unstable := strings.HasSuffix(opath, gopkgUnstableSuffix)
-		mb := maybeGopkginSource{
-			opath:    opath,
-			url:      u,
-			major:    major,
-			unstable: unstable,
-		}
-
-		ctx := context.Background()
-		superv := newSupervisor(ctx)
-		isrc, state, err := mb.try(ctx, cpath, newMemoryCache(), superv)
-		if err != nil {
-			t.Errorf("Unexpected error while setting up gopkginSource for test repo: %s", err)
-			return
-		}
-
-		wantstate := sourceIsSetUp | sourceExistsUpstream | sourceHasLatestVersionList
-		if state != wantstate {
-			t.Errorf("Expected return state to be %v, got %v", wantstate, state)
-		}
-
-		err = isrc.initLocal(ctx)
-		if err != nil {
-			t.Fatalf("Error on cloning git repo: %s", err)
-		}
-
-		src, ok := isrc.(*gopkginSource)
-		if !ok {
-			t.Errorf("Expected a gopkginSource, got a %T", isrc)
-			return
-		}
-
-		if un != src.upstreamURL() {
-			t.Errorf("Expected %s as source URL, got %s", un, src.upstreamURL())
-		}
-		if src.major != major {
-			t.Errorf("Expected %v as major version filter on gopkginSource, got %v", major, src.major)
-		}
-
-		// check that an expected rev is present
-		rev := evl[0].(PairedVersion).Revision()
-		is, err := src.revisionPresentIn(rev)
-		if err != nil {
-			t.Errorf("Unexpected error while checking revision presence: %s", err)
-		} else if !is {
-			t.Errorf("Revision %s that should exist was not present", rev)
-		}
-
-		pvlist, err := src.listVersions(ctx)
-		if err != nil {
-			t.Errorf("Unexpected error getting version pairs from hg repo: %s", err)
-		}
-
-		vlist := hidePair(pvlist)
-		if len(vlist) != len(evl) {
-			t.Errorf("gopkgin test repo (%s) should've produced %v versions, got %v.\n%v", un, len(evl), len(vlist), vlist)
-		} else {
-			SortForUpgrade(vlist)
-			if !reflect.DeepEqual(vlist, evl) {
-				t.Errorf("Version list for %s was not what we expected:\n\t(GOT): %#v\n\t(WNT): %#v", un, vlist, evl)
-			}
-		}
-
-		// Run again, this time to ensure cache outputs correctly
-		pvlist, err = src.listVersions(ctx)
-		if err != nil {
-			t.Errorf("Unexpected error getting version pairs from hg repo: %s", err)
-		}
-
-		vlist = hidePair(pvlist)
-		if len(vlist) != len(evl) {
-			t.Errorf("gopkgin test repo should've produced %v versions, got %v", len(evl), len(vlist))
-		} else {
-			SortForUpgrade(vlist)
-			if !reflect.DeepEqual(vlist, evl) {
-				t.Errorf("Version list for %s was not what we expected:\n\t(GOT): %#v\n\t(WNT): %#v", un, vlist, evl)
-			}
-		}
-
-		// recheck that rev is present, this time interacting with cache differently
-		is, err = src.revisionPresentIn(rev)
-		if err != nil {
-			t.Errorf("Unexpected error while re-checking revision presence: %s", err)
-		} else if !is {
-			t.Errorf("Revision that should exist was not present on re-check")
-		}
-	}
-
-	// simultaneously run for v1, v2, and v3 filters of the target repo
-	wg := &sync.WaitGroup{}
-	wg.Add(6)
-
-	go func() {
-		// Treat master as v0 when no other branches/tags exist that match gopkg.in's rules
-		tfunc("gopkg.in/carolynvs/deptest-gopkgin-implicit-v0.v0", "github.com/carolynvs/deptest-gopkgin-implicit-v0", 0, []Version{
-			newDefaultBranch("notmaster").Pair(Revision("94ee631b9833cd805d15f50a52e0533124ec0292")),
-		})
-		wg.Done()
-	}()
-
-	go func() {
-		// Use the existing v0 branch for v0, not master
-		tfunc("gopkg.in/carolynvs/deptest-gopkgin-explicit-v0.v0", "github.com/carolynvs/deptest-gopkgin-explicit-v0", 0, []Version{
-			newDefaultBranch("v0").Pair(Revision("ec73e84554fb28f08dba630e48dbec868e77f734")),
-		})
-		wg.Done()
-	}()
-
-	go func() {
-		tfunc("gopkg.in/sdboyer/gpkt.v1", "github.com/sdboyer/gpkt", 1, []Version{
-			NewVersion("v1.1.0").Pair(Revision("b2cb48dda625f6640b34d9ffb664533359ac8b91")),
-			NewVersion("v1.0.0").Pair(Revision("bf85021c0405edbc4f3648b0603818d641674f72")),
-			newDefaultBranch("v1.1").Pair(Revision("f1fbc520489a98306eb28c235204e39fa8a89c84")),
-			NewBranch("v1").Pair(Revision("e3777f683305eafca223aefe56b4e8ecf103f467")),
-		})
-		wg.Done()
-	}()
-
-	go func() {
-		tfunc("gopkg.in/sdboyer/gpkt.v2", "github.com/sdboyer/gpkt", 2, []Version{
-			NewVersion("v2.0.0").Pair(Revision("4a54adf81c75375d26d376459c00d5ff9b703e5e")),
-		})
-		wg.Done()
-	}()
-
-	go func() {
-		tfunc("gopkg.in/sdboyer/gpkt.v3", "github.com/sdboyer/gpkt", 3, []Version{
-			newDefaultBranch("v3").Pair(Revision("4a54adf81c75375d26d376459c00d5ff9b703e5e")),
-		})
-		wg.Done()
-	}()
-
-	go func() {
-		tfunc("github.com/sdboyer/gpkt2.v1-unstable", "github.com/sdboyer/gpkt2", 1, []Version{
-			newDefaultBranch("v1-unstable").Pair(Revision("24de0be8f4a0b8a44321562117749b257bfcef69")),
-		})
-		wg.Done()
-	}()
-
-	wg.Wait()
 }
 
 func testBzrSourceInteractions(t *testing.T) {


### PR DESCRIPTION
### What does this do / why do we need it?

This PR removes unused gopkgin code.  Special case gopkgin types were used to augment normal git behavior, but they were being given standard github urls, so the special case code was not relevant.  Now gopkgin imports map directly to their github source, avoiding duplication/isolation for each unique gopkgin import.

### Which issue(s) does this PR fix?

Towards #1250 and #431
