### PR TITLE
Add optional '-v' flag to ensure args help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ BUG FIXES:
 * Validate `git ls-remote` output and ignore all malformed lines (#1379)
 * Support [gopkg.in version zero](http://labix.org/gopkg.in#VersionZero) (#1243).
 * Fix how dep status print revision constraints. (#1421)
+* Add optional `-v` flag to ensure help output. (#1458)
 
 IMPROVEMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ BUG FIXES:
 * Validate `git ls-remote` output and ignore all malformed lines (#1379)
 * Support [gopkg.in version zero](http://labix.org/gopkg.in#VersionZero) (#1243).
 * Fix how dep status print revision constraints. (#1421)
-* Add optional `-v` flag to ensure help output. (#1458)
+* Add optional `-v` flag to ensure sub command's syntax. (#1458)
 
 IMPROVEMENTS:
 

--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -126,7 +126,7 @@ var (
 
 func (cmd *ensureCommand) Name() string { return "ensure" }
 func (cmd *ensureCommand) Args() string {
-	return "[-update | -add] [-no-vendor | -vendor-only] [-dry-run] [<spec>...]"
+	return "[-update | -add] [-no-vendor | -vendor-only] [-dry-run] [-v] [<spec>...]"
 }
 func (cmd *ensureCommand) ShortHelp() string { return ensureShortHelp }
 func (cmd *ensureCommand) LongHelp() string  { return ensureLongHelp }

--- a/cmd/dep/ensure_test.go
+++ b/cmd/dep/ensure_test.go
@@ -193,6 +193,15 @@ func TestValidateUpdateArgs(t *testing.T) {
 			},
 			lockedProjects: []string{"github.com/golang/dep"},
 		},
+		{
+			name:      "flags after spec",
+			args:      []string{"github.com/golang/dep@master", "-v"},
+			wantError: errUpdateArgsValidation,
+			wantWarn: []string{
+				"could not infer project root from dependency path",
+			},
+			lockedProjects: []string{"github.com/golang/dep"},
+		},
 	}
 
 	h := test.NewHelper(t)


### PR DESCRIPTION
### What does this do / why do we need it?
Details use of '-v' command line option in the ensure sub command.

### What should your reviewer look out for in this PR?
Look for the updated command line option syntax and an associated test case.

### Do you need help or clarification on anything?
No

### Which issue(s) does this PR fix?
Fixes #1458 
