### PR TITLE
increment CI go versions from 1.8.x/1.9.x/tip to 1.9.x/1.10.x/tip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jobs:
       env:
         - DEPTESTBYPASS501=1
       os: linux
-      go: 1.9.x
+      go: "1.10"
       script:
         - go test -i ./...
         - ./hack/lint.bash
@@ -23,18 +23,18 @@ jobs:
         - codeclimate-test-reporter < coverage.txt
     # YAML alias, for settings shared across the simpler builds
     - &simple-test
-      go: 1.8.x
+      go: 1.9.x
       stage: test
       go_import_path: github.com/golang/dep
       install: skip
       env:
         - DEPTESTBYPASS501=1
-      script: go test -race $(go list ./... | grep -v vendor)
+      script: go test -race ./...
     - <<: *simple-test
       go: tip
     - <<: *simple-test
       os: osx
-      go: 1.9.x
+      go: "1.10"
       install:
         # brew takes horribly long to update itself despite the above caching
         # attempt; only bzr install if it's not on the $PATH
@@ -50,7 +50,7 @@ jobs:
         # Related: https://superuser.com/questions/1044130/why-am-i-having-how-can-i-fix-this-error-shell-session-update-command-not-f
         - trap EXIT
         - go test -race ./...
-    - go: 1.9.x
+    - go: "1.10"
       stage: deploy
       go_import_path: github.com/golang/dep
       install: skip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 NEW FEATURES:
 
+* Add CI tests against go1.10. Drop support for go1.8.
+
 BUG FIXES:
 
 IMPROVEMENTS:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ clone_folder: c:\gopath\src\github.com\golang\dep
 environment:
   GOPATH: c:\gopath
   DEPTESTBYPASS501: 1
-  GOVERSION: 1.8
+  GOVERSION: 1.9
 
 init:
   - git config --global core.autocrlf input
@@ -31,4 +31,4 @@ deploy: false
 
 test_script:
   - go build github.com/golang/dep/cmd/dep
-  - for /f "" %%G in ('go list github.com/golang/dep/... ^| find /i /v "/vendor/"') do ( go test %%G & IF ERRORLEVEL == 1 EXIT 1)
+  - for /f "" %%G in ('go list github.com/golang/dep/...') do ( go test %%G & IF ERRORLEVEL == 1 EXIT 1)


### PR DESCRIPTION
### What does this do / why do we need it?

This PR increments the go versions for Travis and AppVeyor.  1.10 is only on release candidate 1, but is expected this month.  I don't know if Travis/Gimme will route `1.10.x` to `1.10rc1`, but in case it does and this turns green: **Don't merge until 1.10 is officially released!**.

- [x] Changelog
- [x] Simpler appveyor.yml init?