### PR TITLE
Enforce using literal version strings on the command line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ BUG FIXES:
 
 IMPROVEMENTS:
 
+* Only allow literal version strings as CLI constraints  ([#1036](https://github.com/golang/dep/issues/1036))
+
 # v0.4.1
 
 BUG FIXES:

--- a/cmd/dep/testdata/harness_tests/ensure/add/all-new-double-spec/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/ensure/add/all-new-double-spec/final/Gopkg.lock
@@ -16,6 +16,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "645b5b52e1bfb9e3db1cefde758485e009edfe5bad611b490582d94467f9c1b0"
+  inputs-digest = "1f650e0dab960c9e8e8849ab842ee9961bef4892b2fa65466bb3f23c62136768"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/dep/testdata/harness_tests/ensure/add/all-new-double-spec/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/ensure/add/all-new-double-spec/final/Gopkg.toml
@@ -9,4 +9,4 @@
 
 [[constraint]]
   name = "github.com/sdboyer/deptest"
-  version = "0.8.1"
+  version = "=0.8.1"

--- a/cmd/dep/testdata/harness_tests/ensure/add/all-new-spec/final/Gopkg.lock
+++ b/cmd/dep/testdata/harness_tests/ensure/add/all-new-spec/final/Gopkg.lock
@@ -16,6 +16,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "645b5b52e1bfb9e3db1cefde758485e009edfe5bad611b490582d94467f9c1b0"
+  inputs-digest = "1f650e0dab960c9e8e8849ab842ee9961bef4892b2fa65466bb3f23c62136768"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/dep/testdata/harness_tests/ensure/add/all-new-spec/final/Gopkg.toml
+++ b/cmd/dep/testdata/harness_tests/ensure/add/all-new-spec/final/Gopkg.toml
@@ -9,4 +9,4 @@
 
 [[constraint]]
   name = "github.com/sdboyer/deptest"
-  version = "0.8.1"
+  version = "=0.8.1"

--- a/cmd/dep/testdata/harness_tests/ensure/update/errs/spec-with-source/testcase.json
+++ b/cmd/dep/testdata/harness_tests/ensure/update/errs/spec-with-source/testcase.json
@@ -2,5 +2,5 @@
   "commands": [
     ["ensure", "-update", "github.com/sdboyer/deptest@1.0.0"]
   ],
-  "error-expected": "version constraint ^1.0.0 passed for github.com/sdboyer/deptest, but -update follows constraints declared in"
+  "error-expected": "version constraint 1.0.0 passed for github.com/sdboyer/deptest, but -update follows constraints declared in"
 }


### PR DESCRIPTION
This change adds a check to ensure that only literal version strings are used on
the command line. This impacts both `dep ensure -add` and `dep update`.

This  allows version strings to be formatted with or without the leading
`v` (`v0.0.0` or `0.0.0`).

Fixes #1036

Signed-off-by: Tim Heckman <t@heckman.io>