### PR TITLE
status: use unpaired ver constr when checking updateability

### DIFF
--- a/cmd/dep/status.go
+++ b/cmd/dep/status.go
@@ -551,7 +551,8 @@ func runStatusAll(ctx *dep.Ctx, out outputter, p *dep.Project, sm gps.SourceMana
 						// Get constraint for locked project
 						for _, lockedP := range p.Lock.P {
 							if lockedP.Ident().ProjectRoot == proj.Ident().ProjectRoot {
-								c.Constraint = lockedP.Version()
+								// Use the unpaired version as the constraint for checking updates.
+								c.Constraint = bs.Version
 							}
 						}
 					}


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

### What does this do / why do we need it?
This changes fixes a bug due to which the LATEST field in status was
missing for projects that were not in manifest but in lock and had
pairedVersion.

Since we check `bs.Version` to not be nil before entering into
updateability block, we can use the same value as the constraint for
matching with the version list obtained for the projects.

### What should your reviewer look out for in this PR?
Impact of this change in other part of the code.

### Do you need help or clarification on anything?

### Which issue(s) does this PR fix?
Fixes #1462

<!--

fixes #
fixes #

-->
