### PR TITLE
Print message when looking in parent

### DIFF
--- a/context.go
+++ b/context.go
@@ -113,7 +113,7 @@ func (c *Ctx) SourceManager() (*gps.SourceMgr, error) {
 // present.  The import path is calculated as the remaining path segment
 // below Ctx.GOPATH/src.
 func (c *Ctx) LoadProject() (*Project, error) {
-	root, err := findProjectRoot(c.WorkingDir)
+	root, err := findProjectRoot(c, c.WorkingDir)
 	if err != nil {
 		return nil, err
 	}

--- a/context_test.go
+++ b/context_test.go
@@ -171,7 +171,7 @@ func TestLoadProjectNotFoundErrors(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		ctx := &Ctx{GOPATHs: []string{tg.Path(".")}, WorkingDir: tg.Path(testcase.start)}
+		ctx := &Ctx{GOPATHs: []string{tg.Path(".")}, WorkingDir: tg.Path(testcase.start), Out: log.New(ioutil.Discard, "", log.LstdFlags)}
 
 		_, err := ctx.LoadProject()
 		if err == nil {

--- a/project.go
+++ b/project.go
@@ -22,7 +22,7 @@ var (
 
 // findProjectRoot searches from the starting directory upwards looking for a
 // manifest file until we get to the root of the filesystem.
-func findProjectRoot(from string) (string, error) {
+func findProjectRoot(c *Ctx, from string) (string, error) {
 	for {
 		mp := filepath.Join(from, ManifestName)
 
@@ -33,6 +33,10 @@ func findProjectRoot(from string) (string, error) {
 		if !os.IsNotExist(err) {
 			// Some err other than non-existence - return that out
 			return "", err
+		}
+
+		if c != nil && c.Out != nil {
+			c.Out.Printf("No %s, looking in parent", mp)
 		}
 
 		parent := filepath.Dir(from)


### PR DESCRIPTION
### What does this do

It prints out a message when looking for manifest in parent directory

### Why do we need it?

This communicates where it found a manifest. If the manifest is not found, it communicates more where to start looking

### What should your reviewer look out for in this PR?

Is the message format as wanted

### Which issue(s) does this PR fix?

Improves for cases like #1576