### PR TITLE
Fix case of Gopkg.toml.md links in the docs

### DIFF
--- a/docs/daily-dep.md
+++ b/docs/daily-dep.md
@@ -101,7 +101,7 @@ Only if it is the first/last import of a project being added/removed - cases 3 a
 
 ### Rule changes in `Gopkg.toml`
 
-`Gopkg.toml` files contain five basic types of rules. The  [`Gopkg.toml` docs](gopkg.toml.md) explain them in detail, but here's an overview:
+`Gopkg.toml` files contain five basic types of rules. The  [`Gopkg.toml` docs](Gopkg.toml.md) explain them in detail, but here's an overview:
 
 * `required`, which are mostly equivalent to `import` statements in `.go` files, except that it's OK to list a `main` package here
 * `ignored`, which causes dep to black hole an import path (and any imports it uniquely introduces)

--- a/docs/deduction.md
+++ b/docs/deduction.md
@@ -21,6 +21,6 @@ If the static logic cannot identify the root for a given import path, the algori
 Import path deduction is applied to all of the following:
 
 * `import` statements found in all `.go` files
-* Import paths in the [`required`](gopkg.toml.md#required) list in `Gopkg.toml`
+* Import paths in the [`required`](Gopkg.toml.md#required) list in `Gopkg.toml`
 * `name` properties in both [`[[constraint]]`](Gopkg.toml.md#constraint) and [`[[override]]`](Gopkg.toml.md#override) stanzas in `Gopkg.toml`. This is solely for validation purposes, enforcing that these names correspond only to project/source roots.
 

--- a/docs/failure-modes.md
+++ b/docs/failure-modes.md
@@ -183,7 +183,7 @@ It means that the solver was unable to find a combination of versions for all de
 
 These rules, and specific remediations for failing to meet them, are described in detail in the section on [solver invariants](the-solver.md#solving-invariants). This section is about the steps to take when solving failures occur in general. But, to set context, here's a summary:
 
-* **`[[constraint]]` conflicts:** when projects in the dependency graph disagree on what [versions](gopkg.toml.md#version-rules) are acceptable for a project, or where to [source](gopkg.toml.md#source) it from.
+* **`[[constraint]]` conflicts:** when projects in the dependency graph disagree on what [versions](Gopkg.toml.md#version-rules) are acceptable for a project, or where to [source](Gopkg.toml.md#source) it from.
   * Remediation will usually be either changing a `[[constraint]]` or adding an `[[override]]`, but genuine conflicts may require forking and hacking code.
 * **Package validity failure:** when an imported package is quite obviously not capable of being built. 
   * There usually isn't much remediation here beyond "stop importing that," as it indicates something broken at a particular version.

--- a/docs/the-solver.md
+++ b/docs/the-solver.md
@@ -19,7 +19,7 @@ The solver is an iterative algorithm, working its way project-by-project through
 
 ### `[[constraint]]` rules
 
-As described in the `Gopkg.toml` docs, each [`[[constraint]]`](gopkg.toml.md#constraint) stanza is associated with a single project, and each stanza can contain both [a version rule](Gopkg.toml.md#version-rules) and a [source rule](Gopkg.toml.md#source). For any given project `P`, all dependers on `P` whose constraint rules are "activated" must express mutually compatible rules. That means:
+As described in the `Gopkg.toml` docs, each [`[[constraint]]`](Gopkg.toml.md#constraint) stanza is associated with a single project, and each stanza can contain both [a version rule](Gopkg.toml.md#version-rules) and a [source rule](Gopkg.toml.md#source). For any given project `P`, all dependers on `P` whose constraint rules are "activated" must express mutually compatible rules. That means:
 
 * For version rules, all activated constraints on `P` must [intersect](https://en.wikipedia.org/wiki/Intersection_(set_theory)), and and there must be at least one published version must exist in the intersecting space. Intersection varies depending on version rule type:
   * For `revision` and `branch`, it must be a string-literal match.
@@ -27,7 +27,7 @@ As described in the `Gopkg.toml` docs, each [`[[constraint]]`](gopkg.toml.md#con
   * For `version` that are valid semantic version ranges, intersection is standard set-theoretic intersection of the possible values in each range range. Semantic versions without ranges are treated as a single element set (e.g., `version = "=v1.0.0"`) for intersection purposes.
 * For `source` rules, all projects with a particular dependency must either express a string-equal `source` value, or have no `source` value at all. This allows one dependency to specify an alternate `source`, and other dependencies to play along if they have no opinion. (NB: this play-along behavior may be removed in a future version.)
 
-If the current project's `Gopkg.toml` has an [`[[override]]`](gopkg.toml.md#override) on `P`, then all `[[constraint]]` declarations (including any in the current project) are ignored, obviating the possibility of conflict.
+If the current project's `Gopkg.toml` has an [`[[override]]`](Gopkg.toml.md#override) on `P`, then all `[[constraint]]` declarations (including any in the current project) are ignored, obviating the possibility of conflict.
 
 #### Activated constraints
 


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

### What does this do / why do we need it?

Use of the lowercased name (gopkg.toml.md) was resulting in 404s.