### PR TITLE
Fixes and cleanup to build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /licenseok
 /profile.out
 /coverage.txt
+release/

--- a/hack/build-all.bash
+++ b/hack/build-all.bash
@@ -5,37 +5,44 @@
 #
 # This script will build dep and calculate hash for each
 # (DEP_BUILD_PLATFORMS, DEP_BUILD_ARCHS) pair.
-# DEP_BUILD_PLATFORMS="linux" DEP_BUILD_ARCHS="amd64" ./hack/build-all.sh
+# DEP_BUILD_PLATFORMS="linux" DEP_BUILD_ARCHS="amd64" ./hack/build-all.bash
 # can be called to build only for linux-amd64
 
 set -e
 
+DEP_ROOT=$(git rev-parse --show-toplevel)
 VERSION=$(git describe --tags --dirty)
 COMMIT_HASH=$(git rev-parse --short HEAD 2>/dev/null)
 DATE=$(date "+%Y-%m-%d")
 
-GO_BUILD_CMD="go build -a -installsuffix cgo"
-GO_BUILD_LDFLAGS="-s -w -X main.commitHash=$COMMIT_HASH -X main.buildDate=$DATE -X main.version=$VERSION"
+if [[ "$(pwd)" != "${DEP_ROOT}" ]]; then
+  echo "you are not in the root of the repo" 1>&2
+  echo "please cd to ${DEP_ROOT} before running this script" 1>&2
+  exit 1
+fi
 
-if [ -z "$DEP_BUILD_PLATFORMS" ]; then
+GO_BUILD_CMD="go build -a -installsuffix cgo"
+GO_BUILD_LDFLAGS="-s -w -X main.commitHash=${COMMIT_HASH} -X main.buildDate=${DATE} -X main.version=${VERSION}"
+
+if [[ -z "${DEP_BUILD_PLATFORMS}" ]]; then
     DEP_BUILD_PLATFORMS="linux windows darwin freebsd"
 fi
 
-if [ -z "$DEP_BUILD_ARCHS" ]; then
+if [[ -z "${DEP_BUILD_ARCHS}" ]]; then
     DEP_BUILD_ARCHS="amd64 386"
 fi
 
-mkdir -p release
+mkdir -p "${DEP_ROOT}/release"
 
 for OS in ${DEP_BUILD_PLATFORMS[@]}; do
   for ARCH in ${DEP_BUILD_ARCHS[@]}; do
-    NAME="dep-$OS-$ARCH"
-    if [ "$OS" == "windows" ]; then
-      NAME="$NAME.exe"
+    NAME="dep-${OS}-${ARCH}"
+    if [[ "${OS}" == "windows" ]]; then
+      NAME="${NAME}.exe"
     fi
-    echo "Building for $OS/$ARCH"
-    GOARCH=$ARCH GOOS=$OS CGO_ENABLED=0 $GO_BUILD_CMD -ldflags "$GO_BUILD_LDFLAGS"\
-     -o "release/$NAME" ./cmd/dep/
-    shasum -a 256 "release/$NAME" > "release/$NAME".sha256
+    echo "Building for ${OS}/${ARCH}"
+    GOARCH=${ARCH} GOOS=${OS} CGO_ENABLED=0 ${GO_BUILD_CMD} -ldflags "${GO_BUILD_LDFLAGS}"\
+     -o "${DEP_ROOT}/release/${NAME}" ./cmd/dep/
+    shasum -a 256 "${DEP_ROOT}/release/${NAME}" > "${DEP_ROOT}/release/${NAME}".sha256
   done
 done


### PR DESCRIPTION
### What does this do / why do we need it?
This change has a few simple improvements to the bash build script, such as ensuring that you're in the root of the repo, to ensure it will work. It also encloses all variable calls in curly brackets, and adds the `release/` output dir to the gitignore.

I was cleaning this up as a knock on to https://github.com/Homebrew/homebrew-core/pull/23360 so that users of homebrew can get full version information.

### What should your reviewer look out for in this PR?
This should have no functional change.

### Do you need help or clarification on anything?
Nope!

### Which issue(s) does this PR fix?
None
