### PR TITLE
log.Logger api changes

### DIFF
--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -10,7 +10,6 @@ import (
 	"flag"
 	"fmt"
 	"go/build"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -288,9 +287,9 @@ func (cmd *ensureCommand) runDefault(ctx *dep.Ctx, args []string, p *dep.Project
 			return sw.PrintPreparedActions(ctx.Out, ctx.Verbose)
 		}
 
-		logger := ctx.Err
-		if !ctx.Verbose {
-			logger = log.New(ioutil.Discard, "", 0)
+		var logger *log.Logger
+		if ctx.Verbose {
+			logger = ctx.Err
 		}
 		return errors.WithMessage(sw.Write(p.AbsRoot, sm, true, logger), "grouped write of manifest, lock and vendor")
 	}
@@ -312,9 +311,9 @@ func (cmd *ensureCommand) runDefault(ctx *dep.Ctx, args []string, p *dep.Project
 		return sw.PrintPreparedActions(ctx.Out, ctx.Verbose)
 	}
 
-	logger := ctx.Err
-	if !ctx.Verbose {
-		logger = log.New(ioutil.Discard, "", 0)
+	var logger *log.Logger
+	if ctx.Verbose {
+		logger = ctx.Err
 	}
 	return errors.Wrap(sw.Write(p.AbsRoot, sm, false, logger), "grouped write of manifest, lock and vendor")
 }
@@ -338,9 +337,9 @@ func (cmd *ensureCommand) runVendorOnly(ctx *dep.Ctx, args []string, p *dep.Proj
 		return sw.PrintPreparedActions(ctx.Out, ctx.Verbose)
 	}
 
-	logger := ctx.Err
-	if !ctx.Verbose {
-		logger = log.New(ioutil.Discard, "", 0)
+	var logger *log.Logger
+	if ctx.Verbose {
+		logger = ctx.Err
 	}
 	return errors.WithMessage(sw.Write(p.AbsRoot, sm, true, logger), "grouped write of manifest, lock and vendor")
 }
@@ -402,9 +401,9 @@ func (cmd *ensureCommand) runUpdate(ctx *dep.Ctx, args []string, p *dep.Project,
 		return sw.PrintPreparedActions(ctx.Out, ctx.Verbose)
 	}
 
-	logger := ctx.Err
-	if !ctx.Verbose {
-		logger = log.New(ioutil.Discard, "", 0)
+	var logger *log.Logger
+	if ctx.Verbose {
+		logger = ctx.Err
 	}
 	return errors.Wrap(sw.Write(p.AbsRoot, sm, false, logger), "grouped write of manifest, lock and vendor")
 }
@@ -702,9 +701,9 @@ func (cmd *ensureCommand) runAdd(ctx *dep.Ctx, args []string, p *dep.Project, sm
 		return sw.PrintPreparedActions(ctx.Out, ctx.Verbose)
 	}
 
-	logger := ctx.Err
-	if !ctx.Verbose {
-		logger = log.New(ioutil.Discard, "", 0)
+	var logger *log.Logger
+	if ctx.Verbose {
+		logger = ctx.Err
 	}
 	if err := errors.Wrap(sw.Write(p.AbsRoot, sm, true, logger), "grouped write of manifest, lock and vendor"); err != nil {
 		return err

--- a/cmd/dep/init.go
+++ b/cmd/dep/init.go
@@ -7,7 +7,6 @@ package main
 import (
 	"context"
 	"flag"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -185,9 +184,9 @@ func (cmd *initCommand) Run(ctx *dep.Ctx, args []string) error {
 		return errors.Wrap(err, "init failed: unable to create a SafeWriter")
 	}
 
-	logger := ctx.Err
-	if !ctx.Verbose {
-		logger = log.New(ioutil.Discard, "", 0)
+	var logger *log.Logger
+	if ctx.Verbose {
+		logger = ctx.Err
 	}
 	if err := sw.Write(root, sm, !cmd.noExamples, logger); err != nil {
 		return errors.Wrap(err, "init failed: unable to write the manifest, lock and vendor directory to disk")

--- a/cmd/dep/prune.go
+++ b/cmd/dep/prune.go
@@ -103,7 +103,10 @@ func pruneProject(p *dep.Project, sm gps.SourceManager, logger *log.Logger) erro
 	}
 	defer os.RemoveAll(td)
 
-	if err := gps.WriteDepTree(td, p.Lock, sm, gps.CascadingPruneOptions{DefaultOptions: gps.PruneNestedVendorDirs}, logger); err != nil {
+	onWrite := func(progress gps.WriteProgress) {
+		logger.Println(progress)
+	}
+	if err := gps.WriteDepTree(td, p.Lock, sm, gps.CascadingPruneOptions{DefaultOptions: gps.PruneNestedVendorDirs}, onWrite); err != nil {
 		return err
 	}
 

--- a/gps/example.go
+++ b/gps/example.go
@@ -54,7 +54,10 @@ func main() {
 		// If no failure, blow away the vendor dir and write a new one out,
 		// stripping nested vendor directories as we go.
 		os.RemoveAll(filepath.Join(root, "vendor"))
-		gps.WriteDepTree(filepath.Join(root, "vendor"), solution, sourcemgr, true)
+		pruneOpts := gps.CascadingPruneOptions{
+			DefaultOptions: gps.PruneNestedVendorDirs | gps.PruneUnusedPackages | gps.PruneGoTestFiles,
+		}
+		gps.WriteDepTree(filepath.Join(root, "vendor"), solution, sourcemgr, pruneOpts, nil)
 	}
 }
 

--- a/gps/prune.go
+++ b/gps/prune.go
@@ -5,7 +5,6 @@
 package gps
 
 import (
-	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -138,7 +137,7 @@ var (
 
 // PruneProject remove excess files according to the options passed, from
 // the lp directory in baseDir.
-func PruneProject(baseDir string, lp LockedProject, options PruneOptions, logger *log.Logger) error {
+func PruneProject(baseDir string, lp LockedProject, options PruneOptions) error {
 	fsState, err := deriveFilesystemState(baseDir)
 
 	if err != nil {

--- a/gps/prune_test.go
+++ b/gps/prune_test.go
@@ -6,7 +6,6 @@ package gps
 
 import (
 	"io/ioutil"
-	"log"
 	"os"
 	"testing"
 
@@ -120,9 +119,8 @@ func TestPruneProject(t *testing.T) {
 	}
 
 	options := PruneNestedVendorDirs | PruneNonGoFiles | PruneGoTestFiles | PruneUnusedPackages
-	logger := log.New(ioutil.Discard, "", 0)
 
-	err := PruneProject(baseDir, lp, options, logger)
+	err := PruneProject(baseDir, lp, options)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/gps/solution.go
+++ b/gps/solution.go
@@ -47,6 +47,7 @@ type solution struct {
 	solv Solver
 }
 
+// WriteProgress informs about the progress of WriteDepTree.
 type WriteProgress struct {
 	Count   int
 	Total   int

--- a/gps/solution.go
+++ b/gps/solution.go
@@ -7,7 +7,6 @@ package gps
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"sync"
@@ -48,6 +47,21 @@ type solution struct {
 	solv Solver
 }
 
+type WriteProgress struct {
+	Count   int
+	Total   int
+	LP      LockedProject
+	Failure bool
+}
+
+func (p WriteProgress) String() string {
+	msg := "Wrote"
+	if p.Failure {
+		msg = "Failed to write"
+	}
+	return fmt.Sprintf("(%d/%d) %s %s@%s", p.Count, p.Total, msg, p.LP.Ident(), p.LP.Version())
+}
+
 const concurrentWriters = 16
 
 // WriteDepTree takes a basedir, a Lock and a RootPruneOptions and exports all
@@ -58,7 +72,9 @@ const concurrentWriters = 16
 //
 // It requires a SourceManager to do the work. Prune options are read from the
 // passed manifest.
-func WriteDepTree(basedir string, l Lock, sm SourceManager, co CascadingPruneOptions, logger *log.Logger) error {
+//
+// If onWrite is not nil, it will be called after each project write. Calls are ordered and atomic.
+func WriteDepTree(basedir string, l Lock, sm SourceManager, co CascadingPruneOptions, onWrite func(WriteProgress)) error {
 	if l == nil {
 		return fmt.Errorf("must provide non-nil Lock to WriteDepTree")
 	}
@@ -95,7 +111,7 @@ func WriteDepTree(basedir string, l Lock, sm SourceManager, co CascadingPruneOpt
 					return errors.Wrapf(err, "failed to export %s", projectRoot)
 				}
 
-				err := PruneProject(to, p, co.PruneOptionsFor(ident.ProjectRoot), logger)
+				err := PruneProject(to, p, co.PruneOptionsFor(ident.ProjectRoot))
 				if err != nil {
 					return errors.Wrapf(err, "failed to prune %s", projectRoot)
 				}
@@ -105,18 +121,20 @@ func WriteDepTree(basedir string, l Lock, sm SourceManager, co CascadingPruneOpt
 
 			switch err {
 			case context.Canceled, context.DeadlineExceeded:
-				// Don't log "secondary" errors.
+				// Don't report "secondary" errors.
 			default:
-				msg := "Wrote"
-				if err != nil {
-					msg = "Failed to write"
+				if onWrite != nil {
+					// Increment and call atomically to prevent re-ordering.
+					cnt.Lock()
+					cnt.i++
+					onWrite(WriteProgress{
+						Count:   cnt.i,
+						Total:   len(lps),
+						LP:      p,
+						Failure: err != nil,
+					})
+					cnt.Unlock()
 				}
-
-				// Log and increment atomically to prevent re-ordering.
-				cnt.Lock()
-				cnt.i++
-				logger.Printf("(%d/%d) %s %s@%s\n", cnt.i, len(lps), msg, p.Ident(), p.Version())
-				cnt.Unlock()
 			}
 
 			return err

--- a/gps/solution_test.go
+++ b/gps/solution_test.go
@@ -16,10 +16,6 @@ import (
 	"github.com/golang/dep/internal/test"
 )
 
-func discardLogger() *log.Logger {
-	return log.New(ioutil.Discard, "", 0)
-}
-
 var basicResult solution
 
 func pi(n string) ProjectIdentifier {
@@ -109,12 +105,12 @@ func testWriteDepTree(t *testing.T) {
 	}
 
 	// nil lock/result should err immediately
-	err = WriteDepTree(tmp, nil, sm, defaultCascadingPruneOptions(), discardLogger())
+	err = WriteDepTree(tmp, nil, sm, defaultCascadingPruneOptions(), nil)
 	if err == nil {
 		t.Errorf("Should error if nil lock is passed to WriteDepTree")
 	}
 
-	err = WriteDepTree(tmp, r, sm, defaultCascadingPruneOptions(), discardLogger())
+	err = WriteDepTree(tmp, r, sm, defaultCascadingPruneOptions(), nil)
 	if err != nil {
 		t.Errorf("Unexpected error while creating vendor tree: %s", err)
 	}
@@ -157,7 +153,6 @@ func BenchmarkCreateVendorTree(b *testing.B) {
 	}
 
 	if clean {
-		logger := discardLogger()
 		b.ResetTimer()
 		b.StopTimer()
 		exp := path.Join(tmp, "export")
@@ -166,7 +161,7 @@ func BenchmarkCreateVendorTree(b *testing.B) {
 			// ease manual inspection
 			os.RemoveAll(exp)
 			b.StartTimer()
-			err = WriteDepTree(exp, r, sm, defaultCascadingPruneOptions(), logger)
+			err = WriteDepTree(exp, r, sm, defaultCascadingPruneOptions(), nil)
 			b.StopTimer()
 			if err != nil {
 				b.Errorf("unexpected error after %v iterations: %s", i, err)

--- a/txn_writer_test.go
+++ b/txn_writer_test.go
@@ -34,7 +34,7 @@ func TestSafeWriter_BadInput_MissingRoot(t *testing.T) {
 	defer pc.Release()
 
 	sw, _ := NewSafeWriter(nil, nil, nil, VendorOnChanged, defaultCascadingPruneOptions())
-	err := sw.Write("", pc.SourceManager, true, discardLogger())
+	err := sw.Write("", pc.SourceManager, true, nil)
 
 	if err == nil {
 		t.Fatal("should have errored without a root path, but did not")
@@ -52,7 +52,7 @@ func TestSafeWriter_BadInput_MissingSourceManager(t *testing.T) {
 	pc.Load()
 
 	sw, _ := NewSafeWriter(nil, nil, pc.Project.Lock, VendorAlways, defaultCascadingPruneOptions())
-	err := sw.Write(pc.Project.AbsRoot, nil, true, discardLogger())
+	err := sw.Write(pc.Project.AbsRoot, nil, true, nil)
 
 	if err == nil {
 		t.Fatal("should have errored without a source manager when forceVendor is true, but did not")
@@ -100,7 +100,7 @@ func TestSafeWriter_BadInput_NonexistentRoot(t *testing.T) {
 	sw, _ := NewSafeWriter(nil, nil, nil, VendorOnChanged, defaultCascadingPruneOptions())
 
 	missingroot := filepath.Join(pc.Project.AbsRoot, "nonexistent")
-	err := sw.Write(missingroot, pc.SourceManager, true, discardLogger())
+	err := sw.Write(missingroot, pc.SourceManager, true, nil)
 
 	if err == nil {
 		t.Fatal("should have errored with nonexistent dir for root path, but did not")
@@ -118,7 +118,7 @@ func TestSafeWriter_BadInput_RootIsFile(t *testing.T) {
 	sw, _ := NewSafeWriter(nil, nil, nil, VendorOnChanged, defaultCascadingPruneOptions())
 
 	fileroot := pc.CopyFile("fileroot", "txn_writer/badinput_fileroot")
-	err := sw.Write(fileroot, pc.SourceManager, true, discardLogger())
+	err := sw.Write(fileroot, pc.SourceManager, true, nil)
 
 	if err == nil {
 		t.Fatal("should have errored when root path is a file, but did not")
@@ -153,7 +153,7 @@ func TestSafeWriter_Manifest(t *testing.T) {
 	}
 
 	// Write changes
-	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, discardLogger())
+	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, nil)
 	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
 	// Verify file system changes
@@ -198,7 +198,7 @@ func TestSafeWriter_ManifestAndUnmodifiedLock(t *testing.T) {
 	}
 
 	// Write changes
-	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, discardLogger())
+	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, nil)
 	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
 	// Verify file system changes
@@ -243,7 +243,7 @@ func TestSafeWriter_ManifestAndUnmodifiedLockWithForceVendor(t *testing.T) {
 	}
 
 	// Write changes
-	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, discardLogger())
+	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, nil)
 	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
 	// Verify file system changes
@@ -293,7 +293,7 @@ func TestSafeWriter_ModifiedLock(t *testing.T) {
 	}
 
 	// Write changes
-	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, discardLogger())
+	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, nil)
 	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
 	// Verify file system changes
@@ -343,7 +343,7 @@ func TestSafeWriter_ModifiedLockSkipVendor(t *testing.T) {
 	}
 
 	// Write changes
-	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, discardLogger())
+	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, nil)
 	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
 	// Verify file system changes
@@ -371,7 +371,7 @@ func TestSafeWriter_ForceVendorWhenVendorAlreadyExists(t *testing.T) {
 	pc.Load()
 
 	sw, _ := NewSafeWriter(nil, pc.Project.Lock, pc.Project.Lock, VendorAlways, defaultCascadingPruneOptions())
-	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, discardLogger())
+	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, nil)
 	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
 	// Verify prepared actions
@@ -389,7 +389,7 @@ func TestSafeWriter_ForceVendorWhenVendorAlreadyExists(t *testing.T) {
 		t.Fatal("Expected the payload to contain the vendor directory ")
 	}
 
-	err = sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, discardLogger())
+	err = sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, nil)
 	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
 	// Verify file system changes
@@ -439,7 +439,7 @@ func TestSafeWriter_NewLock(t *testing.T) {
 	}
 
 	// Write changes
-	err = sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, discardLogger())
+	err = sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, nil)
 	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
 	// Verify file system changes
@@ -486,7 +486,7 @@ func TestSafeWriter_NewLockSkipVendor(t *testing.T) {
 	}
 
 	// Write changes
-	err = sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, discardLogger())
+	err = sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, nil)
 	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
 	// Verify file system changes
@@ -579,7 +579,7 @@ func TestSafeWriter_VendorDotGitPreservedWithForceVendor(t *testing.T) {
 		t.Fatal("Expected the payload to contain the vendor directory")
 	}
 
-	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, discardLogger())
+	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, nil)
 	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
 	// Verify file system changes


### PR DESCRIPTION
### What does this do / why do we need it?

This PR proposes making some exported API surrounding logging more flexible.  The effect is simpler caller code (e.g. `nil` rather than `discardLogger`), and completely removing some "log" imports from gps.

gps:
 - PruneProject: remove unused logger
 - WriteDepTree: swap logger for onWrite callback
 - fix example

dep:
 - SafeWriter.Write: nilable logger

cmd:
 - ensure/prune/init: react to changes

### Do you need help or clarification on anything?

Is there a better name for `gps.WriteProgress`?

### Which issue(s) does this PR fix?

Towards #672.