### PR TITLE
Add default prune options for init cmd

### DIFF
--- a/cmd/dep/init.go
+++ b/cmd/dep/init.go
@@ -152,6 +152,9 @@ func (cmd *initCommand) Run(ctx *dep.Ctx, args []string) error {
 		return errors.Wrap(err, "init failed: unable to prepare an initial manifest and lock for the solver")
 	}
 
+	// Set default prune options for go-tests and unused-packages
+	p.Manifest.PruneOptions.PruneOptions = gps.PruneNestedVendorDirs + gps.PruneGoTestFiles + gps.PruneUnusedPackages
+
 	if cmd.gopath {
 		gs := newGopathScanner(ctx, directDeps, sm)
 		err = gs.InitializeRootManifestAndLock(p.Manifest, p.Lock)

--- a/cmd/dep/testdata/harness_tests/ensure/add/all-new-double-spec/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/ensure/add/all-new-double-spec/final/Gopkg.toml
@@ -3,6 +3,10 @@
   branch = "master"
   name = "github.com/sdboyer/deptesttres"
 
+[prune]
+  go-tests = true
+  unused-packages = true
+
 [[constraint]]
   name = "github.com/sdboyer/deptest"
   version = "0.8.1"

--- a/cmd/dep/testdata/harness_tests/ensure/add/all-new-double/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/ensure/add/all-new-double/final/Gopkg.toml
@@ -3,6 +3,10 @@
   name = "github.com/sdboyer/deptest"
   version = "1.0.0"
 
+[prune]
+  go-tests = true
+  unused-packages = true
+
 [[constraint]]
   branch = "master"
   name = "github.com/sdboyer/deptesttres"

--- a/cmd/dep/testdata/harness_tests/ensure/add/all-new-spec/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/ensure/add/all-new-spec/final/Gopkg.toml
@@ -3,6 +3,10 @@
   branch = "master"
   name = "github.com/sdboyer/deptesttres"
 
+[prune]
+  go-tests = true
+  unused-packages = true
+
 [[constraint]]
   name = "github.com/sdboyer/deptest"
   version = "0.8.1"

--- a/cmd/dep/testdata/harness_tests/ensure/add/all-new/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/ensure/add/all-new/final/Gopkg.toml
@@ -3,6 +3,10 @@
   branch = "master"
   name = "github.com/sdboyer/deptesttres"
 
+[prune]
+  go-tests = true
+  unused-packages = true
+
 [[constraint]]
   name = "github.com/sdboyer/deptest"
   version = "1.0.0"

--- a/cmd/dep/testdata/harness_tests/ensure/add/errs/double-diff-spec/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/ensure/add/errs/double-diff-spec/final/Gopkg.toml
@@ -2,3 +2,7 @@
 [[constraint]]
   branch = "master"
   name = "github.com/sdboyer/deptesttres"
+
+[prune]
+  go-tests = true
+  unused-packages = true

--- a/cmd/dep/testdata/harness_tests/ensure/add/errs/self-add/case2/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/ensure/add/errs/self-add/case2/final/Gopkg.toml
@@ -1,0 +1,4 @@
+
+[prune]
+  go-tests = true
+  unused-packages = true

--- a/cmd/dep/testdata/harness_tests/ensure/empty/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/ensure/empty/case1/final/Gopkg.toml
@@ -2,3 +2,7 @@
 [[constraint]]
   name = "github.com/sdboyer/deptest"
   version = "1.0.0"
+
+[prune]
+  go-tests = true
+  unused-packages = true

--- a/cmd/dep/testdata/harness_tests/ensure/pkg-errors/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/ensure/pkg-errors/case1/final/Gopkg.toml
@@ -1,0 +1,4 @@
+
+[prune]
+  go-tests = true
+  unused-packages = true

--- a/cmd/dep/testdata/harness_tests/init/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/case1/final/Gopkg.toml
@@ -2,3 +2,7 @@
 [[constraint]]
   name = "github.com/sdboyer/deptest"
   version = "0.8.0"
+
+[prune]
+  go-tests = true
+  unused-packages = true

--- a/cmd/dep/testdata/harness_tests/init/case2/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/case2/final/Gopkg.toml
@@ -6,3 +6,7 @@
 [[constraint]]
   name = "github.com/sdboyer/deptestdos"
   version = "2.0.0"
+
+[prune]
+  go-tests = true
+  unused-packages = true

--- a/cmd/dep/testdata/harness_tests/init/case3/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/case3/final/Gopkg.toml
@@ -2,3 +2,7 @@
 [[constraint]]
   branch = "master"
   name = "github.com/sdboyer/deptest"
+
+[prune]
+  go-tests = true
+  unused-packages = true

--- a/cmd/dep/testdata/harness_tests/init/case4/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/case4/final/Gopkg.toml
@@ -6,3 +6,7 @@
 [[constraint]]
   name = "github.com/sdboyer/deptestdos"
   version = "2.0.0"
+
+[prune]
+  go-tests = true
+  unused-packages = true

--- a/cmd/dep/testdata/harness_tests/init/glide/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/glide/case1/final/Gopkg.toml
@@ -3,3 +3,7 @@ ignored = ["github.com/golang/notexist/samples","github.com/sdboyer/dep-test"]
 [[constraint]]
   name = "github.com/sdboyer/deptestdos"
   version = "2.0.0"
+
+[prune]
+  go-tests = true
+  unused-packages = true

--- a/cmd/dep/testdata/harness_tests/init/glide/case2/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/glide/case2/final/Gopkg.toml
@@ -2,3 +2,7 @@
 [[constraint]]
   name = "github.com/sdboyer/deptestdos"
   version = "2.0.0"
+
+[prune]
+  go-tests = true
+  unused-packages = true

--- a/cmd/dep/testdata/harness_tests/init/glide/case3/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/glide/case3/final/Gopkg.toml
@@ -2,3 +2,7 @@
 [[constraint]]
   name = "github.com/carolynvs/deptestglide"
   version = "0.1.1"
+
+[prune]
+  go-tests = true
+  unused-packages = true

--- a/cmd/dep/testdata/harness_tests/init/glock/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/glock/case1/final/Gopkg.toml
@@ -2,3 +2,7 @@
 [[constraint]]
   name = "github.com/sdboyer/deptestdos"
   version = "2.0.0"
+
+[prune]
+  go-tests = true
+  unused-packages = true

--- a/cmd/dep/testdata/harness_tests/init/godep/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/godep/case1/final/Gopkg.toml
@@ -2,3 +2,7 @@
 [[constraint]]
   name = "github.com/sdboyer/deptestdos"
   version = "2.0.0"
+
+[prune]
+  go-tests = true
+  unused-packages = true

--- a/cmd/dep/testdata/harness_tests/init/govend/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/govend/case1/final/Gopkg.toml
@@ -2,3 +2,7 @@
 [[constraint]]
   name = "github.com/sdboyer/deptestdos"
   version = "2.0.0"
+
+[prune]
+  go-tests = true
+  unused-packages = true

--- a/cmd/dep/testdata/harness_tests/init/govendor/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/govendor/case1/final/Gopkg.toml
@@ -3,3 +3,7 @@ ignored = ["github.com/golang/notexist/samples*","github.com/sdboyer/dep-test*"]
 [[constraint]]
   name = "github.com/sdboyer/deptestdos"
   version = "2.0.0"
+
+[prune]
+  go-tests = true
+  unused-packages = true

--- a/cmd/dep/testdata/harness_tests/init/gvt/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/gvt/case1/final/Gopkg.toml
@@ -10,3 +10,7 @@
 [[constraint]]
   branch = "v2"
   name = "gopkg.in/yaml.v2"
+
+[prune]
+  go-tests = true
+  unused-packages = true

--- a/cmd/dep/testdata/harness_tests/init/relative_path/final/project_dir/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/relative_path/final/project_dir/Gopkg.toml
@@ -2,3 +2,7 @@
 [[constraint]]
   branch = "master"
   name = "github.com/sdboyer/deptest"
+
+[prune]
+  go-tests = true
+  unused-packages = true

--- a/cmd/dep/testdata/harness_tests/init/skip-hidden/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/skip-hidden/final/Gopkg.toml
@@ -2,3 +2,7 @@
 [[constraint]]
   name = "github.com/sdboyer/deptest"
   version = "1.0.0"
+
+[prune]
+  go-tests = true
+  unused-packages = true

--- a/cmd/dep/testdata/harness_tests/init/vndr/case1/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/init/vndr/case1/final/Gopkg.toml
@@ -2,3 +2,7 @@
 [[constraint]]
   name = "github.com/sdboyer/deptestdos"
   version = "2.0.0"
+
+[prune]
+  go-tests = true
+  unused-packages = true

--- a/manifest.go
+++ b/manifest.go
@@ -417,6 +417,23 @@ func fromRawPruneOptions(raw rawPruneOptions) gps.RootPruneOptions {
 	return opts
 }
 
+func toRawPruneOptions(options gps.PruneOptions) rawPruneOptions {
+	raw := rawPruneOptions{}
+
+	if (options & gps.PruneUnusedPackages) != 0 {
+		raw.UnusedPackages = true
+	}
+
+	if (options & gps.PruneNonGoFiles) != 0 {
+		raw.NonGoFiles = true
+	}
+
+	if (options & gps.PruneGoTestFiles) != 0 {
+		raw.GoTests = true
+	}
+	return raw
+}
+
 // toProject interprets the string representations of project information held in
 // a rawProject, converting them into a proper gps.ProjectProperties. An
 // error is returned if the rawProject contains some invalid combination -
@@ -462,11 +479,10 @@ func (m *Manifest) MarshalTOML() ([]byte, error) {
 // toRaw converts the manifest into a representation suitable to write to the manifest file
 func (m *Manifest) toRaw() rawManifest {
 	raw := rawManifest{
-		Constraints:  make([]rawProject, 0, len(m.Constraints)),
-		Overrides:    make([]rawProject, 0, len(m.Ovr)),
-		Ignored:      m.Ignored,
-		Required:     m.Required,
-		PruneOptions: rawPruneOptions{},
+		Constraints: make([]rawProject, 0, len(m.Constraints)),
+		Overrides:   make([]rawProject, 0, len(m.Ovr)),
+		Ignored:     m.Ignored,
+		Required:    m.Required,
 	}
 
 	for n, prj := range m.Constraints {
@@ -479,7 +495,7 @@ func (m *Manifest) toRaw() rawManifest {
 	}
 	sort.Sort(sortedRawProjects(raw.Overrides))
 
-	// TODO(ibrasho): write out prune options.
+	raw.PruneOptions = toRawPruneOptions(m.PruneOptions.PruneOptions)
 
 	return raw
 }

--- a/manifest.go
+++ b/manifest.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/golang/dep/gps"
 	"github.com/golang/dep/gps/pkgtree"
-	"github.com/pelletier/go-toml"
+	toml "github.com/pelletier/go-toml"
 	"github.com/pkg/errors"
 )
 
@@ -417,18 +417,25 @@ func fromRawPruneOptions(raw rawPruneOptions) gps.RootPruneOptions {
 	return opts
 }
 
-func toRawPruneOptions(options gps.PruneOptions) rawPruneOptions {
+// toRawPruneOptions converts a gps.RootPruneOption's PruneOptions to rawPruneOptions
+//
+// Will panic if gps.RootPruneOption includes ProjectPruneOptions
+// See https://github.com/golang/dep/pull/1460#discussion_r158128740 for more information
+func toRawPruneOptions(root gps.RootPruneOptions) rawPruneOptions {
+	if len(root.ProjectOptions) != 0 {
+		panic("toRawPruneOptions cannot convert ProjectOptions to rawPruneOptions")
+	}
 	raw := rawPruneOptions{}
 
-	if (options & gps.PruneUnusedPackages) != 0 {
+	if (root.PruneOptions & gps.PruneUnusedPackages) != 0 {
 		raw.UnusedPackages = true
 	}
 
-	if (options & gps.PruneNonGoFiles) != 0 {
+	if (root.PruneOptions & gps.PruneNonGoFiles) != 0 {
 		raw.NonGoFiles = true
 	}
 
-	if (options & gps.PruneGoTestFiles) != 0 {
+	if (root.PruneOptions & gps.PruneGoTestFiles) != 0 {
 		raw.GoTests = true
 	}
 	return raw
@@ -495,7 +502,7 @@ func (m *Manifest) toRaw() rawManifest {
 	}
 	sort.Sort(sortedRawProjects(raw.Overrides))
 
-	raw.PruneOptions = toRawPruneOptions(m.PruneOptions.PruneOptions)
+	raw.PruneOptions = toRawPruneOptions(m.PruneOptions)
 
 	return raw
 }

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -611,12 +611,12 @@ func TestValidateProjectRoots(t *testing.T) {
 func TestToRawPruneOptions(t *testing.T) {
 	cases := []struct {
 		name         string
-		pruneOptions gps.PruneOptions
+		pruneOptions gps.RootPruneOptions
 		wantOptions  rawPruneOptions
 	}{
 		{
 			name:         "all options",
-			pruneOptions: 15,
+			pruneOptions: gps.RootPruneOptions{PruneOptions: 15},
 			wantOptions: rawPruneOptions{
 				UnusedPackages: true,
 				NonGoFiles:     true,
@@ -625,7 +625,7 @@ func TestToRawPruneOptions(t *testing.T) {
 		},
 		{
 			name:         "no options",
-			pruneOptions: 1,
+			pruneOptions: gps.RootPruneOptions{PruneOptions: 1},
 			wantOptions: rawPruneOptions{
 				UnusedPackages: false,
 				NonGoFiles:     false,
@@ -643,6 +643,19 @@ func TestToRawPruneOptions(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestToRawPruneOptions_Panic(t *testing.T) {
+	pruneOptions := gps.RootPruneOptions{
+		PruneOptions:   1,
+		ProjectOptions: gps.PruneProjectOptions{"github.com/carolynvs/deptest": 1},
+	}
+	defer func() {
+		if err := recover(); err == nil {
+			t.Error("toRawPruneOptions did not panic with non-empty ProjectOptions")
+		}
+	}()
+	_ = toRawPruneOptions(pruneOptions)
 }
 
 func containsErr(s []error, e error) bool {

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -608,6 +608,43 @@ func TestValidateProjectRoots(t *testing.T) {
 	}
 }
 
+func TestToRawPruneOptions(t *testing.T) {
+	cases := []struct {
+		name         string
+		pruneOptions gps.PruneOptions
+		wantOptions  rawPruneOptions
+	}{
+		{
+			name:         "all options",
+			pruneOptions: 15,
+			wantOptions: rawPruneOptions{
+				UnusedPackages: true,
+				NonGoFiles:     true,
+				GoTests:        true,
+			},
+		},
+		{
+			name:         "no options",
+			pruneOptions: 1,
+			wantOptions: rawPruneOptions{
+				UnusedPackages: false,
+				NonGoFiles:     false,
+				GoTests:        false,
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			raw := toRawPruneOptions(c.pruneOptions)
+
+			if !reflect.DeepEqual(raw, c.wantOptions) {
+				t.Fatalf("rawPruneOptions are not as expected:\n\t(GOT) %v\n\t(WNT) %v", raw, c.wantOptions)
+			}
+		})
+	}
+}
+
 func containsErr(s []error, e error) bool {
 	for _, a := range s {
 		if a.Error() == e.Error() {

--- a/testdata/txn_writer/expected_manifest.toml
+++ b/testdata/txn_writer/expected_manifest.toml
@@ -16,8 +16,13 @@
 #   source = "github.com/myfork/project2"
 #
 # [[override]]
-#  name = "github.com/x/y"
-#  version = "2.4.0"
+#   name = "github.com/x/y"
+#   version = "2.4.0"
+#
+# [prune]
+#   non-go = false
+#   go-tests = true
+#   unused-packages = true
 
 
 [[constraint]]

--- a/txn_writer.go
+++ b/txn_writer.go
@@ -39,8 +39,13 @@ var exampleTOML = []byte(`# Gopkg.toml example
 #   source = "github.com/myfork/project2"
 #
 # [[override]]
-#  name = "github.com/x/y"
-#  version = "2.4.0"
+#   name = "github.com/x/y"
+#   version = "2.4.0"
+#
+# [prune]
+#   non-go = false
+#   go-tests = true
+#   unused-packages = true
 
 `)
 


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

### What does this do / why do we need it?

- Adds default prune options on `init`
- Updates example comment in manifest to include default prune settings

### What should your reviewer look out for in this PR?

- How defaults are set in `init.go`
- The examples comment in `txn_writer.go`

### Do you need help or clarification on anything?

Do we need tests for `toRawPruneOptions`?

### Which issue(s) does this PR fix?

fixes #1404
