### PR TITLE
Fix ignored per-project prune options (#1561)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ NEW FEATURES:
 
 BUG FIXES:
 
+* Fix per-project prune option handling ([#1562](https://github.com/golang/dep/pull/1562))
+
 IMPROVEMENTS:
 
 # v0.4.0

--- a/manifest.go
+++ b/manifest.go
@@ -403,13 +403,13 @@ func fromRawPruneOptions(raw rawPruneOptions) gps.RootPruneOptions {
 		pr := gps.ProjectRoot(p.Name)
 		opts.ProjectOptions[pr] = gps.PruneNestedVendorDirs
 
-		if raw.UnusedPackages {
+		if p.UnusedPackages {
 			opts.ProjectOptions[pr] |= gps.PruneUnusedPackages
 		}
-		if raw.GoTests {
+		if p.GoTests {
 			opts.ProjectOptions[pr] |= gps.PruneGoTestFiles
 		}
-		if raw.NonGoFiles {
+		if p.NonGoFiles {
 			opts.ProjectOptions[pr] |= gps.PruneNonGoFiles
 		}
 	}

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -608,6 +608,69 @@ func TestValidateProjectRoots(t *testing.T) {
 	}
 }
 
+func TestFromRawPruneOptions(t *testing.T) {
+	cases := []struct {
+		name            string
+		rawPruneOptions rawPruneOptions
+		wantOptions     gps.RootPruneOptions
+	}{
+		{
+			name: "global all options project no options",
+			rawPruneOptions: rawPruneOptions{
+				UnusedPackages: true,
+				NonGoFiles:     true,
+				GoTests:        true,
+				Projects: []rawPruneProjectOptions{
+					{
+						Name:           "github.com/golang/dep/gps",
+						UnusedPackages: false,
+						NonGoFiles:     false,
+						GoTests:        false,
+					},
+				},
+			},
+			wantOptions: gps.RootPruneOptions{
+				PruneOptions: 15,
+				ProjectOptions: gps.PruneProjectOptions{
+					"github.com/golang/dep/gps": 1,
+				},
+			},
+		},
+		{
+			name: "global no options project all options",
+			rawPruneOptions: rawPruneOptions{
+				UnusedPackages: false,
+				NonGoFiles:     false,
+				GoTests:        false,
+				Projects: []rawPruneProjectOptions{
+					{
+						Name:           "github.com/golang/dep/gps",
+						UnusedPackages: true,
+						NonGoFiles:     true,
+						GoTests:        true,
+					},
+				},
+			},
+			wantOptions: gps.RootPruneOptions{
+				PruneOptions: 1,
+				ProjectOptions: gps.PruneProjectOptions{
+					"github.com/golang/dep/gps": 15,
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			opts := fromRawPruneOptions(c.rawPruneOptions)
+
+			if !reflect.DeepEqual(opts, c.wantOptions) {
+				t.Fatalf("rawPruneOptions are not as expected:\n\t(GOT) %v\n\t(WNT) %v", opts, c.wantOptions)
+			}
+		})
+	}
+}
+
 func TestToRawPruneOptions(t *testing.T) {
 	cases := []struct {
 		name         string


### PR DESCRIPTION
### What does this do / why do we need it?
Per-project prune option handling is broken in v0.4.0. This PR fixes the handling and add corresponding
tests.

### Which issue(s) does this PR fix?

Fixes #1561 