### PR TITLE
Remove description about `dep prune`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,9 +43,7 @@ use GitHub pull requests for this purpose. Consult [GitHub Help] for more
 information on using pull requests.
 
 We check `dep`'s own `vendor` directory into git. For any PR to `dep` where you're
-updating `Gopkg.toml`, make sure to run `dep ensure` and
-([for now](https://github.com/golang/dep/issues/944)) `dep prune` and commit all
-changes to `vendor`.
+updating `Gopkg.toml`, make sure to run `dep ensure` and commit all changes to `vendor`.
 
 [GitHub Help]: https://help.github.com/articles/about-pull-requests/
 


### PR DESCRIPTION
### What does this do / why do we need it?

Fixed that the explanation was described to execute `dep prune` when `Gopkg.toml` was updated. 
Because now it is no longer necessary to manually run `dep prune`.
