### PR TITLE
Make it easier to update all golden files at once

### DIFF
--- a/cmd/dep/testdata/harness_tests/status/case1/table/stdout.txt
+++ b/cmd/dep/testdata/harness_tests/status/case1/table/stdout.txt
@@ -1,3 +1,3 @@
 PROJECT                        CONSTRAINT  VERSION  REVISION  LATEST  PKGS USED
-github.com/sdboyer/deptest     ^0.8.0      v0.8.0   ff2948a   v0.8.1  1
-github.com/sdboyer/deptestdos  v2.0.0      v2.0.0   5c60720   v2.0.0  1
+github.com/sdboyer/deptest     ^0.8.0      v0.8.0   ff2948a   v0.8.1  1  
+github.com/sdboyer/deptestdos  v2.0.0      v2.0.0   5c60720   v2.0.0  1  

--- a/cmd/dep/testdata/harness_tests/status/override_constraint/stdout.txt
+++ b/cmd/dep/testdata/harness_tests/status/override_constraint/stdout.txt
@@ -1,3 +1,3 @@
 PROJECT                        CONSTRAINT         VERSION  REVISION  LATEST  PKGS USED
-github.com/sdboyer/deptest     v0.8.1 (override)  v0.8.1   3f4c3be   v0.8.1  1
-github.com/sdboyer/deptestdos  v2.0.0             v2.0.0   5c60720   v2.0.0  1
+github.com/sdboyer/deptest     v0.8.1 (override)  v0.8.1   3f4c3be   v0.8.1  1  
+github.com/sdboyer/deptestdos  v2.0.0             v2.0.0   5c60720   v2.0.0  1  

--- a/cmd/dep/testdata/harness_tests/status/revision_constraint/stdout.txt
+++ b/cmd/dep/testdata/harness_tests/status/revision_constraint/stdout.txt
@@ -1,3 +1,3 @@
 PROJECT                        CONSTRAINT  VERSION  REVISION  LATEST  PKGS USED
-github.com/sdboyer/deptest     v1.0.0      v1.0.0   ff2948a   v1.0.0  1
-github.com/sdboyer/deptestdos  a0196ba              a0196ba           1
+github.com/sdboyer/deptest     v1.0.0      v1.0.0   ff2948a   v1.0.0  1  
+github.com/sdboyer/deptestdos  a0196ba              a0196ba           1  

--- a/gps/paths/paths_test.go
+++ b/gps/paths/paths_test.go
@@ -4,7 +4,11 @@
 
 package paths
 
-import "testing"
+import (
+	"testing"
+
+	_ "github.com/golang/dep/internal/test" // DO NOT REMOVE, allows go test ./... -update to work
+)
 
 func TestIsStandardImportPath(t *testing.T) {
 	fix := []struct {

--- a/gps/pkgtree/pkgtree_test.go
+++ b/gps/pkgtree/pkgtree_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/golang/dep/gps/paths"
 	"github.com/golang/dep/internal/fs"
+	_ "github.com/golang/dep/internal/test" // DO NOT REMOVE, allows go test ./... -update to work
 )
 
 // PackageTree.ToReachMap() uses an easily separable algorithm, wmToReach(),

--- a/internal/feedback/feedback_test.go
+++ b/internal/feedback/feedback_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/golang/dep/gps"
+	_ "github.com/golang/dep/internal/test" // DO NOT REMOVE, allows go test ./... -update to work
 )
 
 func TestFeedback_Constraint(t *testing.T) {


### PR DESCRIPTION
### What does this do / why do we need it?
This allows people to run `go test ./... -update` (which used to work but must have gotten broken at some point). Without this, in order to do a mass update of golden files, you need to run the update against individual packages which is a huge pain.

While I was in there, I also updated the golden files for status. They always show as modified when I update all the tests, but I'm pretty sure they don't fail in CI because it's just trailing whitespace.

### What should your reviewer look out for in this PR?
Nothing

### Do you need help or clarification on anything?
Nope

### Which issue(s) does this PR fix?
None
