### PR TITLE
Added lost documentation about generating graph visualizations

### DIFF
--- a/docs/daily-dep.md
+++ b/docs/daily-dep.md
@@ -105,7 +105,7 @@ $ dep status -dot | dot -T png | open -f -a /Applications/Preview.app
 > dep status -dot | dot -T png -o status.png; start status.png
 ```
 
-<p align="center"><img src="docs/assets/StatusGraph.png"></p>
+<p align="center"><img src="/dep/docs/assets/StatusGraph.png"></p>
 
 ### Adding and removing `import` statements
 

--- a/docs/daily-dep.md
+++ b/docs/daily-dep.md
@@ -82,6 +82,31 @@ $ dep ensure -update
 
 `dep ensure -update` searches for versions that work with the `branch`, `version`, or `revision` constraint defined in `Gopkg.toml`. These constraint types have different semantics, some of which allow `dep ensure -update` to effectively find a "newer" version, while others will necessitate hand-updating the `Gopkg.toml`. The [ensure mechanics](ensure-mechanics.md#update-and-constraint-types) guide explains this in greater detail, but if you want to know what effect a `dep ensure -update` is likely to have for a particular project, the `LATEST` field in `dep status` output will tell you.
 
+### Visualizing dependencies
+
+Generate a visual representation of the dependency tree by piping the output of `dep status -dot` to [graphviz](http://www.graphviz.org/).
+
+#### Linux
+
+```
+$ sudo apt-get install graphviz
+$ dep status -dot | dot -T png | display
+```
+#### MacOS
+```
+$ brew install graphviz
+$ dep status -dot | dot -T png | open -f -a /Applications/Preview.app
+```
+
+#### Windows
+
+```
+> choco install graphviz.portable
+> dep status -dot | dot -T png -o status.png; start status.png
+```
+
+<p align="center"><img src="docs/assets/StatusGraph.png"></p>
+
 ### Adding and removing `import` statements
 
 As noted in [the section on adding dependencies](#adding-a-new-dependency), dep relies on the import statements in your code to figure out which dependencies your project actually needs. Thus, when you add or remove import statements, dep might need to care about it.

--- a/docs/daily-dep.md
+++ b/docs/daily-dep.md
@@ -89,7 +89,7 @@ $ dep status -dot | dot -T png | open -f -a /Applications/Preview.app
 > dep status -dot | dot -T png -o status.png; start status.png
 ```
 
-<p align="center"><img src="/dep/docs/assets/StatusGraph.png"></p>
+![status graph](assets/StatusGraph.png)
 
 ### Updating dependencies
 

--- a/docs/daily-dep.md
+++ b/docs/daily-dep.md
@@ -66,22 +66,6 @@ Of course, given this model, you don't _have to_ use `dep ensure -add` to add ne
 
 The [ensure mechanics section on `-add`](ensure-mechanics.md#add) has a more thorough exploration, including some ways that `dep ensure -add`'s behavior subtly varies depending on the state of your project.
 
-### Updating dependencies
-
-Ideally, updating a dependency project to a newer version is a single command:
-
-```bash
-$ dep ensure -update github.com/foo/bar
-```
-
-This also works without arguments to try to update all dependencies, though it's generally not recommended:
-
-```bash
-$ dep ensure -update
-```
-
-`dep ensure -update` searches for versions that work with the `branch`, `version`, or `revision` constraint defined in `Gopkg.toml`. These constraint types have different semantics, some of which allow `dep ensure -update` to effectively find a "newer" version, while others will necessitate hand-updating the `Gopkg.toml`. The [ensure mechanics](ensure-mechanics.md#update-and-constraint-types) guide explains this in greater detail, but if you want to know what effect a `dep ensure -update` is likely to have for a particular project, the `LATEST` field in `dep status` output will tell you.
-
 ### Visualizing dependencies
 
 Generate a visual representation of the dependency tree by piping the output of `dep status -dot` to [graphviz](http://www.graphviz.org/).
@@ -106,6 +90,22 @@ $ dep status -dot | dot -T png | open -f -a /Applications/Preview.app
 ```
 
 <p align="center"><img src="/dep/docs/assets/StatusGraph.png"></p>
+
+### Updating dependencies
+
+Ideally, updating a dependency project to a newer version is a single command:
+
+```bash
+$ dep ensure -update github.com/foo/bar
+```
+
+This also works without arguments to try to update all dependencies, though it's generally not recommended:
+
+```bash
+$ dep ensure -update
+```
+
+`dep ensure -update` searches for versions that work with the `branch`, `version`, or `revision` constraint defined in `Gopkg.toml`. These constraint types have different semantics, some of which allow `dep ensure -update` to effectively find a "newer" version, while others will necessitate hand-updating the `Gopkg.toml`. The [ensure mechanics](ensure-mechanics.md#update-and-constraint-types) guide explains this in greater detail, but if you want to know what effect a `dep ensure -update` is likely to have for a particular project, the `LATEST` field in `dep status` output will tell you.
 
 ### Adding and removing `import` statements
 

--- a/docs/daily-dep.md
+++ b/docs/daily-dep.md
@@ -66,31 +66,6 @@ Of course, given this model, you don't _have to_ use `dep ensure -add` to add ne
 
 The [ensure mechanics section on `-add`](ensure-mechanics.md#add) has a more thorough exploration, including some ways that `dep ensure -add`'s behavior subtly varies depending on the state of your project.
 
-### Visualizing dependencies
-
-Generate a visual representation of the dependency tree by piping the output of `dep status -dot` to [graphviz](http://www.graphviz.org/).
-
-#### Linux
-
-```
-$ sudo apt-get install graphviz
-$ dep status -dot | dot -T png | display
-```
-#### MacOS
-```
-$ brew install graphviz
-$ dep status -dot | dot -T png | open -f -a /Applications/Preview.app
-```
-
-#### Windows
-
-```
-> choco install graphviz.portable
-> dep status -dot | dot -T png -o status.png; start status.png
-```
-
-![status graph](assets/StatusGraph.png)
-
 ### Updating dependencies
 
 Ideally, updating a dependency project to a newer version is a single command:
@@ -135,6 +110,32 @@ Only if it is the first/last import of a project being added/removed - cases 3 a
 * `[prune]`, global and per-project rules that govern what kinds of files should be removed from `vendor/`
 
 Changes to any one of these rules will likely necessitate changes in `Gopkg.lock` and `vendor/`; a single successful `dep ensure` run will incorporate all such changes at once, bringing your project back in sync.
+
+## Visualizing dependencies
+
+Generate a visual representation of the dependency tree by piping the output of `dep status -dot` to [graphviz](http://www.graphviz.org/).
+
+### Linux
+
+```
+$ sudo apt-get install graphviz
+$ dep status -dot | dot -T png | display
+```
+
+### MacOS
+```
+$ brew install graphviz
+$ dep status -dot | dot -T png | open -f -a /Applications/Preview.app
+```
+
+### Windows
+
+```
+> choco install graphviz.portable
+> dep status -dot | dot -T png -o status.png; start status.png
+```
+
+![status graph](assets/StatusGraph.png)
 
 ## Key Takeaways
 


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

### What does this do / why do we need it?
`dep` used to have documentation showing how to generate nifty dependency graphs from dep status but they got lost in the great doc shuffle of 2018.This PR adds these docs to the new website.
### What should your reviewer look out for in this PR?
- Is the section placed at the right position in docs ?
- Any more information to add ?
- Does the addition render correctly in website ?
### Which issue(s) does this PR fix?
Fixes #1663 
<!--

fixes #1663 


-->
