### PR TITLE
[DO NOT MERGE, need fix verification] manifest: skip ProjectRoot validation for alt source

### DIFF
--- a/manifest_test.go
+++ b/manifest_test.go
@@ -618,6 +618,20 @@ func TestValidateProjectRoots(t *testing.T) {
 			wantError: errInvalidProjectRoot,
 			wantWarn:  []string{},
 		},
+		{
+			name: "skip project root deduction for alternate source",
+			manifest: Manifest{
+				Constraints: map[gps.ProjectRoot]gps.ProjectProperties{
+					// bad ProjectRoot
+					gps.ProjectRoot("golang.org/x"): {
+						Constraint: gps.NewBranch("master"),
+						Source:     "github.com/golang/text",
+					},
+				},
+			},
+			wantError: nil,
+			wantWarn:  []string{},
+		},
 	}
 
 	h := test.NewHelper(t)


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

### What does this do / why do we need it?
Alternate source could be used to bypass network reachability issues and
when that is the case, PR validation fails because gps tries to reach
the project over network and the project isn't reachable.

This change skips PR validation for projects with alternate source only.

### What should your reviewer look out for in this PR?
Implementation. Any possible side-effect?

### Do you need help or clarification on anything?
Any way to do any better for validation other than skipping?

### Which issue(s) does this PR fix?

fixes #1322 
<!--

fixes #
fixes #

-->
