### PR TITLE
gps: BenchmarkCreateVendorTree - fatal error instead of nil panic

### DIFF
--- a/gps/solution_test.go
+++ b/gps/solution_test.go
@@ -143,8 +143,7 @@ func BenchmarkCreateVendorTree(b *testing.B) {
 		Logger:   log.New(test.Writer{TB: b}, "", 0),
 	})
 	if err != nil {
-		b.Errorf("failed to create SourceManager: %q", err)
-		clean = false
+		b.Fatalf("failed to create SourceManager: %q", err)
 	}
 
 	// Prefetch the projects before timer starts


### PR DESCRIPTION
### What does this do / why do we need it?

This PR *"fixes"* a nil pointer benchmark panic by calling `Fatalf` instead of `Errorf` to halt the test.  The underlying failure to create a `SourceMgr` still exists.

### What should your reviewer look out for in this PR?

> failed to create SourceManager: "failed to ensure directory at \"/tmp/vsolvtest/cache/sources\": mkdir /tmp/vsolvtest/cache/sources: no such file or directory"

Is the root cause obvious enough to fix in this PR? Or is there some local state to initialize first which can be documented?

### Do you need help or clarification on anything?

In general, should we run benchmarks in CI, if only to confirm that they work? Or would it be a mistake to have code which is only covered by benchmarks and not separate tests in the first place?
(FYI - There are only four benchmarks, and two are hard coded to skip)