### PR TITLE
dep: update TestReadManifest to actually check prune options

### DIFF
--- a/manifest_test.go
+++ b/manifest_test.go
@@ -64,6 +64,10 @@ func TestReadManifest(t *testing.T) {
 	if !reflect.DeepEqual(got.Ignored, want.Ignored) {
 		t.Error("Valid manifest's ignored did not parse as expected")
 	}
+	if !reflect.DeepEqual(got.PruneOptions, want.PruneOptions) {
+		t.Error("Valid manifest's prune options did not parse as expected")
+		t.Error(got.PruneOptions, want.PruneOptions)
+	}
 }
 
 func TestWriteManifest(t *testing.T) {

--- a/testdata/manifest/golden.toml
+++ b/testdata/manifest/golden.toml
@@ -12,3 +12,15 @@ ignored = ["github.com/foo/bar"]
   branch = "master"
   name = "github.com/golang/dep"
   source = "https://github.com/golang/dep"
+
+[prune]
+  non-go = true
+
+  [[prune.project]]
+    name = "github.com/golang/dep"
+    non-go = false
+
+  [[prune.project]]
+    name = "github.com/babble/brook"
+    non-go = false
+    go-tests = true


### PR DESCRIPTION
### What does this do / why do we need it?
I didn't complete the `TestReadManifest` in #1219 (https://github.com/golang/dep/pull/1219/files#diff-d7b85a5311d6b44f46ac202c1aa4a015). This PR fixes that.
