### PR TITLE
Update docs to reflect default prune settings

### DIFF
--- a/docs/Gopkg.toml.md
+++ b/docs/Gopkg.toml.md
@@ -192,10 +192,12 @@ The following are the current available options:
 
 Out of an abundance of caution, dep non-optionally preserves files that may have legal significance.
 
-Pruning is disabled by default. It can be enabled by setting them to `true` at the root level.
+Pruning options are disabled by default. However, generating a `Gopkg.toml` via `dep init` will add lines to enable `go-tests` and `unused-packages` prune options at the root level.
+
 ```toml
 [prune]
-  non-go = true
+  go-tests = true
+  unused-packages = true
 ```
 
 The same prune options can be defined per-project. An addtional `name` field is required and, as with `[[constraint]]` and `[[override]]`, should be a [source root](glossary.md#source-root), not just any import path.


### PR DESCRIPTION
### What does this do / why do we need it?
The default prune settings have changed, but the docs have not been updated.

### What should your reviewer look out for in this PR?
N/A

### Do you need help or clarification on anything?
No

### Which issue(s) does this PR fix?
This PR updates the docs for the following PR: https://github.com/golang/dep/pull/1460
