### PR TITLE
Amend prune command line message to include doc link

### DIFF
--- a/cmd/dep/prune.go
+++ b/cmd/dep/prune.go
@@ -42,10 +42,11 @@ func (cmd *pruneCommand) Register(fs *flag.FlagSet) {
 
 func (cmd *pruneCommand) Run(ctx *dep.Ctx, args []string) error {
 	ctx.Err.Printf("Pruning is now performed automatically by dep ensure.\n")
-	ctx.Err.Printf("Set prune settings in %s and it it will be applied when running ensure.\n", dep.ManifestName)
+	ctx.Err.Printf("Set prune settings in %s and it will be applied when running ensure.\n", dep.ManifestName)
 	ctx.Err.Printf("\nThis command currently still prunes as it always has, to ease the transition.\n")
 	ctx.Err.Printf("However, it will be removed in a future version of dep.\n")
 	ctx.Err.Printf("\nNow is the time to update your Gopkg.toml and remove `dep prune` from any scripts.\n")
+	ctx.Err.Printf("\nFor more information, see: https://golang.github.io/dep/docs/Gopkg.toml.html#prune\n")
 
 	p, err := ctx.LoadProject()
 	if err != nil {


### PR DESCRIPTION
Adds the doc link to how to add prune config to Gopkg.toml and fixes typo.

fixes #1579
