### PR TITLE
godep: Import additional packages as required

### DIFF
--- a/internal/importers/godep/importer_test.go
+++ b/internal/importers/godep/importer_test.go
@@ -77,6 +77,22 @@ func TestGodepConfig_Convert(t *testing.T) {
 				},
 			},
 		},
+		"package with requirements": {
+			importertest.TestCase{
+				WantRequired: []string{importertest.Project},
+			},
+			godepJSON{
+				Required: []string{importertest.Project},
+			},
+		},
+		"package with local requirements": {
+			importertest.TestCase{
+				WantRequired: nil,
+			},
+			godepJSON{
+				Required: []string{"./..."},
+			},
+		},
 	}
 
 	for name, testCase := range testCases {

--- a/internal/importers/importertest/testcase.go
+++ b/internal/importers/importertest/testcase.go
@@ -27,6 +27,7 @@ type TestCase struct {
 	WantRevision              gps.Revision
 	WantVersion               string
 	WantIgnored               []string
+	WantRequired              []string
 	WantWarning               string
 }
 
@@ -69,6 +70,11 @@ func (tc TestCase) validate(manifest *dep.Manifest, lock *dep.Lock, output *byte
 	if !equalSlice(manifest.Ignored, tc.WantIgnored) {
 		return errors.Errorf("unexpected set of ignored projects: \n\t(GOT) %#v \n\t(WNT) %#v",
 			manifest.Ignored, tc.WantIgnored)
+	}
+
+	if !equalSlice(manifest.Required, tc.WantRequired) {
+		return errors.Errorf("unexpected set of required projects: \n\t(GOT) %#v \n\t(WNT) %#v",
+			manifest.Required, tc.WantRequired)
 	}
 
 	wantConstraintCount := 0


### PR DESCRIPTION
### What does this do / why do we need it?

In a godep manifest, entries in Packages are commonly used to specify extra
dependencies of a project, like tools (code generators for example).
Adding those same packages to dep's "required" entry achieves the same.

This hopefully reduces the number of manual tweaks to Gopkg.toml before a migration is "complete".