### PR TITLE
gps: Also remove symlinks when pruning non-go files

### DIFF
--- a/gps/prune.go
+++ b/gps/prune.go
@@ -267,7 +267,12 @@ func collectUnusedPackagesFiles(fsState filesystemState, unusedPackages map[stri
 func pruneNonGoFiles(fsState filesystemState) error {
 	toDelete := make([]string, 0, len(fsState.files)/4)
 
-	for _, path := range fsState.files {
+	paths := fsState.files
+	for _, link := range fsState.links {
+		paths = append(paths, link.path)
+	}
+
+	for _, path := range paths {
 		ext := fileExt(path)
 
 		// Refer to: https://github.com/golang/go/blob/release-branch.go1.9/src/go/build/build.go#L750

--- a/gps/prune_test.go
+++ b/gps/prune_test.go
@@ -329,6 +329,32 @@ func TestPruneNonGoFiles(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"symlinks",
+			fsTestCase{
+				before: filesystemState{
+					files: []string{
+						"target.md",
+					},
+					links: []fsLink{
+						{path: "remove-1.md", to: "target.md"},
+						{path: "remove-2.md", to: "nonexistent", broken: true},
+						{path: "remove-3.md", to: "remove-3.md", circular: true},
+						{path: "retain-1.go", to: "target.md"},
+						{path: "retain-2.go", to: "nonexistent", broken: true},
+						{path: "retain-3.go", to: "retain-3.go", circular: true},
+					},
+				},
+				after: filesystemState{
+					links: []fsLink{
+						{path: "retain-1.go", to: "target.md"},
+						{path: "retain-2.go", to: "nonexistent", broken: true},
+						{path: "retain-3.go", to: "retain-3.go", circular: true},
+					},
+				},
+			},
+			false,
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
This treats symlinks like files when considering whether to remove them in the non-go pruning stage.

Fixes #1625.
