### PR TITLE
Install.sh script for dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ IMPROVEMENTS:
 
 # v0.4.1
 
+NEW FEATURES:
+
+* Added `install.sh` script. ([#1533](https://github.com/golang/dep/pull/1533))
+
 BUG FIXES:
 
 * Fix per-project prune option handling ([#1570](https://github.com/golang/dep/pull/1570))
@@ -15,6 +19,7 @@ BUG FIXES:
 # v0.4.0
 
 NEW FEATURES:
+
 * Absorb `dep prune` into `dep ensure`. ([#944](https://github.com/golang/dep/issues/944))
 * Add support for importing from [glock](https://github.com/robfig/glock) based projects. ([#1422](https://github.com/golang/dep/pull/1422))
 * Add support for importing from [govendor](https://github.com/kardianos/govendor) based projects. ([#815](https://github.com/golang/dep/pull/815))

--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ $ brew install dep
 $ brew upgrade dep
 ```
 
+On other platforms you can use the `install.sh` script:
+
+```sh
+$ curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+```
+
+It will install into your `$GOPATH/bin` directory by default or any other directory you specify using the `INSTALL_DIRECTORY` environment variable.
+
+If your platform is not supported, you'll need to build it manually or let the team know and we'll consider adding your platform
+to the release builds.
+
 If you're interested in hacking on `dep`, you can install via `go get`:
 
 ```sh

--- a/install.sh
+++ b/install.sh
@@ -9,8 +9,8 @@
 # Environment variables:
 # - INSTALL_DIRECTORY (optional): defaults to $GOPATH/bin
 # - DEP_RELEASE_TAG (optional): defaults to fetching the latest release
-# - DEP_FAKE_OS (optional): use a fake value for OS (mostly for testing)
-# - DEP_FAKE_ARCH (optional): use a fake value for ARCH (mostly for testing)
+# - DEP_OS (optional): use a specific value for OS (mostly for testing)
+# - DEP_ARCH (optional): use a specific value for ARCH (mostly for testing)
 #
 # You can install using this script:
 # $ curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
@@ -80,9 +80,9 @@ findGoBinDirectory() {
 
 initArch() {
     ARCH=$(uname -m)
-    if [ -n "$DEP_FAKE_ARCH" ]; then
-        echo "Using DEP_FAKE_ARCH"
-        ARCH="$DEP_FAKE_ARCH"
+    if [ -n "$DEP_ARCH" ]; then
+        echo "Using DEP_ARCH"
+        ARCH="$DEP_ARCH"
     fi
     case $ARCH in
         amd64) ARCH="amd64";;
@@ -95,9 +95,9 @@ initArch() {
 
 initOS() {
     OS=$(uname | tr '[:upper:]' '[:lower:]')
-    if [ -n "$DEP_FAKE_OS" ]; then
-        echo "Using DEP_FAKE_OS"
-        OS="$DEP_FAKE_OS"
+    if [ -n "$DEP_OS" ]; then
+        echo "Using DEP_OS"
+        OS="$DEP_OS"
     fi
     case "$OS" in
         darwin) OS='darwin';;

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,135 @@
+#!/bin/sh
+
+# This install script is intended to download and install the latest available
+# release of the dep dependency manager for Golang.
+#
+# It attempts to identify the current platform and an error will be thrown if
+# the platform is not supported.
+#
+# Environment variables:
+# - INSTALL_DIRECTORY (optional): defaults to $GOPATH/bin
+# - DEP_RELEASE_TAG (optional): defaults to fetching the latest release
+#
+# You can install using this script:
+# $ curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+
+set -e
+
+RELEASES_URL="https://github.com/golang/dep/releases"
+
+downloadJSON() {
+    url="$2"
+
+    echo "Fetching $url.."
+    if type curl > /dev/null; then
+        response=$(curl -s -L -w 'HTTPSTATUS:%{http_code}' -H 'Accept: application/json' "$url")
+        body=$(echo "$response" | sed -e 's/HTTPSTATUS\:.*//g')
+        code=$(echo "$response" | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
+    elif type wget > /dev/null; then
+        temp=$(mktemp)
+        body=$(wget -q --header='Accept: application/json' -O - --server-response --content-on-error "$url" 2> "$temp")
+        code=$(awk '/^  HTTP/{print $2}' < "$temp")
+    else
+        echo "Neither curl nor wget was available to perform http requests."
+        exit 1
+    fi
+    if [ "$code" != 200 ]; then
+		echo "Request failed with code $code"
+		exit 1
+	fi
+
+    eval "$1='$body'"
+}
+
+downloadFile() {
+    url="$1"
+    destination="$2"
+
+    echo "Fetching $url.."
+    if type curl > /dev/null; then
+        code=$(curl -s -w '%{http_code}' -L "$url" -o "$destination")
+    elif type wget > /dev/null; then
+        code=$(wget -q -O "$destination" --server-response "$url" 2>&1 | awk '/^  HTTP/{print $2}')
+    else
+        echo "Neither curl nor wget was available to perform http requests."
+        exit 1
+    fi
+
+    if [ "$code" != 200 ]; then
+		echo "Request failed with code $code"
+		exit 1
+	fi
+}
+
+findGoBinDirectory() {
+    if [ -z "$GOPATH" ]; then
+        echo "Installation requires \$GOPATH to be set for your Golang environment."
+        exit 1
+    fi
+    if [ -z "$GOBIN" ]; then
+        GOBIN="$GOPATH/bin"
+    fi
+    if [ ! -d "$GOBIN" ]; then
+        echo "Installation requires your GOBIN directory $GOBIN to exist. Please create it."
+        exit 1
+    fi
+    eval "$1='$GOBIN'"
+}
+
+initArch() {
+	ARCH=$(uname -m)
+	case $ARCH in
+        amd64) ARCH="amd64";;
+		x86_64) ARCH="amd64";;
+        i386) ARCH="386";;
+        *) echo "Architecture ${ARCH} is not supported by this installation script"; exit 1;;
+	esac
+	echo "ARCH = $ARCH"
+}
+
+initOS() {
+	OS=$(uname | tr '[:upper:]' '[:lower:]')
+
+	case "$OS" in
+        darwin) OS='darwin';;
+        linux) OS='linux';;
+        freebsd) OS='freebsd';;
+		mingw*) OS='windows';;
+		msys*) OS='windows';;
+        *) echo "OS ${OS} is not supported by this installation script"; exit 1;;
+	esac
+	echo "OS = $OS"
+}
+
+# identify platform based on uname output
+initArch
+initOS
+
+if [ -z "$INSTALL_DIRECTORY" ]; then
+    findGoBinDirectory INSTALL_DIRECTORY
+fi
+echo "Will install into $INSTALL_DIRECTORY"
+
+# assemble expected release artifact name
+BINARY="dep-${OS}-${ARCH}"
+
+# if DEP_RELEASE_TAG was not provided, assume latest
+if [ -z "$DEP_RELEASE_TAG" ]; then
+    downloadJSON LATEST_RELEASE "$RELEASES_URL/latest"
+    DEP_RELEASE_TAG=$(echo "${LATEST_RELEASE}" | tr -s '\n' ' ' | sed 's/.*"tag_name":"//' | sed 's/".*//' )
+fi
+echo "Release Tag = $DEP_RELEASE_TAG"
+
+# fetch the real release data to make sure it exists before we attempt a download
+downloadJSON RELEASE_DATA "$RELEASES_URL/tag/$DEP_RELEASE_TAG"
+
+BINARY_URL="$RELEASES_URL/download/$DEP_RELEASE_TAG/$BINARY"
+DOWNLOAD_FILE=$(mktemp)
+
+downloadFile "$BINARY_URL" "$DOWNLOAD_FILE"
+
+echo "Setting executable permissions."
+chmod +x "$DOWNLOAD_FILE"
+
+echo "Moving executable to $INSTALL_DIRECTORY/dep"
+mv "$DOWNLOAD_FILE" "$INSTALL_DIRECTORY/dep"


### PR DESCRIPTION
### What does this do / why do we need it?

Provides a portable sh script for installing an appropriate dep binary into your environment.

Some regular build environments need `dep` installed but don't want to pull all the dependencies and build it every time. (Especially in docker-based build environments). 

This script provides an easy way to install dep into the GOPATH/bin or specified location via:

```
$ curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
```

### What should your reviewer look out for in this PR?

It _should_ be compatible with basic `sh` syntax without needing any `bash` magic. I'd appreciate it if others could test it in their environments.

It supports both `curl` and `wget` as download mechanisms and bails out if neither are available.

It supports the current binaries available under releases.

### Do you need help or clarification on anything?

- Is this something dep actually needs? 
- Should this script attempt to do an integrity check against the `*.sha256` files? I feel it may add some unexpected complexity having to deal with different platforms provided shasum binary.
- Should more binaries be built during the CI build and uploaded to the releases so that this script can support more than just the basics?

### Which issue(s) does this PR fix?

No issue was cut for this, it is just a suggestion. Can retroactively cut an issue for it if necessary.

--- 

Example:

```
$ docker run --rm -ti oraclelinux:6
[root@97422287de6f /]# curl https://raw.githubusercontent.com/AstromechZA/golang-dep/aza_dep_install_script/install.sh | INSTALL_DIRECTORY=/usr/local/bin sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
101  3742  101  3742    0     0   5780      0 --:--:-- --:--:-- --:--:-- 13706
ARCH = amd64
OS = linux
Will install into /usr/local/bin
Fetching https://github.com/golang/dep/releases/latest..
Release Tag = v0.3.2
Fetching https://github.com/golang/dep/releases/tag/v0.3.2..
Fetching https://github.com/golang/dep/releases/download/v0.3.2/dep-linux-amd64..
Setting executable permissions.
Moving to /usr/local/bin/dep
[root@97422287de6f /]# dep
dep is a tool for managing dependencies for Go projects

Usage: dep <command>

Commands:

  init     Initialize a new project with manifest and lock files
  status   Report the status of the project's dependencies
  ensure   Ensure a dependency is safely vendored in the project
  prune    Prune the vendor tree of unused packages
  version  Show the dep version information

Examples:
  dep init                               set up a new project
  dep ensure                             install the project's dependencies
  dep ensure -update                     update the locked versions of all dependencies
  dep ensure -add github.com/pkg/errors  add a dependency to the project

Use "dep help [command]" for more information about a command.
[root@97422287de6f /]#
```