### PR TITLE
Collect Applicable Constraints

### DIFF
--- a/cmd/dep/status.go
+++ b/cmd/dep/status.go
@@ -20,6 +20,7 @@ import (
 	"github.com/golang/dep"
 	"github.com/golang/dep/gps"
 	"github.com/golang/dep/gps/paths"
+	"github.com/golang/dep/gps/pkgtree"
 	"github.com/pkg/errors"
 )
 
@@ -793,12 +794,23 @@ func collectConstraints(ctx *dep.Ctx, p *dep.Project, sm gps.SourceManager) (con
 			// Get project constraints.
 			pc := manifest.DependencyConstraints()
 
+			imports, err := projectImports(sm, proj)
+			if err != nil {
+				errCh <- errors.Wrapf(err, "error listing imports used in %s", proj.Ident().ProjectRoot)
+				return
+			}
+
 			// Obtain a lock for constraintCollection.
 			mutex.Lock()
 			defer mutex.Unlock()
 			// Iterate through the project constraints to get individual dependency
 			// project and constraint values.
 			for pr, pp := range pc {
+				// Check if the project constraint is imported in the project
+				if _, ok := imports[string(pr)]; !ok {
+					continue
+				}
+
 				tempCC := append(
 					constraintCollection[string(pr)],
 					projectConstraint{proj.Ident().ProjectRoot, pp.Constraint},
@@ -824,6 +836,29 @@ func collectConstraints(ctx *dep.Ctx, p *dep.Project, sm gps.SourceManager) (con
 	}
 
 	return constraintCollection, errs
+}
+
+// projectImports creates a set of all imports paths used in a project.
+// The set of imports be used to check if an package is imported in a project.
+func projectImports(sm gps.SourceManager, proj gps.LockedProject) (map[string]bool, error) {
+	pkgTree, err := sm.ListPackages(proj.Ident(), proj.Version())
+	if err != nil {
+		return nil, err
+	}
+	return packageTreeImports(pkgTree), nil
+}
+
+func packageTreeImports(pkgTree pkgtree.PackageTree) map[string]bool {
+	imports := make(map[string]bool)
+	for _, pkg := range pkgTree.Packages {
+		if pkg.Err != nil {
+			continue
+		}
+		for _, imp := range pkg.P.Imports {
+			imports[imp] = true
+		}
+	}
+	return imports
 }
 
 type byProject []projectConstraint

--- a/cmd/dep/status_test.go
+++ b/cmd/dep/status_test.go
@@ -387,7 +387,7 @@ func TestCollectConstraints(t *testing.T) {
 			lock: dep.Lock{
 				P: []gps.LockedProject{
 					gps.NewLockedProject(
-						gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot("github.com/JackyChiu/dep-applicable-constraints")},
+						gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot("github.com/darkowlzz/dep-applicable-constraints")},
 						gps.NewVersion("v1.0.0"),
 						[]string{"."},
 					),
@@ -395,10 +395,10 @@ func TestCollectConstraints(t *testing.T) {
 			},
 			wantConstraints: constraintsCollection{
 				"github.com/boltdb/bolt": []projectConstraint{
-					{"github.com/JackyChiu/dep-applicable-constraints", gps.NewBranch("master")},
+					{"github.com/darkowlzz/dep-applicable-constraints", gps.NewBranch("master")},
 				},
 				"github.com/sdboyer/deptest": []projectConstraint{
-					{"github.com/JackyChiu/dep-applicable-constraints", ver08},
+					{"github.com/darkowlzz/dep-applicable-constraints", ver08},
 				},
 			},
 		},

--- a/cmd/dep/status_test.go
+++ b/cmd/dep/status_test.go
@@ -382,6 +382,23 @@ func TestCollectConstraints(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "collect only applicable constraints",
+			lock: dep.Lock{
+				P: []gps.LockedProject{
+					gps.NewLockedProject(
+						gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot("github.com/JackyChiu/deptest")},
+						gps.NewVersion("v1.0.0"),
+						[]string{"."},
+					),
+				},
+			},
+			wantConstraints: constraintsCollection{
+				"github.com/sdboyer/deptest": []projectConstraint{
+					{"github.com/JackyChiu/deptest", ver08},
+				},
+			},
+		},
 	}
 
 	h := test.NewHelper(t)
