### PR TITLE
Refer to new docs instead of GitHub in `Gopkg.toml` example

### DIFF
--- a/testdata/txn_writer/expected_manifest.toml
+++ b/testdata/txn_writer/expected_manifest.toml
@@ -1,6 +1,6 @@
 # Gopkg.toml example
 #
-# Refer to https://github.com/golang/dep/blob/master/docs/Gopkg.toml.md
+# Refer to https://golang.github.io/dep/docs/Gopkg.toml.html
 # for detailed Gopkg.toml documentation.
 #
 # required = ["github.com/user/thing/cmd/thing"]

--- a/txn_writer.go
+++ b/txn_writer.go
@@ -23,7 +23,7 @@ import (
 // during `dep init`
 var exampleTOML = []byte(`# Gopkg.toml example
 #
-# Refer to https://github.com/golang/dep/blob/master/docs/Gopkg.toml.md
+# Refer to https://golang.github.io/dep/docs/Gopkg.toml.html
 # for detailed Gopkg.toml documentation.
 #
 # required = ["github.com/user/thing/cmd/thing"]


### PR DESCRIPTION
### What does this do / why do we need it?

Refer to new docs instead of GitHub in `Gopkg.toml` example.
I think that it is better to have new docs than GitHub to refer to docs.

### What should your reviewer look out for in this PR?

Whether the link destination is correct or not

### Do you need help or clarification on anything?

No.

### Which issue(s) does this PR fix?

None.