### PR TITLE
status: remove -detailed flag from help

### DIFF
--- a/cmd/dep/status.go
+++ b/cmd/dep/status.go
@@ -34,12 +34,6 @@ With no arguments, print the status of each dependency of the project.
   LATEST      Latest VCS revision available
   PKGS USED   Number of packages from this project that are actually used
 
-With one or more explicitly specified packages, or with the -detailed flag,
-print an extended status output for each dependency of the project.
-
-  TODO    Another column description
-  FOOBAR  Another column description
-
 Status returns exit code zero if all dependencies are in a "good state".
 `
 


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

### What does this do / why do we need it?
We no longer have -detailed flag. Remove it from status help. A similar paragraph for
project status would be added later for #1367 .

### What should your reviewer look out for in this PR?
Nothing. Just a cleanup.

### Do you need help or clarification on anything?
No.

### Which issue(s) does this PR fix?
None.
<!--

fixes #
fixes #

-->
