### PR TITLE
upgrade github.com/jmank88/nuts to 0.3.0

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -41,8 +41,8 @@
 [[projects]]
   name = "github.com/jmank88/nuts"
   packages = ["."]
-  revision = "a1e02c788669d022c325a8ee674f15360d7104f4"
-  version = "v0.2.0"
+  revision = "8b28145dffc87104e66d074f62ea8080edfad7c8"
+  version = "v0.3.0"
 
 [[projects]]
   branch = "master"
@@ -89,6 +89,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "05c1cd69be2c917c0cc4b32942830c2acfa044d8200fdc94716aae48a8083702"
+  inputs-digest = "e70d26b359aed7af66f3393fc9d4985bbcf499c0b5ed3b5661a5912b4c71a32e"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -25,7 +25,7 @@
 
 [[constraint]]
   name = "github.com/jmank88/nuts"
-  version = "0.2.0"
+  version = "0.3.0"
 
 [[constraint]]
   name = "github.com/golang/protobuf"

--- a/vendor/github.com/jmank88/nuts/Gopkg.lock
+++ b/vendor/github.com/jmank88/nuts/Gopkg.lock
@@ -9,12 +9,6 @@
 
 [[projects]]
   branch = "master"
-  name = "github.com/dgryski/go-metro"
-  packages = ["."]
-  revision = "0f6473574cdfd7be3962c41fb23dc4768b1f7deb"
-
-[[projects]]
-  branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix"]
   revision = "7ddbeae9ae08c6a06a59597f0c9edbc5ff2444ce"
@@ -22,6 +16,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "051cec76ab73ca227eb718f999fe302404bd5b6673fc29b438eb5945e97f571b"
+  inputs-digest = "568758fa97eac2946d6043bc72b7e728f802aeba2169c527f8fbad2222e74700"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/vendor/github.com/jmank88/nuts/Gopkg.toml
+++ b/vendor/github.com/jmank88/nuts/Gopkg.toml
@@ -1,7 +1,3 @@
 [[constraint]]
   name = "github.com/boltdb/bolt"
   version = "^1.0.0"
-
-[[constraint]]
-  name = "github.com/dgryski/go-metro"
-  branch = "master"

--- a/vendor/github.com/jmank88/nuts/paths_test.go
+++ b/vendor/github.com/jmank88/nuts/paths_test.go
@@ -1,4 +1,4 @@
-//go:generate rm -r testdata
+//go:generate rm -rf testdata
 //
 //go:generate go run cmd/testpaths/main.go testdata standard 10 100 1000 10000 100000 1000000
 //go:generate go run cmd/testpaths/main.go testdata segmentCount 1 5 10 50 100


### PR DESCRIPTION
### What does this do / why do we need it?

Upgrades `github.com/jmank88/nuts` to 0.3.0. Reacting to https://github.com/jmank88/nuts/issues/2.