### PR TITLE
Update release notes link in v0.4.1 blog post

### DIFF
--- a/website/blog/2018-01-23-announce-v0.4.0.md
+++ b/website/blog/2018-01-23-announce-v0.4.0.md
@@ -4,7 +4,7 @@ author: sam boyer
 authorURL: http://twitter.com/sdboyer
 ---
 
-v0.4.0 of dep has been released - and along with it, this site for documentation and announcements about dep! And, being that it's been nearly six months since [the last dep status update](https://sdboyer.io/dep-status/2017-08-17/) (which are now officially discontinued, in favor of this blog), and the roadmap hasn't been substantially updated in even longer, we'll use this release as an excuse to bring a bunch of things up to speed.
+v0.4.1 of dep has been released - and along with it, this site for documentation and announcements about dep! And, being that it's been nearly six months since [the last dep status update](https://sdboyer.io/dep-status/2017-08-17/) (which are now officially discontinued, in favor of this blog), and the roadmap hasn't been substantially updated in even longer, we'll use this release as an excuse to bring a bunch of things up to speed.
 
 _Note: there was [a significant omission](https://github.com/golang/dep/issues/1561) in v0.4.0's new pruning behavior, so we immediately shipped [v0.4.1](https://github.com/golang/dep/releases/tag/v0.4.1) with a fix._
 
@@ -15,7 +15,7 @@ After three months of work, the next version of dep is stable and ready for publ
 * `dep prune` no longer exists as a separate command. It has been absorbed into `dep ensure`, and its behavior can now be more granularly controlled by [directives in `Gopkg.toml`](https://golang.github.io/dep/docs/Gopkg.toml.html#prune). Calls to `dep prune` will not fail now, but will in future versions, so update your scripts!
 * Support for govendor and glock have been added; `dep init` can now read their metadata files and attempt to automatically convert projects managed by those tools.
 
-Additional information is available in [the release notes](https://github.com/golang/dep/releases/tag/v0.4.0). The other major addition is this documentation site!
+Additional information is available in [the release notes](https://github.com/golang/dep/releases/tag/v0.4.1). The other major addition is this documentation site!
 
 ### Docs docs docs
 


### PR DESCRIPTION
It's still pointing to v0.4.0 release notes, which contains that prune bug.