### PR TITLE
cmd/dep: apply default prune options on init

### DIFF
--- a/cmd/dep/init.go
+++ b/cmd/dep/init.go
@@ -214,7 +214,7 @@ func (cmd *initCommand) Run(ctx *dep.Ctx, args []string) error {
 		ctx.Err.Printf("Old vendor backed up to %v", vendorbak)
 	}
 
-	sw, err := dep.NewSafeWriter(p.Manifest, nil, p.Lock, dep.VendorAlways, gps.DefaultRootPruneOptions())
+	sw, err := dep.NewSafeWriter(p.Manifest, nil, p.Lock, dep.VendorAlways, p.Manifest.PruneOptions)
 	if err != nil {
 		return errors.Wrap(err, "init failed: unable to create a SafeWriter")
 	}


### PR DESCRIPTION
Use the default prune options set on the manifest to immediately prune vendor when it is written.

Follow-on to #1460.

/cc @arbourd 