### PR TITLE
Make it easier for contributors to mimic a PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,14 @@ jobs:
     - stage: test
       go_import_path: github.com/golang/dep
       install:
-        - go get -u github.com/golang/lint/golint honnef.co/go/tools/cmd/megacheck
+        - make get-deps
         - npm install -g codeclimate-test-reporter
       env:
         - DEPTESTBYPASS501=1
       os: linux
       go: 1.9.x
       script:
-        - go test -i ./...
-        - ./hack/lint.bash
-        - ./hack/validate-vendor.bash
-        - ./hack/validate-licence.bash
+        - make validate test
         - ./hack/coverage.bash
       after_success:
         - codeclimate-test-reporter < coverage.txt

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+SHELL="/bin/bash"
+
+default: build validate test
+
+get-deps:
+	go get -u github.com/golang/lint/golint honnef.co/go/tools/cmd/megacheck
+
+build:
+	go fmt ./...
+	go build ./cmd/dep
+
+licenseok:
+	go build ./hack/licenseok
+
+validate: build licenseok
+	./hack/lint.bash
+	./hack/validate-vendor.bash
+	./hack/validate-licence.bash
+
+test:
+	go test -i ./...
+
+install:
+	go install ./cmd/dep
+
+docusaurus:
+	docker run --rm -it -v `pwd`:/dep -p 3000:3000 \
+		-w /dep/website node \
+		bash -c "npm i --only=dev && npm start"
+
+.PHONY: build validate test install docusaurus


### PR DESCRIPTION
* `make get-deps` installs the tools used to validate dep, e.g. golint
* `make` runs a sane set of defaults that mimic what a PR does without adding too much burden. Doesn't do the code coverage checks because I'm not sure anyone cares... :trollface: 
* `make build` - format and compile dep binary for the current GOOS/GOARCH
* `make test` - run the tests
* `make validate` - run all the static analysis, linting, etc
* `make docusaurus` - builds and runs the site in a docker container because I refuse to install npm on my machine
* `make install` - compiles and installs dep
