### PR TITLE
Dep status -f doc and string display

### DIFF
--- a/cmd/dep/status.go
+++ b/cmd/dep/status.go
@@ -34,6 +34,15 @@ With no arguments, print the status of each dependency of the project.
   LATEST      Latest VCS revision available
   PKGS USED   Number of packages from this project that are actually used
 
+You may use the -f flag to create a custom format for the output of the
+dep status command. The available flags you can utilize are as follows:
+ProjectRoot, Constraint, Version, Revision, Latest, and PackageCount.
+
+For example to display all package names constrained on the master branch
+you can run the following command:
+
+  dep status -f='{{if eq .Constraint "master"}}{{.ProjectRoot}} {{end}}'
+
 Status returns exit code zero if all dependencies are in a "good state".
 `
 
@@ -200,7 +209,18 @@ func (out *templateOutput) BasicHeader() error { return nil }
 func (out *templateOutput) BasicFooter() error { return nil }
 
 func (out *templateOutput) BasicLine(bs *BasicStatus) error {
-	return out.tmpl.Execute(out.w, bs)
+	data := struct {
+		ProjectRoot, Constraint, Version, Revision, Latest string
+		PackageCount                                       int
+	}{
+		ProjectRoot:  bs.ProjectRoot,
+		Constraint:   bs.Constraint.String(),
+		Version:      bs.Version.String(),
+		Revision:     bs.Revision.String(),
+		Latest:       bs.Latest.String(),
+		PackageCount: bs.PackageCount,
+	}
+	return out.tmpl.Execute(out.w, data)
 }
 
 func (out *templateOutput) MissingHeader() error { return nil }

--- a/cmd/dep/status.go
+++ b/cmd/dep/status.go
@@ -9,13 +9,14 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"html/template"
 	"io"
 	"io/ioutil"
 	"log"
 	"sort"
+	"strings"
 	"sync"
 	"text/tabwriter"
+	"text/template"
 
 	"github.com/golang/dep"
 	"github.com/golang/dep/gps"
@@ -35,15 +36,40 @@ With no arguments, print the status of each dependency of the project.
   PKGS USED   Number of packages from this project that are actually used
 
 You may use the -f flag to create a custom format for the output of the
-dep status command. The available flags you can utilize are as follows:
+dep status command. The available fields you can utilize are as follows:
 ProjectRoot, Constraint, Version, Revision, Latest, and PackageCount.
 
-For example to display all package names constrained on the master branch
-you can run the following command:
-
-  dep status -f='{{if eq .Constraint "master"}}{{.ProjectRoot}} {{end}}'
-
 Status returns exit code zero if all dependencies are in a "good state".
+`
+
+const statusExamples = `
+dep status
+
+	Displays a table of the various dependencies in the project along with
+	their properties such as the constraints they are bound by and the 
+	revision they are at.
+
+dep status -f='{{if eq .Constraint "master"}}{{.ProjectRoot}} {{end}}'
+
+	Display the list of package names constrained on the master branch.
+	The -f flag allows you to use Go templates along with it's various 
+	constructs for formating the output data. See -help for available 
+	variables for this flag.
+
+dep status -json
+
+	Displays the dependency information in JSON format as a list of 
+	project objects. Each project object contains keys which correspond
+	to the table column names from the standard 'dep status' command.
+
+Linux:   dep status -dot | dot -T png | display
+MacOS:   dep status -dot | dot -T png | open -f -a /Applications/Preview.app
+Windows: dep status -dot | dot -T png -o status.png; start status.png
+
+	Generate a visual representation of the dependency tree using GraphViz.
+	(Note: in order for this example to work you must first have graphviz
+	installed on your system)
+
 `
 
 const (
@@ -65,6 +91,7 @@ func (cmd *statusCommand) LongHelp() string  { return statusLongHelp }
 func (cmd *statusCommand) Hidden() bool      { return false }
 
 func (cmd *statusCommand) Register(fs *flag.FlagSet) {
+	fs.BoolVar(&cmd.examples, "examples", false, "print detailed usage examples")
 	fs.BoolVar(&cmd.json, "json", false, "output in JSON format")
 	fs.StringVar(&cmd.template, "f", "", "output in text/template format")
 	fs.BoolVar(&cmd.dot, "dot", false, "output the dependency graph in GraphViz format")
@@ -73,6 +100,7 @@ func (cmd *statusCommand) Register(fs *flag.FlagSet) {
 }
 
 type statusCommand struct {
+	examples bool
 	json     bool
 	template string
 	output   string
@@ -214,10 +242,10 @@ func (out *templateOutput) BasicLine(bs *BasicStatus) error {
 		PackageCount                                       int
 	}{
 		ProjectRoot:  bs.ProjectRoot,
-		Constraint:   bs.Constraint.String(),
-		Version:      bs.Version.String(),
+		Constraint:   bs.getConsolidatedConstraint(),
+		Version:      bs.getConsolidatedVersion(),
 		Revision:     bs.Revision.String(),
-		Latest:       bs.Latest.String(),
+		Latest:       bs.getConsolidatedLatest(shortRev),
 		PackageCount: bs.PackageCount,
 	}
 	return out.tmpl.Execute(out.w, data)
@@ -231,6 +259,11 @@ func (out *templateOutput) MissingLine(ms *MissingStatus) error {
 }
 
 func (cmd *statusCommand) Run(ctx *dep.Ctx, args []string) error {
+	if cmd.examples {
+		ctx.Err.Println(strings.TrimSpace(statusExamples))
+		return nil
+	}
+
 	if err := cmd.validateFlags(); err != nil {
 		return err
 	}

--- a/cmd/dep/status.go
+++ b/cmd/dep/status.go
@@ -24,6 +24,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+const availableTemplateVariables = "ProjectRoot, Constraint, Version, Revision, Latest, and PackageCount."
+
 const statusShortHelp = `Report the status of the project's dependencies`
 const statusLongHelp = `
 With no arguments, print the status of each dependency of the project.
@@ -37,7 +39,7 @@ With no arguments, print the status of each dependency of the project.
 
 You may use the -f flag to create a custom format for the output of the
 dep status command. The available fields you can utilize are as follows:
-ProjectRoot, Constraint, Version, Revision, Latest, and PackageCount.
+` + availableTemplateVariables + `
 
 Status returns exit code zero if all dependencies are in a "good state".
 `
@@ -53,8 +55,8 @@ dep status -f='{{if eq .Constraint "master"}}{{.ProjectRoot}} {{end}}'
 
 	Display the list of package names constrained on the master branch.
 	The -f flag allows you to use Go templates along with it's various 
-	constructs for formating the output data. See -help for available 
-	variables for this flag.
+	constructs for formating the output data. Available flags are as follows:
+	` + availableTemplateVariables + `
 
 dep status -json
 
@@ -237,10 +239,7 @@ func (out *templateOutput) BasicHeader() error { return nil }
 func (out *templateOutput) BasicFooter() error { return nil }
 
 func (out *templateOutput) BasicLine(bs *BasicStatus) error {
-	data := struct {
-		ProjectRoot, Constraint, Version, Revision, Latest string
-		PackageCount                                       int
-	}{
+	data := rawStatus{
 		ProjectRoot:  bs.ProjectRoot,
 		Constraint:   bs.getConsolidatedConstraint(),
 		Version:      bs.getConsolidatedVersion(),

--- a/cmd/dep/status_test.go
+++ b/cmd/dep/status_test.go
@@ -58,7 +58,7 @@ func TestBasicLine(t *testing.T) {
 			wantDotStatus:      []string{`[label="github.com/foo/bar"];`},
 			wantJSONStatus:     []string{`"Version":""`, `"Revision":""`},
 			wantTableStatus:    []string{`github.com/foo/bar                                         0`},
-			wantTemplateStatus: []string{`->~~<-`},
+			wantTemplateStatus: []string{`PR:github.com/foo/bar, Const:, Ver:, Rev:, Lat:, PkgCt:0`},
 		},
 		{
 			name: "BasicStatus with Revision",
@@ -69,7 +69,7 @@ func TestBasicLine(t *testing.T) {
 			wantDotStatus:      []string{`[label="github.com/foo/bar\nflooboo"];`},
 			wantJSONStatus:     []string{`"Version":""`, `"Revision":"flooboofoobooo"`, `"Constraint":""`},
 			wantTableStatus:    []string{`github.com/foo/bar                       flooboo           0`},
-			wantTemplateStatus: []string{`->flooboofoobooo~~flooboo<-`},
+			wantTemplateStatus: []string{`PR:github.com/foo/bar, Const:, Ver:flooboo, Rev:flooboofoobooo, Lat:, PkgCt:0`},
 		},
 		{
 			name: "BasicStatus with Version and Revision",
@@ -81,7 +81,7 @@ func TestBasicLine(t *testing.T) {
 			wantDotStatus:      []string{`[label="github.com/foo/bar\n1.0.0"];`},
 			wantJSONStatus:     []string{`"Version":"1.0.0"`, `"Revision":"flooboofoobooo"`, `"Constraint":""`},
 			wantTableStatus:    []string{`github.com/foo/bar              1.0.0    flooboo           0`},
-			wantTemplateStatus: []string{`->flooboofoobooo~~1.0.0<-`},
+			wantTemplateStatus: []string{`PR:github.com/foo/bar, Const:, Ver:1.0.0, Rev:flooboofoobooo, Lat:, PkgCt:0`},
 		},
 		{
 			name: "BasicStatus with Constraint, Version and Revision",
@@ -94,7 +94,7 @@ func TestBasicLine(t *testing.T) {
 			wantDotStatus:      []string{`[label="github.com/foo/bar\n1.0.0"];`},
 			wantJSONStatus:     []string{`"Revision":"revxyz"`, `"Constraint":"1.2.3"`, `"Version":"1.0.0"`},
 			wantTableStatus:    []string{`github.com/foo/bar  1.2.3       1.0.0    revxyz            0`},
-			wantTemplateStatus: []string{`->revxyz~1.2.3~1.0.0<-`},
+			wantTemplateStatus: []string{`PR:github.com/foo/bar, Const:1.2.3, Ver:1.0.0, Rev:revxyz, Lat:, PkgCt:0`},
 		},
 		{
 			name: "BasicStatus with update error",
@@ -105,7 +105,7 @@ func TestBasicLine(t *testing.T) {
 			wantDotStatus:      []string{`[label="github.com/foo/bar"];`},
 			wantJSONStatus:     []string{`"Version":""`, `"Revision":""`, `"Latest":"unknown"`},
 			wantTableStatus:    []string{`github.com/foo/bar                                 unknown  0`},
-			wantTemplateStatus: []string{`->~~<-`},
+			wantTemplateStatus: []string{`PR:github.com/foo/bar, Const:, Ver:, Rev:, Lat:unknown, PkgCt:0`},
 		},
 	}
 
@@ -158,7 +158,7 @@ func TestBasicLine(t *testing.T) {
 			}
 
 			buf.Reset()
-			template, _ := template.New("status").Parse("->{{.Revision}}~{{.Constraint}}~{{.Version}}<-")
+			template, _ := template.New("status").Parse("PR:{{.ProjectRoot}}, Const:{{.Constraint}}, Ver:{{.Version}}, Rev:{{.Revision}}, Lat:{{.Latest}}, PkgCt:{{.PackageCount}}")
 			templateout := &templateOutput{w: &buf, tmpl: template}
 			templateout.BasicHeader()
 			templateout.BasicLine(&test.status)

--- a/cmd/dep/status_test.go
+++ b/cmd/dep/status_test.go
@@ -42,23 +42,28 @@ func TestBasicLine(t *testing.T) {
 	project := dep.Project{}
 	aSemverConstraint, _ := gps.NewSemverConstraint("1.2.3")
 
+	templateString := "PR:{{.ProjectRoot}}, Const:{{.Constraint}}, Ver:{{.Version}}, Rev:{{.Revision}}, Lat:{{.Latest}}, PkgCt:{{.PackageCount}}"
+	equalityTestTemplate := `{{if eq .Constraint "1.2.3"}}Constraint is 1.2.3{{end}}|{{if eq .Version "flooboo"}}Version is flooboo{{end}}|{{if eq .Latest "unknown"}}Latest is unknown{{end}}`
+
 	tests := []struct {
-		name               string
-		status             BasicStatus
-		wantDotStatus      []string
-		wantJSONStatus     []string
-		wantTableStatus    []string
-		wantTemplateStatus []string
+		name                 string
+		status               BasicStatus
+		wantDotStatus        []string
+		wantJSONStatus       []string
+		wantTableStatus      []string
+		wantTemplateStatus   []string
+		wantEqTemplateStatus []string
 	}{
 		{
 			name: "BasicStatus with ProjectRoot only",
 			status: BasicStatus{
 				ProjectRoot: "github.com/foo/bar",
 			},
-			wantDotStatus:      []string{`[label="github.com/foo/bar"];`},
-			wantJSONStatus:     []string{`"Version":""`, `"Revision":""`},
-			wantTableStatus:    []string{`github.com/foo/bar                                         0`},
-			wantTemplateStatus: []string{`PR:github.com/foo/bar, Const:, Ver:, Rev:, Lat:, PkgCt:0`},
+			wantDotStatus:        []string{`[label="github.com/foo/bar"];`},
+			wantJSONStatus:       []string{`"Version":""`, `"Revision":""`},
+			wantTableStatus:      []string{`github.com/foo/bar                                         0`},
+			wantTemplateStatus:   []string{`PR:github.com/foo/bar, Const:, Ver:, Rev:, Lat:, PkgCt:0`},
+			wantEqTemplateStatus: []string{`||`},
 		},
 		{
 			name: "BasicStatus with Revision",
@@ -66,10 +71,11 @@ func TestBasicLine(t *testing.T) {
 				ProjectRoot: "github.com/foo/bar",
 				Revision:    gps.Revision("flooboofoobooo"),
 			},
-			wantDotStatus:      []string{`[label="github.com/foo/bar\nflooboo"];`},
-			wantJSONStatus:     []string{`"Version":""`, `"Revision":"flooboofoobooo"`, `"Constraint":""`},
-			wantTableStatus:    []string{`github.com/foo/bar                       flooboo           0`},
-			wantTemplateStatus: []string{`PR:github.com/foo/bar, Const:, Ver:flooboo, Rev:flooboofoobooo, Lat:, PkgCt:0`},
+			wantDotStatus:        []string{`[label="github.com/foo/bar\nflooboo"];`},
+			wantJSONStatus:       []string{`"Version":""`, `"Revision":"flooboofoobooo"`, `"Constraint":""`},
+			wantTableStatus:      []string{`github.com/foo/bar                       flooboo           0`},
+			wantTemplateStatus:   []string{`PR:github.com/foo/bar, Const:, Ver:flooboo, Rev:flooboofoobooo, Lat:, PkgCt:0`},
+			wantEqTemplateStatus: []string{`|Version is flooboo|`},
 		},
 		{
 			name: "BasicStatus with Version and Revision",
@@ -78,10 +84,11 @@ func TestBasicLine(t *testing.T) {
 				Version:     gps.NewVersion("1.0.0"),
 				Revision:    gps.Revision("flooboofoobooo"),
 			},
-			wantDotStatus:      []string{`[label="github.com/foo/bar\n1.0.0"];`},
-			wantJSONStatus:     []string{`"Version":"1.0.0"`, `"Revision":"flooboofoobooo"`, `"Constraint":""`},
-			wantTableStatus:    []string{`github.com/foo/bar              1.0.0    flooboo           0`},
-			wantTemplateStatus: []string{`PR:github.com/foo/bar, Const:, Ver:1.0.0, Rev:flooboofoobooo, Lat:, PkgCt:0`},
+			wantDotStatus:        []string{`[label="github.com/foo/bar\n1.0.0"];`},
+			wantJSONStatus:       []string{`"Version":"1.0.0"`, `"Revision":"flooboofoobooo"`, `"Constraint":""`},
+			wantTableStatus:      []string{`github.com/foo/bar              1.0.0    flooboo           0`},
+			wantTemplateStatus:   []string{`PR:github.com/foo/bar, Const:, Ver:1.0.0, Rev:flooboofoobooo, Lat:, PkgCt:0`},
+			wantEqTemplateStatus: []string{`||`},
 		},
 		{
 			name: "BasicStatus with Constraint, Version and Revision",
@@ -91,10 +98,11 @@ func TestBasicLine(t *testing.T) {
 				Version:     gps.NewVersion("1.0.0"),
 				Revision:    gps.Revision("revxyz"),
 			},
-			wantDotStatus:      []string{`[label="github.com/foo/bar\n1.0.0"];`},
-			wantJSONStatus:     []string{`"Revision":"revxyz"`, `"Constraint":"1.2.3"`, `"Version":"1.0.0"`},
-			wantTableStatus:    []string{`github.com/foo/bar  1.2.3       1.0.0    revxyz            0`},
-			wantTemplateStatus: []string{`PR:github.com/foo/bar, Const:1.2.3, Ver:1.0.0, Rev:revxyz, Lat:, PkgCt:0`},
+			wantDotStatus:        []string{`[label="github.com/foo/bar\n1.0.0"];`},
+			wantJSONStatus:       []string{`"Revision":"revxyz"`, `"Constraint":"1.2.3"`, `"Version":"1.0.0"`},
+			wantTableStatus:      []string{`github.com/foo/bar  1.2.3       1.0.0    revxyz            0`},
+			wantTemplateStatus:   []string{`PR:github.com/foo/bar, Const:1.2.3, Ver:1.0.0, Rev:revxyz, Lat:, PkgCt:0`},
+			wantEqTemplateStatus: []string{`Constraint is 1.2.3||`},
 		},
 		{
 			name: "BasicStatus with update error",
@@ -102,10 +110,11 @@ func TestBasicLine(t *testing.T) {
 				ProjectRoot: "github.com/foo/bar",
 				hasError:    true,
 			},
-			wantDotStatus:      []string{`[label="github.com/foo/bar"];`},
-			wantJSONStatus:     []string{`"Version":""`, `"Revision":""`, `"Latest":"unknown"`},
-			wantTableStatus:    []string{`github.com/foo/bar                                 unknown  0`},
-			wantTemplateStatus: []string{`PR:github.com/foo/bar, Const:, Ver:, Rev:, Lat:unknown, PkgCt:0`},
+			wantDotStatus:        []string{`[label="github.com/foo/bar"];`},
+			wantJSONStatus:       []string{`"Version":""`, `"Revision":""`, `"Latest":"unknown"`},
+			wantTableStatus:      []string{`github.com/foo/bar                                 unknown  0`},
+			wantTemplateStatus:   []string{`PR:github.com/foo/bar, Const:, Ver:, Rev:, Lat:unknown, PkgCt:0`},
+			wantEqTemplateStatus: []string{`||Latest is unknown`},
 		},
 	}
 
@@ -158,13 +167,27 @@ func TestBasicLine(t *testing.T) {
 			}
 
 			buf.Reset()
-			template, _ := template.New("status").Parse("PR:{{.ProjectRoot}}, Const:{{.Constraint}}, Ver:{{.Version}}, Rev:{{.Revision}}, Lat:{{.Latest}}, PkgCt:{{.PackageCount}}")
+			template, _ := template.New("status").Parse(templateString)
 			templateout := &templateOutput{w: &buf, tmpl: template}
 			templateout.BasicHeader()
 			templateout.BasicLine(&test.status)
 			templateout.BasicFooter()
 
 			for _, wantStatus := range test.wantTemplateStatus {
+				if ok := strings.Contains(buf.String(), wantStatus); !ok {
+					t.Errorf("Did not find expected template status: \n\t(GOT) %v \n\t(WNT) %v", buf.String(), wantStatus)
+				}
+			}
+
+			// The following test is to ensure that certain fields usable with string operations such as .eq
+			buf.Reset()
+			template, _ = template.New("status").Parse(equalityTestTemplate)
+			templateout = &templateOutput{w: &buf, tmpl: template}
+			templateout.BasicHeader()
+			templateout.BasicLine(&test.status)
+			templateout.BasicFooter()
+
+			for _, wantStatus := range test.wantEqTemplateStatus {
 				if ok := strings.Contains(buf.String(), wantStatus); !ok {
 					t.Errorf("Did not find expected template status: \n\t(GOT) %v \n\t(WNT) %v", buf.String(), wantStatus)
 				}


### PR DESCRIPTION
### What does this do / why do we need it?
This pul requests chages the structure of the data fed into the template used by the `go status -f` command. The BasicStatus struct had fields that were not directly of type string making certain template constructs confusing (ex. `dep status -f='{{if eq .Constraint "master"}}{{.ProjectRoot}}{{end}}'`  doesn't work because _.Constraint_ is of type gps.Constraint, not a string).

This PR takes such elements and puts them into a structure whos type is string making the above example work.

In addition, I added some documentation to the help prompt explainging the usable field names and giving an example.

### What should your reviewer look out for in this PR?
Is there any other place / a better place that I should document the -f flag?

### Which issue(s) does this PR fix?
fixes #1497
fixes #1540
