### PR TITLE
prune: Handle testdata directories

### DIFF
--- a/gps/prune_test.go
+++ b/gps/prune_test.go
@@ -426,6 +426,31 @@ func TestPruneGoTestFiles(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"testdata-files",
+			fsTestCase{
+				before: filesystemState{
+					dirs: []string{
+						"dir",
+						"dir/testdata",
+					},
+					files: []string{
+						"dir/main.go",
+						"dir/main_test.go",
+						"dir/testdata/foo",
+					},
+				},
+				after: filesystemState{
+					dirs: []string{
+						"dir",
+					},
+					files: []string{
+						"dir/main.go",
+					},
+				},
+			},
+			false,
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
### What does this do / why do we need it?

"testdata" is special, as documented in commit
https://github.com/golang/go/commit/2f9eeea212681927385a4713004438cd864966e0

Therefore such a directory can be discarded when test files are.

This should fix #1580 

### What should your reviewer look out for in this PR?

### Do you need help or clarification on anything?

### Which issue(s) does this PR fix?
