### PR TITLE
Improve error message when gopath dependency exists but lacks VCS

### DIFF
--- a/cmd/dep/gopath_scanner.go
+++ b/cmd/dep/gopath_scanner.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -119,17 +120,32 @@ func (g *gopathScanner) overlay(rootM *dep.Manifest, rootL *dep.Lock) {
 	}
 
 	// Identify projects whose version is unknown and will have to be solved for
-	var unlockedProjects []string
+	var missing []string    // all project roots missing from GOPATH
+	var missingVCS []string // all project roots missing VCS information
 	for pr := range g.pd.notondisk {
 		if _, isLocked := lockedProjects[pr]; isLocked {
 			continue
 		}
-		unlockedProjects = append(unlockedProjects, string(pr))
+		if g.pd.invalidSVC[pr] {
+			missingVCS = append(missingVCS, string(pr))
+		} else {
+			missing = append(missing, string(pr))
+		}
 	}
-	if len(unlockedProjects) > 0 {
-		g.ctx.Err.Printf("Following dependencies were not found in GOPATH. "+
-			"Dep will use the most recent versions of these projects.\n  %s",
-			strings.Join(unlockedProjects, "\n  "))
+
+	missingStr := ""
+	missingVCSStr := ""
+	if len(missing) > 0 {
+		missingStr = fmt.Sprintf("Following dependencies were not found in GOPATH:\n  %s\n",
+			strings.Join(missing, "\n  "))
+	}
+	if len(missingVCS) > 0 {
+		missingVCSStr = fmt.Sprintf("Following dependencies found in GOPATH were missing VCS information:\n  %s\n",
+			strings.Join(missingVCS, "\n  "))
+	}
+	if len(missingVCS)+len(missing) > 0 {
+		g.ctx.Err.Printf("%s%sDep will use the most recent versions of these projects."+
+			" (Dep will not work if a remote source for these projects doesn't exist)\n\n", missingStr, missingVCSStr)
 	}
 }
 
@@ -181,6 +197,7 @@ type projectData struct {
 	constraints  gps.ProjectConstraints          // constraints that could be found
 	dependencies map[gps.ProjectRoot][]string    // all dependencies (imports) found by project root
 	notondisk    map[gps.ProjectRoot]bool        // projects that were not found on disk
+	invalidSVC   map[gps.ProjectRoot]bool        // projects that were found on disk but SVC data could not be read
 	ondisk       map[gps.ProjectRoot]gps.Version // projects that were found on disk
 }
 
@@ -189,6 +206,7 @@ func (g *gopathScanner) scanGopathForDependencies() (projectData, error) {
 	dependencies := make(map[gps.ProjectRoot][]string)
 	packages := make(map[string]bool)
 	notondisk := make(map[gps.ProjectRoot]bool)
+	invalidSVC := make(map[gps.ProjectRoot]bool)
 	ondisk := make(map[gps.ProjectRoot]gps.Version)
 
 	var syncDepGroup sync.WaitGroup
@@ -225,6 +243,7 @@ func (g *gopathScanner) scanGopathForDependencies() (projectData, error) {
 		}
 		v, err := gps.VCSVersion(abs)
 		if err != nil {
+			invalidSVC[pr] = true
 			notondisk[pr] = true
 			continue
 		}
@@ -379,6 +398,7 @@ func (g *gopathScanner) scanGopathForDependencies() (projectData, error) {
 	pd := projectData{
 		constraints:  constraints,
 		dependencies: dependencies,
+		invalidSVC:   invalidSVC,
 		notondisk:    notondisk,
 		ondisk:       ondisk,
 	}

--- a/cmd/dep/gopath_scanner.go
+++ b/cmd/dep/gopath_scanner.go
@@ -136,16 +136,15 @@ func (g *gopathScanner) overlay(rootM *dep.Manifest, rootL *dep.Lock) {
 	missingStr := ""
 	missingVCSStr := ""
 	if len(missing) > 0 {
-		missingStr = fmt.Sprintf("Following dependencies were not found in GOPATH:\n  %s\n",
+		missingStr = fmt.Sprintf("The following dependencies were not found in GOPATH:\n  %s\n\n",
 			strings.Join(missing, "\n  "))
 	}
 	if len(missingVCS) > 0 {
-		missingVCSStr = fmt.Sprintf("Following dependencies found in GOPATH were missing VCS information:\n  %s\n",
+		missingVCSStr = fmt.Sprintf("The following dependencies found in GOPATH were missing VCS information (a remote source is required):\n  %s\n\n",
 			strings.Join(missingVCS, "\n  "))
 	}
 	if len(missingVCS)+len(missing) > 0 {
-		g.ctx.Err.Printf("%s%sDep will use the most recent versions of these projects."+
-			" (Dep will not work if a remote source for these projects doesn't exist)\n\n", missingStr, missingVCSStr)
+		g.ctx.Err.Printf("\n%s%sThe most recent version of these projects will be used.\n\n", missingStr, missingVCSStr)
 	}
 }
 


### PR DESCRIPTION
### What does this do / why do we need it?
When the -gopath flag is used with dep init, it currently displays the error message that `Following dependencies were not found in GOPATH` when the VCS info returns an error, even if the dependency actually exists in the GOPATH. Showing the user which project roots didn't exist and which ones existed but had problematic version info would lead to less confusion. 

### What should your reviewer look out for in this PR?
I wasn't sure of the best way to go about doing this. Basically, in the `scanGopathForDependencies` method, there it is checking `g.ctx.AbsForImport` and `gps.VCSVersion` which both end up setting notondisk[pr] for that item. The errors from gps.VCSVersion don't really mean that that the root was not on disk, but rather the VCS info had an error. I didn't want to mess with notondisk so I created another map to keep track of which project roots received an error for gps.VCSVersion and then used that info for displaying the error. Is there be a better way to go about doing this?

### Which issue(s) does this PR fix?
fixes #1416 