### PR TITLE
[WIP] Add case in validateUpdateArgs to check if revision constraint exists

### DIFF
--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -875,6 +875,10 @@ func validateUpdateArgs(ctx *dep.Ctx, args []string, p *dep.Project, sm gps.Sour
 				return
 			}
 
+			if rev, ok := params.Manifest.DependencyConstraints()[pc.Ident.ProjectRoot].Constraint.(gps.Revision); ok {
+				errCh <- errors.Errorf("cannot upgrade %s which was constrained with revision %s", pc.Ident.ProjectRoot, rev)
+			}
+
 			// Valid argument.
 			argsCh <- arg
 		}(arg)


### PR DESCRIPTION
### What does this do / why do we need it?
It doesn't make sense to run `dep ensure update` when a project listed as an arg is constrained by a revision. 

### What should your reviewer look out for in this PR? / Do you need help or clarification on anything?
I was wondering if I was going in the correct direction for this. Perhaps edge cases which I might have missed.

Todo:
- [ ] Write test

### Which issue(s) does this PR fix?
fixes #1491 