### PR TITLE
Pr/fix legal sources

### DIFF
--- a/gps/prune.go
+++ b/gps/prune.go
@@ -261,6 +261,37 @@ func collectUnusedPackagesFiles(fsState filesystemState, unusedPackages map[stri
 	return files
 }
 
+func isSourceFile(path string) bool {
+	ext := fileExt(path)
+
+	// Refer to: https://github.com/golang/go/blob/release-branch.go1.9/src/go/build/build.go#L750
+	switch ext {
+	case ".go":
+		return true
+	case ".c":
+		return true
+	case ".cc", ".cpp", ".cxx":
+		return true
+	case ".m":
+		return true
+	case ".h", ".hh", ".hpp", ".hxx":
+		return true
+	case ".f", ".F", ".for", ".f90":
+		return true
+	case ".s":
+		return true
+	case ".S":
+		return true
+	case ".swig":
+		return true
+	case ".swigcxx":
+		return true
+	case ".syso":
+		return true
+	}
+	return false
+}
+
 // pruneNonGoFiles delete all non-Go files existing in fsState.
 //
 // Files matching licenseFilePrefixes and legalFileSubstrings are not pruned.
@@ -268,31 +299,7 @@ func pruneNonGoFiles(fsState filesystemState) error {
 	toDelete := make([]string, 0, len(fsState.files)/4)
 
 	for _, path := range fsState.files {
-		ext := fileExt(path)
-
-		// Refer to: https://github.com/golang/go/blob/release-branch.go1.9/src/go/build/build.go#L750
-		switch ext {
-		case ".go":
-			continue
-		case ".c":
-			continue
-		case ".cc", ".cpp", ".cxx":
-			continue
-		case ".m":
-			continue
-		case ".h", ".hh", ".hpp", ".hxx":
-			continue
-		case ".f", ".F", ".for", ".f90":
-			continue
-		case ".s":
-			continue
-		case ".S":
-			continue
-		case ".swig":
-			continue
-		case ".swigcxx":
-			continue
-		case ".syso":
+		if isSourceFile(path) {
 			continue
 		}
 

--- a/gps/prune.go
+++ b/gps/prune.go
@@ -322,7 +322,12 @@ func pruneNonGoFiles(fsState filesystemState) error {
 
 // isPreservedFile checks if the file name indicates that the file should be
 // preserved based on licenseFilePrefixes or legalFileSubstrings.
+// This applies only to non-source files.
 func isPreservedFile(name string) bool {
+	if isSourceFile(name) {
+		return false
+	}
+
 	name = strings.ToLower(name)
 
 	for _, prefix := range licenseFilePrefixes {

--- a/gps/prune_test.go
+++ b/gps/prune_test.go
@@ -215,6 +215,7 @@ func TestPruneUnusedPackages(t *testing.T) {
 						"COPYING",
 						"pkg/main.go",
 						"pkg/nestedpkg/main.go",
+						"pkg/nestedpkg/legal.go",
 						"pkg/nestedpkg/PATENT.md",
 						"pkg/nestedpkg/otherpkg/main.go",
 					},


### PR DESCRIPTION
### What does this do / why do we need it?

This handles cases where unneeded source files are left around just because their name sounds legalese.

For example:

    $ dep ensure -add go4.org/errorutil

    $ tree vendor/go4.org
    vendor/go4.org
    ├── AUTHORS
    ├── errorutil
    │   └── highlight.go
    ├── legal
    │   └── legal.go
    └── LICENSE

We want instead:

    $ tree vendor/go4.org
    vendor/go4.org
    ├── AUTHORS
    ├── errorutil
    │   └── highlight.go
    └── LICENSE
