### PR TITLE
Add support for HTTP_PROXY variable

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -71,7 +71,10 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["context"]
+  packages = [
+    "context",
+    "proxy"
+  ]
   revision = "66aacef3dd8a676686c7ae3716979581e8b03c47"
 
 [[projects]]
@@ -89,6 +92,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e70d26b359aed7af66f3393fc9d4985bbcf499c0b5ed3b5661a5912b4c71a32e"
+  inputs-digest = "e02f978b989134d5fd24cd9ca4538851223ed80436ed6f52dd29df579dd83adb"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/gps/deduce.go
+++ b/gps/deduce.go
@@ -854,11 +854,7 @@ func getProxyClient() *http.Client {
 					},
 				}
 				return client
-			} else {
-				fmt.Errorf("%v", err)
 			}
-		} else {
-			fmt.Errorf("proxy parse error: %+v", err)
 		}
 	}
 	return http.DefaultClient

--- a/gps/deduce.go
+++ b/gps/deduce.go
@@ -16,10 +16,11 @@ import (
 	"strings"
 	"sync"
 
-	radix "github.com/armon/go-radix"
+	"os"
+
+	"github.com/armon/go-radix"
 	"github.com/pkg/errors"
 	"golang.org/x/net/proxy"
-	"os"
 )
 
 var (
@@ -841,23 +842,23 @@ func fetchMetadata(ctx context.Context, path, scheme string) (rc io.ReadCloser, 
 
 // getPorxyClient returns a *http.Client with proxy transport if HTTP_PROXY is set in env
 // otherwise it will return a normal *http.Client
-func getProxyClient()*http.Client{
-	if envproxy,isset:=os.LookupEnv("HTTP_PROXY");isset{
-		proxyurl ,err := url.Parse(envproxy)
+func getProxyClient() *http.Client {
+	if envproxy, isset := os.LookupEnv("HTTP_PROXY"); isset {
+		proxyurl, err := url.Parse(envproxy)
 		if err == nil {
-			dialer,err := proxy.FromURL(proxyurl,proxy.Direct)
-			if err == nil{
+			dialer, err := proxy.FromURL(proxyurl, proxy.Direct)
+			if err == nil {
 				client := &http.Client{
 					Transport: &http.Transport{
-						Dial:dialer.Dial,
+						Dial: dialer.Dial,
 					},
 				}
 				return client
-			}else{
-				fmt.Errorf("%v",err)
+			} else {
+				fmt.Errorf("%v", err)
 			}
-		}else{
-			fmt.Errorf("proxy parse error: %+v",err)
+		} else {
+			fmt.Errorf("proxy parse error: %+v", err)
 		}
 	}
 	return http.DefaultClient

--- a/gps/deduce.go
+++ b/gps/deduce.go
@@ -18,6 +18,8 @@ import (
 
 	radix "github.com/armon/go-radix"
 	"github.com/pkg/errors"
+	"golang.org/x/net/proxy"
+	"os"
 )
 
 var (
@@ -837,18 +839,43 @@ func fetchMetadata(ctx context.Context, path, scheme string) (rc io.ReadCloser, 
 	return
 }
 
+// getPorxyClient returns a *http.Client with proxy transport if HTTP_PROXY is set in env
+// otherwise it will return a normal *http.Client
+func getProxyClient()*http.Client{
+	if envproxy,isset:=os.LookupEnv("HTTP_PROXY");isset{
+		proxyurl ,err := url.Parse(envproxy)
+		if err == nil {
+			dialer,err := proxy.FromURL(proxyurl,proxy.Direct)
+			if err == nil{
+				client := &http.Client{
+					Transport: &http.Transport{
+						Dial:dialer.Dial,
+					},
+				}
+				return client
+			}else{
+				fmt.Errorf("%v",err)
+			}
+		}else{
+			fmt.Errorf("proxy parse error: %+v",err)
+		}
+	}
+	return http.DefaultClient
+}
+
 func doFetchMetadata(ctx context.Context, scheme, path string) (io.ReadCloser, error) {
-	url := fmt.Sprintf("%s://%s?go-get=1", scheme, path)
+	u := fmt.Sprintf("%s://%s?go-get=1", scheme, path)
 	switch scheme {
 	case "https", "http":
-		req, err := http.NewRequest("GET", url, nil)
+		req, err := http.NewRequest("GET", u, nil)
 		if err != nil {
-			return nil, errors.Wrapf(err, "unable to build HTTP request for URL %q", url)
+			return nil, errors.Wrapf(err, "unable to build HTTP request for URL %q", u)
 		}
 
-		resp, err := http.DefaultClient.Do(req.WithContext(ctx))
+		// resp, err := http.DefaultClient.Do(req.WithContext(ctx))
+		resp, err := getProxyClient().Do(req.WithContext(ctx))
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed HTTP request to URL %q", url)
+			return nil, errors.Wrapf(err, "failed HTTP request to URL %q", u)
 		}
 
 		return resp.Body, nil


### PR DESCRIPTION
### What does this do / why do we need it?

Add support for HTTP_PROXY in command line variable. This can be necessary for developer in China. 

run like this:
```
HTTP_PROXY=http://127.0.0.1:1087 dep ensure
```

### What should your reviewer look out for in this PR?

### Do you need help or clarification on anything?

the new `getProxyClient` func and called at `doFetchMetadata`

### Which issue(s) does this PR fix?

None
