### PR TITLE
Docs: Clarify early what files are checked in

### DIFF
--- a/docs/new-project.md
+++ b/docs/new-project.md
@@ -36,9 +36,9 @@ $ dep ensure -add github.com/foo/bar github.com/baz/quux
 
 ### One Final Note
 
-When you've finished adding / tweaking your dependencies you should make sure to check in both the [Gopkg.toml](Gopkg.toml.md) and the [Gopkg.lock](Gopkg.lock.md).
+When you've finished adding / tweaking your dependencies you should make sure to check in both [Gopkg.toml](Gopkg.toml.md) and [Gopkg.lock](Gopkg.lock.md).
 
-This two files work together to ensure that `dep` can provide reproducible builds. We hear you saying, "well, what about checking in vendor/".
+These two files work together to ensure that `dep` can provide reproducible builds. We hear you saying, "well, what about checking in vendor/".
 
 The decision to check in your `vendor/` is a bit more nuanced. You should check out the [pros/cons](FAQ.md#should-i-commit-my-vendor-directory).
 

--- a/docs/new-project.md
+++ b/docs/new-project.md
@@ -16,7 +16,7 @@ $ mkdir -p $GOPATH/src/github.com/me/example
 $ cd $GOPATH/src/github.com/me/example
 ```
 
-Now, we'll initialize the project:
+### Initialize the Project
 
 ```bash
 $ dep init
@@ -33,5 +33,13 @@ At this point, our project is initialized, and we're ready to start writing code
 ```bash
 $ dep ensure -add github.com/foo/bar github.com/baz/quux
 ```
+
+### One Final Note
+
+When you've finished adding / tweaking your dependencies you should make sure to check in both the [Gopkg.toml](Gopkg.toml.md) and the [Gopkg.lock](Gopkg.lock.md).
+
+This two files work together to ensure that `dep` can provide reproducible builds. We hear you saying, "well, what about checking in vendor/".
+
+The decision to check in your `vendor/` is a bit more nuanced. You should check out the [pros/cons](FAQ.md#should-i-commit-my-vendor-directory).
 
 Now you're ready to move on to [Daily Dep](daily-dep.md)!


### PR DESCRIPTION
Related to this conversation that occurred in the vendor slack:

https://gophers.slack.com/archives/C0M5YP9LN/p1516811755000674

I've seen quite a few newer dep users fail to check in their `lock` and/or `toml` files.

This intro attempts to clarify that.