@@ -418,6 +435,65 @@ func TestCollectConstraints(t *testing.T) {
 
 			if !reflect.DeepEqual(gotConstraints, c.wantConstraints) {
 				t.Fatalf("unexpected collected constraints: \n\t(GOT): %v\n\t(WNT): %v", gotConstraints, c.wantConstraints)
+			}
+		})
+	}
+}
+
+func TestProjectImports(t *testing.T) {
+	cases := []struct {
+		name     string
+		proj     gps.LockedProject
+		expected map[string]bool
+	}{
+		{
+			name: "no imports",
+			proj: gps.NewLockedProject(
+				gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot("github.com/sdboyer/deptest")},
+				gps.NewVersion("v1.0.0"),
+				[]string{"."},
+			),
+			expected: map[string]bool{},
+		},
+		{
+			name: "mutilple imports",
+			proj: gps.NewLockedProject(
+				gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot("github.com/darkowlzz/deptest-project-1")},
+				gps.NewVersion("v0.1.0"),
+				[]string{"."},
+			),
+			expected: map[string]bool{
+				"fmt": true,
+				"github.com/sdboyer/deptest": true,
+			},
+		},
+	}
+
+	h := test.NewHelper(t)
+	defer h.Cleanup()
+
+	h.TempDir("src")
+	pwd := h.Path(".")
+	discardLogger := log.New(ioutil.Discard, "", 0)
+
+	ctx := &dep.Ctx{
+		GOPATH: pwd,
+		Out:    discardLogger,
+		Err:    discardLogger,
+	}
+
+	sm, err := ctx.SourceManager()
+	h.Must(err)
+	defer sm.Release()
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			imports, err := projectImports(sm, c.proj)
+			if err != nil {
+				t.Fatalf("unexpected error while getting project imports: %v", err)
+			}
+			if !reflect.DeepEqual(imports, c.expected) {
+				t.Fatalf("unexpected project imports: \n\t(GOT): %v\n\t(WNT): %v", imports, c.expected)
 			}
 		})
 	}

--- a/cmd/dep/status_test.go
+++ b/cmd/dep/status_test.go
@@ -305,7 +305,6 @@ func TestCollectConstraints(t *testing.T) {
 	ver1, _ := gps.NewSemverConstraintIC("v1.0.0")
 	ver08, _ := gps.NewSemverConstraintIC("v0.8.0")
 	ver2, _ := gps.NewSemverConstraintIC("v2.0.0")
-	master := gps.NewBranch("master")
 
 	cases := []struct {
 		name            string
@@ -396,7 +395,7 @@ func TestCollectConstraints(t *testing.T) {
 			},
 			wantConstraints: constraintsCollection{
 				"github.com/boltdb/bolt": []projectConstraint{
-					{"github.com/JackyChiu/dep-applicable-constraints", master},
+					{"github.com/JackyChiu/dep-applicable-constraints", gps.NewBranch("master")},
 				},
 				"github.com/sdboyer/deptest": []projectConstraint{
 					{"github.com/JackyChiu/dep-applicable-constraints", ver08},


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

### What does this do / why do we need it?
Makes the [`collectConstraints`](https://github.com/golang/dep/blob/5b317da10a7d7a7470d12ef1f8a5fcc592d0238b/cmd/dep/status.go#L751) method collection only applicable constraints (constraints that are actually imported in the project). Does so by checking project constraints against direct deps.  

### What should your reviewer look out for in this PR?
Implementation improvements
- [x] TODO: Have a maintainer fork test project [fixture](https://github.com/JackyChiu/dep-applicable-constraints) and then update project root in tests

### Do you need help or clarification on anything?
- [x] Would like some help in creating a fixture for a test case in [`TestCollectConstraints`](https://github.com/golang/dep/blob/5b317da10a7d7a7470d12ef1f8a5fcc592d0238b/cmd/dep/status_test.go#L304) where the imports don't use all the constraints. Since it seems like only the maintainers should have their projects in the tests.

### Which issue(s) does this PR fix?
fixes #1409 

