### PR TITLE
Allow using symlink in project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ BUG FIXES:
 
 IMPROVEMENTS:
 
+* Allow using symlink in project ([#1531](https://github.com/golang/dep/pull/1531))
 * Log as dependencies are pre-fetched during dep init ([#1176](https://github.com/golang/dep/pull/1176)).
 * Make the gps package importable ([#1349](https://github.com/golang/dep/pull/1349)).
 * Improve file copy performance by not forcing a file sync (PR #1408).

--- a/gps/pkgtree/pkgtree.go
+++ b/gps/pkgtree/pkgtree.go
@@ -81,7 +81,7 @@ func ListPackages(fileRoot, importRoot string) (PackageTree, error) {
 			}
 			return err
 		}
-		if !fi.IsDir() {
+		if !fi.IsDir() && !(fi.Mode()&os.ModeSymlink == os.ModeSymlink) {
 			return nil
 		}
 


### PR DESCRIPTION
### What does this do / why do we need it?

For example in https://github.com/douban/libmc, we would like to use the symlink `github.com/douban/libmc/golibmc` instead of `github.com/douban/libmc/src` to import the package.
