### PR TITLE
docs/FAQ.md: fix typo in relative URL 

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -223,7 +223,7 @@ how to add support for another tool.
 
 ## Why is `dep` ignoring a version constraint in the manifest?
 Only your project's directly imported dependencies are affected by a `constraint` entry
-in the manifest. Transitive dependencies are unaffected. See [How do I constrain a transitive dependency's version](#how-do-i-constrain-a-transitive-dependencys-version)?
+in the manifest. Transitive dependencies are unaffected. See [How do I constrain a transitive dependency's version](#how-do-i-constrain-a-transitive-dependency-s-version)?
 
 ## Why did `dep` use a different revision for package X instead of the revision in the lock file?
 Sometimes the revision specified in the lock file is no longer valid. There are a few


### PR DESCRIPTION
the link “How do I constrain a transitive dependency’s version” points to https://golang.github.io/dep/docs/FAQ.html#how-do-i-constrain-a-transitive-dependencys-version, should be https://golang.github.io/dep/docs/FAQ.html#how-do-i-constrain-a-transitive-dependency-s-version (dash after “depedency”)