### PR TITLE
Fix innefective constraints message.

### DIFF
--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -209,7 +209,7 @@ func (cmd *ensureCommand) Run(ctx *dep.Ctx, args []string) error {
 		ctx.Err.Printf("these rules will have no effect.\n\n")
 		ctx.Err.Printf("Either import/require packages from these projects so that they become direct\n")
 		ctx.Err.Printf("dependencies, or convert each [[constraint]] to an [[override]] to enforce rules\n")
-		ctx.Err.Printf("on these projects, if they happen to be transitive dependencies,\n\n")
+		ctx.Err.Printf("on these projects, if they happen to be transitive dependencies.\n\n")
 	}
 
 	if cmd.add {


### PR DESCRIPTION
### What does this do / why do we need it?

```
Either import/require packages from these projects so that they become direct
dependencies, or convert each [[constraint]] to an [[override]] to enforce rules
on these projects, if they happen to be transitive dependencies,
```

This should end with a full stop instead of a comma.

### What should your reviewer look out for in this PR?

This is just a copy change so shouldn't be anything significant to watch out for.

### Which issue(s) does this PR fix?
N/A