### PR TITLE
Tweak import warnings to prevent confusion

### DIFF
--- a/internal/importers/base/importer.go
+++ b/internal/importers/base/importer.go
@@ -215,7 +215,7 @@ func (i *Importer) ImportPackages(packages []ImportedPackage, defaultConstraintF
 			isTag, version, err = i.isTag(pc.Ident, prj.LockHint)
 			if err != nil {
 				i.Logger.Printf(
-					"  Warning: Skipping project. Unable to apply constraint %q for %v: %s\n",
+					"  Warning: Skipping project. Unable to import lock %q for %v: %s\n",
 					prj.LockHint, pc.Ident, err,
 				)
 				continue
@@ -263,10 +263,6 @@ func (i *Importer) ImportPackages(packages []ImportedPackage, defaultConstraintF
 				Constraint: pc.Constraint,
 			}
 			fb.NewConstraintFeedback(pc, fb.DepTypeImported).LogFeedback(i.Logger)
-		} else {
-			if i.Verbose {
-				i.Logger.Printf("  Skipping import of %v because its constraint is empty.\n", pc.Ident)
-			}
 		}
 
 		if version != nil {

--- a/internal/importers/base/importer_test.go
+++ b/internal/importers/base/importer_test.go
@@ -355,7 +355,6 @@ func TestBaseImporter_ImportProjects(t *testing.T) {
 		"skip empty lock hints": {
 			importertest.TestCase{
 				WantRevision: "",
-				WantWarning:  "constraint is empty",
 			},
 			[]ImportedPackage{
 				{
@@ -379,7 +378,6 @@ func TestBaseImporter_ImportProjects(t *testing.T) {
 		"skip default source": {
 			importertest.TestCase{
 				WantSourceRepo: "",
-				WantWarning:    "constraint is empty",
 			},
 			[]ImportedPackage{
 				{
@@ -415,7 +413,7 @@ func TestBaseImporter_ImportProjects(t *testing.T) {
 			importertest.TestCase{
 				WantSourceRepo: "",
 				WantWarning: fmt.Sprintf(
-					"Warning: Skipping project. Unable to apply constraint %q for %s",
+					"Warning: Skipping project. Unable to import lock %q for %s",
 					importertest.V1Tag, importertest.NonexistentPrj,
 				),
 			},

--- a/internal/importers/govendor/importer_test.go
+++ b/internal/importers/govendor/importer_test.go
@@ -133,7 +133,7 @@ func TestGovendorConfig_Convert(t *testing.T) {
 				},
 			},
 			importertest.TestCase{
-				WantWarning: "constraint is empty",
+				WantRevision: "",
 			},
 		},
 	}

--- a/internal/importers/importertest/testcase.go
+++ b/internal/importers/importertest/testcase.go
@@ -150,8 +150,9 @@ func (tc TestCase) validate(manifest *dep.Manifest, lock *dep.Lock, output *byte
 	}
 
 	if tc.WantWarning != "" {
-		if !strings.Contains(output.String(), tc.WantWarning) {
-			return errors.Errorf("Expected the output to include the warning '%s'", tc.WantWarning)
+		gotWarning := output.String()
+		if !strings.Contains(gotWarning, tc.WantWarning) {
+			return errors.Errorf("Expected the output to include the warning '%s' but got '%s'\n", tc.WantWarning, gotWarning)
 		}
 	}
 


### PR DESCRIPTION
I missed this when I reviewed #1414 but it introduced a misleading log messages that needs to be corrected.

* Remove warning when the constraint hint is empty. It's a common case and the lock may still be imported.
* Fix warning to say lock instead of constraint when the lock hint cannot be resolved.