### PR TITLE
Note diffs b/w imported and solved lock

### DIFF
--- a/cmd/dep/root_analyzer.go
+++ b/cmd/dep/root_analyzer.go
@@ -167,6 +167,9 @@ func (a *rootAnalyzer) DeriveManifestAndLock(dir string, pr gps.ProjectRoot) (gp
 func (a *rootAnalyzer) FinalizeRootManifestAndLock(m *dep.Manifest, l *dep.Lock, ol dep.Lock) {
 	// Iterate through the new projects in solved lock and add them to manifest
 	// if they are direct deps and log feedback for all the new projects.
+	diff := gps.DiffLocks(&ol, l)
+	bi := fb.NewBrokenImportFeedback(diff)
+	bi.LogFeedback(a.ctx.Err)
 	for _, y := range l.Projects() {
 		var f *fb.ConstraintFeedback
 		pr := y.Ident().ProjectRoot

--- a/internal/feedback/feedback.go
+++ b/internal/feedback/feedback.go
@@ -148,13 +148,7 @@ func GetUsingFeedback(version, consType, depType, projectPath string) string {
 //    Locking in v1.1.4 (bc29b4f) for direct dep github.com/foo/bar
 //    Locking in master (436f39d) for transitive dep github.com/baz/qux
 func GetLockingFeedback(version, revision, depType, projectPath string) string {
-	// Check if it's a valid SHA1 digest and trim to 7 characters.
-	if len(revision) == 40 {
-		if _, err := hex.DecodeString(revision); err == nil {
-			// Valid SHA1 digest
-			revision = revision[0:7]
-		}
-	}
+	revision = trimSHA(revision)
 
 	if depType == DepTypeImported {
 		if version == "" {
@@ -165,6 +159,7 @@ func GetLockingFeedback(version, revision, depType, projectPath string) string {
 	return fmt.Sprintf("Locking in %s (%s) for %s %s", version, revision, depType, projectPath)
 }
 
+// trimSHA checks if revision is a valid SHA1 digest and trims to 7 characters.
 func trimSHA(revision string) string {
 	if len(revision) == 40 {
 		if _, err := hex.DecodeString(revision); err == nil {

--- a/internal/feedback/feedback.go
+++ b/internal/feedback/feedback.go
@@ -154,7 +154,7 @@ func (ri removedImport) String() string {
 	}
 
 	// Warning: Unable to preserve imported lock VERSION/BRANCH (REV) for PROJECT(SOURCE). Locking in VERSION/BRANCH (REV) for PROJECT(SOURCE)
-	return fmt.Sprintf("%v %s for %s.  The project was removed from the lock because it is not used.",
+	return fmt.Sprintf("%v %s for %s. The project was removed from the lock because it is not used.",
 		pv,
 		pr,
 		pp,

--- a/internal/feedback/feedback.go
+++ b/internal/feedback/feedback.go
@@ -119,14 +119,7 @@ func (mi modifiedImport) String() string {
 	}
 
 	// Warning: Unable to preserve imported lock VERSION/BRANCH (REV) for PROJECT(SOURCE). Locking in VERSION/BRANCH (REV) for PROJECT(SOURCE)
-	return fmt.Sprintf("%v %s for %s. Locking in %v %s%s",
-		pv,
-		pr,
-		pp,
-		cv,
-		cr,
-		cp,
-	)
+	return fmt.Sprintf("%v %s for %s. Locking in %v %s%s", pv, pr, pp, cv, cr, cp)
 }
 
 type removedImport struct {
@@ -154,11 +147,7 @@ func (ri removedImport) String() string {
 	}
 
 	// Warning: Unable to preserve imported lock VERSION/BRANCH (REV) for PROJECT(SOURCE). Locking in VERSION/BRANCH (REV) for PROJECT(SOURCE)
-	return fmt.Sprintf("%v %s for %s. The project was removed from the lock because it is not used.",
-		pv,
-		pr,
-		pp,
-	)
+	return fmt.Sprintf("%v %s for %s. The project was removed from the lock because it is not used.", pv, pr, pp)
 }
 
 // BrokenImportFeedback holds problematic lock feedback data

--- a/internal/feedback/feedback.go
+++ b/internal/feedback/feedback.go
@@ -150,12 +150,13 @@ func (ri removedImport) String() string {
 	return fmt.Sprintf("%v %s for %s. The project was removed from the lock because it is not used.", pv, pr, pp)
 }
 
-// BrokenImportFeedback holds problematic lock feedback data
+// BrokenImportFeedback holds information on changes to locks pre- and post- solving.
 type BrokenImportFeedback struct {
 	brokenImports []brokenImport
 }
 
-// NewBrokenImportFeedback builds a feedback entry for problems with imports from a diff of the pre- and post- solved locks
+// NewBrokenImportFeedback builds a feedback entry that compares an initially
+// imported, unsolved lock to the same lock after it has been solved.
 func NewBrokenImportFeedback(ld *gps.LockDiff) *BrokenImportFeedback {
 	bi := &BrokenImportFeedback{}
 	for _, lpd := range ld.Modify {

--- a/internal/feedback/feedback.go
+++ b/internal/feedback/feedback.go
@@ -105,11 +105,12 @@ func (bi brokenImport) String() string {
 	)
 }
 
-// ConstraintFeedback holds project constraint feedback data
+// BrokenImportFeedback holds problematic lock feedback data
 type BrokenImportFeedback struct {
 	brokenImports []brokenImport
 }
 
+// NewBrokenImportFeedback builds a feedback entry for problems with imports from a diff of the pre- and post- solved locks
 func NewBrokenImportFeedback(ld *gps.LockDiff) *BrokenImportFeedback {
 	bi := &BrokenImportFeedback{}
 	for _, lpd := range ld.Modify {
@@ -123,6 +124,7 @@ func NewBrokenImportFeedback(ld *gps.LockDiff) *BrokenImportFeedback {
 	return bi
 }
 
+// LogFeedback logs a warning for all changes between the initially imported and post- solve locks
 func (b BrokenImportFeedback) LogFeedback(logger *log.Logger) {
 	for _, bi := range b.brokenImports {
 		logger.Printf("Warning: Unable to preserve imported lock %v\n", bi)

--- a/internal/feedback/feedback.go
+++ b/internal/feedback/feedback.go
@@ -170,6 +170,10 @@ type BrokenImportFeedback struct {
 func NewBrokenImportFeedback(ld *gps.LockDiff) *BrokenImportFeedback {
 	bi := &BrokenImportFeedback{}
 	for _, lpd := range ld.Modify {
+		// Ignore diffs where it's just a modified package set
+		if lpd.Branch == nil && lpd.Revision == nil && lpd.Source == nil && lpd.Version == nil {
+			continue
+		}
 		bi.brokenImports = append(bi.brokenImports, modifiedImport{
 			projectPath: string(lpd.Name),
 			source:      lpd.Source,

--- a/internal/feedback/feedback_test.go
+++ b/internal/feedback/feedback_test.go
@@ -98,7 +98,6 @@ func TestFeedback_BrokenImport(t *testing.T) {
 	pi := gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot("github.com/foo/bar")}
 
 	cases := []struct {
-		diff           *gps.LockDiff
 		oldVersion     gps.Version
 		currentVersion gps.Version
 		pID            gps.ProjectIdentifier

--- a/internal/feedback/feedback_test.go
+++ b/internal/feedback/feedback_test.go
@@ -106,17 +106,15 @@ func TestFeedback_BrokenImport(t *testing.T) {
 		P: []gps.LockedProject{gps.NewLockedProject(pi, lv, nil)},
 	}
 
-	diff := gps.DiffLocks(&ol, &l)
-
 	cases := []struct {
-		feedback *BrokenImportFeedback
-		want     string
-		name     string
+		diff *gps.LockDiff
+		want string
+		name string
 	}{
 		{
-			feedback: NewBrokenImportFeedback(diff),
-			want:     "Warning: Unable to preserve imported lock v1.1.4 (bc29b4f) for github.com/foo/bar. Locking in v1.2.0 (ia3da28)",
-			name:     "Basic broken import",
+			diff: gps.DiffLocks(&ol, &l),
+			want: "Warning: Unable to preserve imported lock v1.1.4 (bc29b4f) for github.com/foo/bar. Locking in v1.2.0 (ia3da28)",
+			name: "Basic broken import",
 		},
 	}
 
@@ -124,7 +122,8 @@ func TestFeedback_BrokenImport(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			buf := &bytes.Buffer{}
 			log := log2.New(buf, "", 0)
-			c.feedback.LogFeedback(log)
+			feedback := NewBrokenImportFeedback(c.diff)
+			feedback.LogFeedback(log)
 			got := strings.TrimSpace(buf.String())
 			if c.want != got {
 				t.Errorf("Feedbacks are not expected: \n\t(GOT) '%s'\n\t(WNT) '%s'", got, c.want)


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

### What does this do / why do we need it?

This is pass at #908 , which intends to inform users when changes have been made from their imported revisions.

In addition to giving the user feedback, this PR changes the implementation of:https://github.com/golang/dep/blob/a92678159ec741a4d28f4b2ea4727de1156ab823/cmd/dep/root_analyzer.go#L167 
to use a map of the projects in the old lock in order to:
a. Find projects that exist in the new and old locks for diffing
b. Find projects that are only in the new lock for `NewLockedProjectFeedback`

### What should your reviewer look out for in this PR?
Am I even on the right track? I may be misunderstanding the differences b/w locks, constraints, and manifest (the terms are a bit fuzzy as yet) or what I'm actually to compare to see a change.

### Do you need help or clarification on anything?
- Am I looking at the right data to check if a pertinent change has happened?
- Is the `Feedback` pattern the right way to propagate this information? If so, does the necessitate a new kind of feedback eg `NewDiffFeedback`? Right now I'm just logging to the console which is, obviously, not a final method of relaying this feedback.
- As a corollary, if I'm going to use a `LockedProjectDiff` for the feedback, I'm considering teaching that type `String()`. Any thoughts on that?

### Which issue(s) does this PR fix?
Fixes #908 
<!--

fixes #
fixes #

-->
