### PR TITLE
plumb context.Context everywhere; limit concurrent sub-processes with DEPMAXSUBPROCS

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -5,6 +5,7 @@
 package dep
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 
@@ -24,7 +25,7 @@ func (a Analyzer) HasDepMetadata(path string) bool {
 
 // DeriveManifestAndLock reads and returns the manifest at path/ManifestName or nil if one is not found.
 // The Lock is always nil for now.
-func (a Analyzer) DeriveManifestAndLock(path string, n gps.ProjectRoot) (gps.Manifest, gps.Lock, error) {
+func (a Analyzer) DeriveManifestAndLock(ctx context.Context, path string, n gps.ProjectRoot) (gps.Manifest, gps.Lock, error) {
 	if !a.HasDepMetadata(path) {
 		return nil, nil, nil
 	}

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -5,6 +5,7 @@
 package dep
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 
@@ -22,7 +23,7 @@ func TestAnalyzerDeriveManifestAndLock(t *testing.T) {
 
 	a := Analyzer{}
 
-	m, l, err := a.DeriveManifestAndLock(h.Path("dep"), "my/fake/project")
+	m, l, err := a.DeriveManifestAndLock(context.Background(), h.Path("dep"), "my/fake/project")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +56,7 @@ func TestAnalyzerDeriveManifestAndLockDoesNotExist(t *testing.T) {
 
 	a := Analyzer{}
 
-	m, l, err := a.DeriveManifestAndLock(h.Path("dep"), "my/fake/project")
+	m, l, err := a.DeriveManifestAndLock(context.Background(), h.Path("dep"), "my/fake/project")
 	if m != nil || l != nil || err != nil {
 		t.Fatalf("expected manifest & lock & err to be nil: m -> %#v l -> %#v err-> %#v", m, l, err)
 	}
@@ -79,7 +80,7 @@ func TestAnalyzerDeriveManifestAndLockCannotOpen(t *testing.T) {
 
 	// Verify that the solver rejects the manifest, rather than treating it as
 	// offering no constraints.
-	m, l, err := a.DeriveManifestAndLock(h.Path("dep"), "my/fake/project")
+	m, l, err := a.DeriveManifestAndLock(context.Background(), h.Path("dep"), "my/fake/project")
 	if m != nil || l != nil || err == nil {
 		t.Fatalf("expected manifest & lock to be nil, err to be not nil: m -> %#v l -> %#v err -> %#v", m, l, err)
 	}
@@ -96,7 +97,7 @@ func TestAnalyzerDeriveManifestAndLockInvalidManifest(t *testing.T) {
 
 	a := Analyzer{}
 
-	m, l, err := a.DeriveManifestAndLock(h.Path("dep"), "my/fake/project")
+	m, l, err := a.DeriveManifestAndLock(context.Background(), h.Path("dep"), "my/fake/project")
 	if m != nil || l != nil || err == nil {
 		t.Fatalf("expected manifest & lock & err to be nil: m -> %#v l -> %#v err-> %#v", m, l, err)
 	}

--- a/cmd/dep/check.go
+++ b/cmd/dep/check.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -58,18 +59,18 @@ func (cmd *checkCommand) Register(fs *flag.FlagSet) {
 	fs.BoolVar(&cmd.quiet, "q", false, "Suppress non-error output")
 }
 
-func (cmd *checkCommand) Run(ctx *dep.Ctx, args []string) error {
-	logger := ctx.Out
+func (cmd *checkCommand) Run(ctx context.Context, depCtx *dep.Ctx, args []string) error {
+	logger := depCtx.Out
 	if cmd.quiet {
 		logger = log.New(ioutil.Discard, "", 0)
 	}
 
-	p, err := ctx.LoadProject()
+	p, err := depCtx.LoadProject()
 	if err != nil {
 		return err
 	}
 
-	sm, err := ctx.SourceManager()
+	sm, err := depCtx.SourceManager()
 	if err != nil {
 		return err
 	}

--- a/cmd/dep/dep_test.go
+++ b/cmd/dep/dep_test.go
@@ -34,7 +34,7 @@ func TestMain(m *testing.M) {
 		// those systems.  Set CCACHE_DIR to cope.  Issue 17668.
 		os.Setenv("CCACHE_DIR", filepath.Join(home, ".ccache"))
 	}
-	os.Setenv("HOME", "/test-dep-home-does-not-exist")
+	os.Setenv("HOME", filepath.Join(os.TempDir(), "test-dep-home-does-not-exist"))
 	r := m.Run()
 
 	os.Remove("testdep" + test.ExeSuffix)

--- a/cmd/dep/ensure_test.go
+++ b/cmd/dep/ensure_test.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"go/build"
 	"io/ioutil"
@@ -50,11 +51,11 @@ func TestInvalidEnsureFlagCombinations(t *testing.T) {
 	// anything other than the error being non-nil. For now, it works well
 	// because a panic will quickly result if the initial arg length validation
 	// checks are incorrectly handled.
-	if err := ec.runDefault(nil, []string{"foo"}, nil, nil, gps.SolveParameters{}); err == nil {
+	if err := ec.runDefault(context.Background(), nil, []string{"foo"}, nil, nil, gps.SolveParameters{}); err == nil {
 		t.Errorf("no args to plain ensure with -vendor-only")
 	}
 	ec.vendorOnly = false
-	if err := ec.runDefault(nil, []string{"foo"}, nil, nil, gps.SolveParameters{}); err == nil {
+	if err := ec.runDefault(context.Background(), nil, []string{"foo"}, nil, nil, gps.SolveParameters{}); err == nil {
 		t.Errorf("no args to plain ensure")
 	}
 }
@@ -240,7 +241,7 @@ func TestValidateUpdateArgs(t *testing.T) {
 			// Add lock to project
 			p.Lock = &dep.Lock{P: lockedProjects}
 
-			err := validateUpdateArgs(ctx, c.args, p, sm, &params)
+			err := validateUpdateArgs(context.Background(), ctx, c.args, p, sm, &params)
 			if err != c.wantError {
 				t.Fatalf("Unexpected error while validating update args:\n\t(GOT): %v\n\t(WNT): %v", err, c.wantError)
 			}

--- a/cmd/dep/integration_test.go
+++ b/cmd/dep/integration_test.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -143,7 +144,7 @@ func runMain(prog string, args []string, stdout, stderr io.Writer, dir string, e
 		WorkingDir: dir,
 		Env:        env,
 	}
-	if exitCode := m.Run(); exitCode != 0 {
+	if exitCode := m.Run(context.Background()); exitCode != 0 {
 		err = fmt.Errorf("exit status %d", exitCode)
 	}
 	return

--- a/cmd/dep/status_test.go
+++ b/cmd/dep/status_test.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -774,7 +775,7 @@ func TestCollectConstraints(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			p.Lock = &c.lock
 			p.Manifest = &c.manifest
-			gotConstraints, err := collectConstraints(ctx, p, sm)
+			gotConstraints, err := collectConstraints(context.Background(), ctx, p, sm)
 			if len(err) > 0 && !c.wantErr {
 				t.Fatalf("unexpected errors while collecting constraints: %v", err)
 			} else if len(err) == 0 && c.wantErr {

--- a/cmd/dep/version.go
+++ b/cmd/dep/version.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"runtime"
 
@@ -31,7 +32,7 @@ func (cmd *versionCommand) Register(fs *flag.FlagSet) {}
 
 type versionCommand struct{}
 
-func (cmd *versionCommand) Run(ctx *dep.Ctx, args []string) error {
+func (cmd *versionCommand) Run(_ context.Context, ctx *dep.Ctx, args []string) error {
 	ctx.Out.Printf(`dep:
  version     : %s
  build date  : %s

--- a/context.go
+++ b/context.go
@@ -5,6 +5,7 @@
 package dep
 
 import (
+	"context"
 	"log"
 	"os"
 	"path/filepath"
@@ -345,8 +346,8 @@ func (c *Ctx) AbsForImport(path string) (string, error) {
 }
 
 // ValidateParams ensure that solving can be completed with the specified params.
-func (c *Ctx) ValidateParams(sm gps.SourceManager, params gps.SolveParameters) error {
-	err := gps.ValidateParams(params, sm)
+func (c *Ctx) ValidateParams(ctx context.Context, sm gps.SourceManager, params gps.SolveParameters) error {
+	err := gps.ValidateParams(ctx, params, sm)
 	if err != nil {
 		if deduceErrs, ok := err.(gps.DeductionErrs); ok {
 			c.Err.Println("The following errors occurred while deducing packages:")

--- a/gps/cmd_windows.go
+++ b/gps/cmd_windows.go
@@ -9,10 +9,15 @@ import (
 	"os/exec"
 )
 
-type cmd struct {
-	*exec.Cmd
+func commandContext(ctx context.Context, name string, arg ...string) cmd {
+	return cmd{ctx: ctx, Cmd: exec.CommandContext(ctx, name, arg...)}
 }
 
-func commandContext(ctx context.Context, name string, arg ...string) cmd {
-	return cmd{Cmd: exec.CommandContext(ctx, name, arg...)}
+func (c cmd) CombinedOutput() ([]byte, error) {
+	if release, err := c.acquire(); err != nil {
+		return nil, err
+	} else if release != nil {
+		defer release()
+	}
+	return c.Cmd.CombinedOutput()
 }

--- a/gps/deduce_test.go
+++ b/gps/deduce_test.go
@@ -620,7 +620,7 @@ func TestVanityDeduction(t *testing.T) {
 			t.Run(fix.in, func(t *testing.T) {
 				t.Parallel()
 
-				pr, err := sm.DeduceProjectRoot(fix.in)
+				pr, err := sm.DeduceProjectRoot(ctx, fix.in)
 				if err != nil {
 					t.Errorf("Unexpected err on deducing project root: %s", err)
 					return
@@ -644,7 +644,7 @@ func TestVanityDeduction(t *testing.T) {
 					t.Errorf("Deduced repo ident does not match fixture:\n\t(GOT) %s\n\t(WNT) %s", goturl, wanturl)
 				}
 
-				urls, err := sm.SourceURLsForPath(fix.in)
+				urls, err := sm.SourceURLsForPath(ctx, fix.in)
 				if err != nil {
 					t.Errorf("Unexpected err on deducing source urls: %s", err)
 					return

--- a/gps/example.go
+++ b/gps/example.go
@@ -7,6 +7,7 @@
 package main
 
 import (
+	"context"
 	"go/build"
 	"io/ioutil"
 	"log"
@@ -48,8 +49,9 @@ func main() {
 	defer sourcemgr.Release()
 
 	// Prep and run the solver
+	ctx := context.Background()
 	solver, _ := gps.Prepare(params, sourcemgr)
-	solution, err := solver.Solve()
+	solution, err := solver.Solve(ctx)
 	if err == nil {
 		// If no failure, blow away the vendor dir and write a new one out,
 		// stripping nested vendor directories as we go.
@@ -57,7 +59,7 @@ func main() {
 		pruneOpts := gps.CascadingPruneOptions{
 			DefaultOptions: gps.PruneNestedVendorDirs | gps.PruneUnusedPackages | gps.PruneGoTestFiles,
 		}
-		gps.WriteDepTree(filepath.Join(root, "vendor"), solution, sourcemgr, pruneOpts, nil)
+		gps.WriteDepTree(ctx, filepath.Join(root, "vendor"), solution, sourcemgr, pruneOpts, nil)
 	}
 }
 

--- a/gps/selection_test.go
+++ b/gps/selection_test.go
@@ -35,7 +35,7 @@ func TestUnselectedRemoval(t *testing.T) {
 	})
 
 	if len(u.sl) != 3 {
-		t.Fatalf("len of unselected slice should have been 2 after no-op removal, got %v", len(u.sl))
+		t.Fatalf("len of unselected slice should have been 3 after no-op removal, got %v", len(u.sl))
 	}
 
 	u.remove(bmi3)

--- a/gps/solution.go
+++ b/gps/solution.go
@@ -75,7 +75,7 @@ const concurrentWriters = 16
 // passed manifest.
 //
 // If onWrite is not nil, it will be called after each project write. Calls are ordered and atomic.
-func WriteDepTree(basedir string, l Lock, sm SourceManager, co CascadingPruneOptions, onWrite func(WriteProgress)) error {
+func WriteDepTree(ctx context.Context, basedir string, l Lock, sm SourceManager, co CascadingPruneOptions, onWrite func(WriteProgress)) error {
 	if l == nil {
 		return fmt.Errorf("must provide non-nil Lock to WriteDepTree")
 	}
@@ -84,7 +84,7 @@ func WriteDepTree(basedir string, l Lock, sm SourceManager, co CascadingPruneOpt
 		return err
 	}
 
-	g, ctx := errgroup.WithContext(context.TODO())
+	g, ctx := errgroup.WithContext(ctx)
 	lps := l.Projects()
 	sem := make(chan struct{}, concurrentWriters)
 	var cnt struct {

--- a/gps/solve_bimodal_test.go
+++ b/gps/solve_bimodal_test.go
@@ -5,6 +5,7 @@
 package gps
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -1401,7 +1402,7 @@ func newbmSM(bmf bimodalFixture) *bmSourceManager {
 	return sm
 }
 
-func (sm *bmSourceManager) ListPackages(id ProjectIdentifier, v Version) (pkgtree.PackageTree, error) {
+func (sm *bmSourceManager) ListPackages(ctx context.Context, id ProjectIdentifier, v Version) (pkgtree.PackageTree, error) {
 	// Deal with address-based root-switching with both case folding and
 	// alternate sources.
 	var src, fsrc, root, froot string
@@ -1448,7 +1449,7 @@ func (sm *bmSourceManager) ListPackages(id ProjectIdentifier, v Version) (pkgtre
 	return pkgtree.PackageTree{}, fmt.Errorf("project %s at version %s could not be found", id, v)
 }
 
-func (sm *bmSourceManager) GetManifestAndLock(id ProjectIdentifier, v Version, an ProjectAnalyzer) (Manifest, Lock, error) {
+func (sm *bmSourceManager) GetManifestAndLock(ctx context.Context, id ProjectIdentifier, v Version, an ProjectAnalyzer) (Manifest, Lock, error) {
 	src := toFold(id.normalizedSource())
 	for _, ds := range sm.specs {
 		if src == string(ds.n) && v.Matches(ds.v) {

--- a/gps/solver_inputs_test.go
+++ b/gps/solver_inputs_test.go
@@ -5,6 +5,7 @@
 package gps
 
 import (
+	"context"
 	"io/ioutil"
 	"log"
 	"math/rand"
@@ -207,6 +208,7 @@ func TestValidateParams(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
 	for _, tc := range testcases {
 		params.RootPackageTree.Packages = map[string]pkgtree.PackageOrErr{
 			"github.com/sdboyer/dep": {
@@ -218,7 +220,7 @@ func TestValidateParams(t *testing.T) {
 			},
 		}
 
-		err = ValidateParams(params, sm)
+		err = ValidateParams(ctx, params, sm)
 		if tc.err && err == nil {
 			t.Fatalf("expected an error when deducing package fails, got none")
 		} else if !tc.err && err != nil {

--- a/gps/source_manager_test.go
+++ b/gps/source_manager_test.go
@@ -5,6 +5,7 @@
 package gps
 
 import (
+	"context"
 	"log"
 	"reflect"
 	"testing"
@@ -98,7 +99,7 @@ func TestSourceManager_InferConstraint(t *testing.T) {
 			})
 			h.Must(err)
 
-			got, err := sm.InferConstraint(tc.str, tc.project)
+			got, err := sm.InferConstraint(context.Background(), tc.str, tc.project)
 			h.Must(err)
 
 			wantT := reflect.TypeOf(tc.want)

--- a/gps/vcs_source.go
+++ b/gps/vcs_source.go
@@ -61,7 +61,7 @@ func (bs *baseVCSSource) getManifestAndLock(ctx context.Context, pr ProjectRoot,
 		return nil, nil, unwrapVcsErr(err)
 	}
 
-	m, l, err := an.DeriveManifestAndLock(bs.repo.LocalPath(), pr)
+	m, l, err := an.DeriveManifestAndLock(ctx, bs.repo.LocalPath(), pr)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/gps/vcs_source_test.go
+++ b/gps/vcs_source_test.go
@@ -687,7 +687,7 @@ func TestGitSourceAdaptiveCleanup(t *testing.T) {
 
 	mkSM()
 	id := mkPI("github.com/sdboyer/gpkt")
-	err = sm.SyncSourceFor(id)
+	err = sm.SyncSourceFor(context.Background(), id)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -709,7 +709,7 @@ func TestGitSourceAdaptiveCleanup(t *testing.T) {
 	}
 
 	mkSM()
-	err = sm.SyncSourceFor(id)
+	err = sm.SyncSourceFor(context.Background(), id)
 	if err != nil {
 		t.Fatalf("choked after adding dummy file: %q", err)
 	}
@@ -723,7 +723,7 @@ func TestGitSourceAdaptiveCleanup(t *testing.T) {
 	os.Remove(readmePath)
 
 	mkSM()
-	err = sm.SyncSourceFor(id)
+	err = sm.SyncSourceFor(context.Background(), id)
 	if err != nil {
 		t.Fatalf("choked after removing known file: %q", err)
 	}
@@ -739,7 +739,7 @@ func TestGitSourceAdaptiveCleanup(t *testing.T) {
 	}
 
 	mkSM()
-	err = sm.SyncSourceFor(id)
+	err = sm.SyncSourceFor(context.Background(), id)
 	if err != nil {
 		t.Fatalf("choked after removing .git/objects directory: %q", err)
 	}

--- a/internal/importers/base/importer_test.go
+++ b/internal/importers/base/importer_test.go
@@ -5,6 +5,7 @@
 package base
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"testing"
@@ -62,7 +63,7 @@ func TestBaseImporter_IsTag(t *testing.T) {
 			defer sm.Release()
 
 			i := NewImporter(ctx.Err, ctx.Verbose, sm)
-			gotIsTag, gotTag, err := i.isTag(pi, tc.input)
+			gotIsTag, gotTag, err := i.isTag(context.Background(), pi, tc.input)
 			h.Must(err)
 
 			if tc.wantIsTag != gotIsTag {
@@ -131,7 +132,7 @@ func TestBaseImporter_LookupVersionForLockedProject(t *testing.T) {
 			defer sm.Release()
 
 			i := NewImporter(ctx.Err, ctx.Verbose, sm)
-			v, err := i.lookupVersionForLockedProject(pi, tc.constraint, tc.revision)
+			v, err := i.lookupVersionForLockedProject(context.Background(), pi, tc.constraint, tc.revision)
 			h.Must(err)
 
 			gotVersion := v.String()
@@ -426,13 +427,14 @@ func TestBaseImporter_ImportProjects(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
 	for name, tc := range testcases {
 		name := name
 		tc := tc
 		t.Run(name, func(t *testing.T) {
 			err := tc.Execute(t, func(logger *log.Logger, sm gps.SourceManager) (*dep.Manifest, *dep.Lock) {
 				i := NewImporter(logger, true, sm)
-				i.ImportPackages(tc.projects, tc.DefaultConstraintFromLock)
+				i.ImportPackages(ctx, tc.projects, tc.DefaultConstraintFromLock)
 				return i.Manifest, i.Lock
 			})
 			if err != nil {

--- a/internal/importers/glide/importer.go
+++ b/internal/importers/glide/importer.go
@@ -6,6 +6,7 @@ package glide
 
 import (
 	"bytes"
+	"context"
 	"io/ioutil"
 	"log"
 	"os"
@@ -83,13 +84,13 @@ func (g *Importer) HasDepMetadata(dir string) bool {
 }
 
 // Import the config found in the directory.
-func (g *Importer) Import(dir string, pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock, error) {
+func (g *Importer) Import(ctx context.Context, dir string, pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock, error) {
 	err := g.load(dir)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	m, l := g.convert(pr)
+	m, l := g.convert(ctx, pr)
 	return m, l, nil
 }
 
@@ -135,7 +136,7 @@ func (g *Importer) load(projectDir string) error {
 }
 
 // convert the glide configuration files into dep configuration files.
-func (g *Importer) convert(pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock) {
+func (g *Importer) convert(ctx context.Context, pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock) {
 	projectName := string(pr)
 
 	task := bytes.NewBufferString("Converting from glide.yaml")
@@ -192,7 +193,7 @@ func (g *Importer) convert(pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock) {
 		packages = append(packages, ip)
 	}
 
-	g.ImportPackages(packages, false)
+	g.ImportPackages(ctx, packages, false)
 
 	// Ignores
 	g.Manifest.Ignored = append(g.Manifest.Ignored, g.glideConfig.Ignores...)

--- a/internal/importers/glide/importer_test.go
+++ b/internal/importers/glide/importer_test.go
@@ -6,6 +6,7 @@ package glide
 
 import (
 	"bytes"
+	"context"
 	"log"
 	"path/filepath"
 	"testing"
@@ -156,6 +157,7 @@ func TestGlideConfig_Convert(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
 	for name, testCase := range testCases {
 		name := name
 		testCase := testCase
@@ -164,7 +166,7 @@ func TestGlideConfig_Convert(t *testing.T) {
 				g := NewImporter(logger, true, sm)
 				g.glideConfig = testCase.yaml
 				g.glideLock = testCase.lock
-				return g.convert(importertest.RootProject)
+				return g.convert(ctx, importertest.RootProject)
 			})
 			if err != nil {
 				t.Fatalf("%#v", err)
@@ -196,7 +198,7 @@ func TestGlideConfig_Import(t *testing.T) {
 		t.Fatal("Expected the importer to detect the glide configuration files")
 	}
 
-	m, l, err := g.Import(projectRoot, importertest.RootProject)
+	m, l, err := g.Import(context.Background(), projectRoot, importertest.RootProject)
 	h.Must(err)
 
 	if m == nil {

--- a/internal/importers/glock/importer.go
+++ b/internal/importers/glock/importer.go
@@ -6,6 +6,7 @@ package glock
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -48,13 +49,13 @@ func (g *Importer) HasDepMetadata(dir string) bool {
 }
 
 // Import the config found in the directory.
-func (g *Importer) Import(dir string, pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock, error) {
+func (g *Importer) Import(ctx context.Context, dir string, pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock, error) {
 	err := g.load(dir)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	m, l := g.convert(pr)
+	m, l := g.convert(ctx, pr)
 	return m, l, nil
 }
 
@@ -116,7 +117,7 @@ func parseGlockLine(line string) (*glockPackage, error) {
 	}, nil
 }
 
-func (g *Importer) convert(pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock) {
+func (g *Importer) convert(ctx context.Context, pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock) {
 	g.Logger.Println("Converting from GLOCKFILE ...")
 
 	packages := make([]base.ImportedPackage, 0, len(g.packages))
@@ -145,6 +146,6 @@ func (g *Importer) convert(pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock) {
 		})
 	}
 
-	g.ImportPackages(packages, true)
+	g.ImportPackages(ctx, packages, true)
 	return g.Manifest, g.Lock
 }

--- a/internal/importers/glock/importer_test.go
+++ b/internal/importers/glock/importer_test.go
@@ -6,6 +6,7 @@ package glock
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"log"
 	"path/filepath"
@@ -54,6 +55,7 @@ func TestGlockConfig_Convert(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
 	for name, testCase := range testCases {
 		name := name
 		testCase := testCase
@@ -61,7 +63,7 @@ func TestGlockConfig_Convert(t *testing.T) {
 			err := testCase.Execute(t, func(logger *log.Logger, sm gps.SourceManager) (*dep.Manifest, *dep.Lock) {
 				g := NewImporter(logger, true, sm)
 				g.packages = testCase.packages
-				return g.convert(importertest.RootProject)
+				return g.convert(ctx, importertest.RootProject)
 			})
 			if err != nil {
 				t.Fatalf("%#v", err)
@@ -111,7 +113,7 @@ func TestGlockConfig_Import(t *testing.T) {
 		t.Fatal("Expected the importer to detect the glock configuration files")
 	}
 
-	m, l, err := g.Import(projectRoot, importertest.RootProject)
+	m, l, err := g.Import(context.Background(), projectRoot, importertest.RootProject)
 	h.Must(err)
 
 	if m == nil {

--- a/internal/importers/godep/importer.go
+++ b/internal/importers/godep/importer.go
@@ -5,6 +5,7 @@
 package godep
 
 import (
+	"context"
 	"encoding/json"
 	"io/ioutil"
 	"log"
@@ -58,13 +59,13 @@ func (g *Importer) HasDepMetadata(dir string) bool {
 }
 
 // Import the config found in the directory.
-func (g *Importer) Import(dir string, pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock, error) {
+func (g *Importer) Import(ctx context.Context, dir string, pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock, error) {
 	err := g.load(dir)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	m, l := g.convert(pr)
+	m, l := g.convert(ctx, pr)
 	return m, l, nil
 }
 
@@ -86,7 +87,7 @@ func (g *Importer) load(projectDir string) error {
 	return nil
 }
 
-func (g *Importer) convert(pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock) {
+func (g *Importer) convert(ctx context.Context, pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock) {
 	g.Logger.Println("Converting from Godeps.json ...")
 
 	packages := make([]base.ImportedPackage, 0, len(g.json.Imports))
@@ -114,7 +115,7 @@ func (g *Importer) convert(pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock) {
 		packages = append(packages, ip)
 	}
 
-	g.ImportPackages(packages, true)
+	g.ImportPackages(ctx, packages, true)
 	required := make([]string, 0, len(g.json.Required))
 	for _, req := range g.json.Required {
 		if !strings.HasPrefix(req, ".") { // ignore project packages

--- a/internal/importers/godep/importer_test.go
+++ b/internal/importers/godep/importer_test.go
@@ -6,6 +6,7 @@ package godep
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"log"
 	"path/filepath"
@@ -95,6 +96,7 @@ func TestGodepConfig_Convert(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
 	for name, testCase := range testCases {
 		name := name
 		testCase := testCase
@@ -102,7 +104,7 @@ func TestGodepConfig_Convert(t *testing.T) {
 			err := testCase.Execute(t, func(logger *log.Logger, sm gps.SourceManager) (*dep.Manifest, *dep.Lock) {
 				g := NewImporter(logger, true, sm)
 				g.json = testCase.json
-				return g.convert(importertest.RootProject)
+				return g.convert(ctx, importertest.RootProject)
 			})
 			if err != nil {
 				t.Fatalf("%#v", err)
@@ -138,7 +140,7 @@ func TestGodepConfig_Import(t *testing.T) {
 		t.Fatal("Expected the importer to detect godep configuration file")
 	}
 
-	m, l, err := g.Import(projectRoot, importertest.RootProject)
+	m, l, err := g.Import(context.Background(), projectRoot, importertest.RootProject)
 	h.Must(err)
 
 	if m == nil {

--- a/internal/importers/govend/importer.go
+++ b/internal/importers/govend/importer.go
@@ -5,6 +5,7 @@
 package govend
 
 import (
+	"context"
 	"io/ioutil"
 	"log"
 	"os"
@@ -57,13 +58,13 @@ func (g *Importer) HasDepMetadata(dir string) bool {
 }
 
 // Import the config found in the directory.
-func (g *Importer) Import(dir string, pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock, error) {
+func (g *Importer) Import(ctx context.Context, dir string, pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock, error) {
 	err := g.load(dir)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	m, l := g.convert(pr)
+	m, l := g.convert(ctx, pr)
 	return m, l, nil
 }
 
@@ -86,7 +87,7 @@ func (g *Importer) load(projectDir string) error {
 }
 
 // convert the govend configuration files into dep configuration files.
-func (g *Importer) convert(pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock) {
+func (g *Importer) convert(ctx context.Context, pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock) {
 	g.Logger.Println("Converting from vendor.yaml...")
 
 	packages := make([]base.ImportedPackage, 0, len(g.yaml.Imports))
@@ -116,6 +117,6 @@ func (g *Importer) convert(pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock) {
 		packages = append(packages, ip)
 	}
 
-	g.ImportPackages(packages, true)
+	g.ImportPackages(ctx, packages, true)
 	return g.Manifest, g.Lock
 }

--- a/internal/importers/govend/importer_test.go
+++ b/internal/importers/govend/importer_test.go
@@ -6,6 +6,7 @@ package govend
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"log"
 	"path/filepath"
@@ -69,6 +70,7 @@ func TestGovendConfig_Convert(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
 	for name, testCase := range testCases {
 		name := name
 		testCase := testCase
@@ -76,7 +78,7 @@ func TestGovendConfig_Convert(t *testing.T) {
 			err := testCase.Execute(t, func(logger *log.Logger, sm gps.SourceManager) (*dep.Manifest, *dep.Lock) {
 				g := NewImporter(logger, true, sm)
 				g.yaml = testCase.yaml
-				return g.convert(importertest.RootProject)
+				return g.convert(ctx, importertest.RootProject)
 			})
 			if err != nil {
 				t.Fatalf("%#v", err)
@@ -110,7 +112,7 @@ func TestGovendConfig_Import(t *testing.T) {
 		t.Fatal("Expected the importer to detect govend configuration file")
 	}
 
-	m, l, err := g.Import(projectRoot, importertest.RootProject)
+	m, l, err := g.Import(context.Background(), projectRoot, importertest.RootProject)
 	h.Must(err)
 
 	if m == nil {

--- a/internal/importers/govendor/importer_test.go
+++ b/internal/importers/govendor/importer_test.go
@@ -6,6 +6,7 @@ package govendor
 
 import (
 	"bytes"
+	"context"
 	"log"
 	"path/filepath"
 	"testing"
@@ -41,7 +42,7 @@ func TestGovendorConfig_Import(t *testing.T) {
 		t.Fatal("Expected the importer to detect the govendor configuration files")
 	}
 
-	m, l, err := g.Import(projectRoot, testGovendorProjectRoot)
+	m, l, err := g.Import(context.Background(), projectRoot, testGovendorProjectRoot)
 	h.Must(err)
 
 	if m == nil {
@@ -138,6 +139,7 @@ func TestGovendorConfig_Convert(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
 	for name, testCase := range testCases {
 		name := name
 		testCase := testCase
@@ -145,7 +147,7 @@ func TestGovendorConfig_Convert(t *testing.T) {
 			err := testCase.Execute(t, func(logger *log.Logger, sm gps.SourceManager) (*dep.Manifest, *dep.Lock) {
 				g := NewImporter(logger, true, sm)
 				g.file = testCase.file
-				return g.convert(importertest.RootProject)
+				return g.convert(ctx, importertest.RootProject)
 			})
 			if err != nil {
 				t.Fatalf("%#v", err)

--- a/internal/importers/gvt/importer.go
+++ b/internal/importers/gvt/importer.go
@@ -5,6 +5,7 @@
 package gvt
 
 import (
+	"context"
 	"encoding/json"
 	"io/ioutil"
 	"log"
@@ -57,13 +58,13 @@ func (g *Importer) HasDepMetadata(dir string) bool {
 }
 
 // Import the config found in the directory.
-func (g *Importer) Import(dir string, pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock, error) {
+func (g *Importer) Import(ctx context.Context, dir string, pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock, error) {
 	err := g.load(dir)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	m, l := g.convert(pr)
+	m, l := g.convert(ctx, pr)
 	return m, l, nil
 }
 
@@ -85,7 +86,7 @@ func (g *Importer) load(projectDir string) error {
 	return nil
 }
 
-func (g *Importer) convert(pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock) {
+func (g *Importer) convert(ctx context.Context, pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock) {
 	g.Logger.Println("Converting from vendor/manifest ...")
 
 	packages := make([]base.ImportedPackage, 0, len(g.gvtConfig.Deps))
@@ -125,6 +126,6 @@ func (g *Importer) convert(pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock) {
 		packages = append(packages, ip)
 	}
 
-	g.ImportPackages(packages, true)
+	g.ImportPackages(ctx, packages, true)
 	return g.Manifest, g.Lock
 }

--- a/internal/importers/gvt/importer_test.go
+++ b/internal/importers/gvt/importer_test.go
@@ -6,6 +6,7 @@ package gvt
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"log"
 	"path/filepath"
@@ -113,6 +114,7 @@ func TestGvtConfig_Convert(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
 	for name, testCase := range testCases {
 		name := name
 		testCase := testCase
@@ -120,7 +122,7 @@ func TestGvtConfig_Convert(t *testing.T) {
 			err := testCase.Execute(t, func(logger *log.Logger, sm gps.SourceManager) (*dep.Manifest, *dep.Lock) {
 				g := NewImporter(logger, true, sm)
 				g.gvtConfig = testCase.gvtConfig
-				return g.convert(importertest.RootProject)
+				return g.convert(ctx, importertest.RootProject)
 			})
 			if err != nil {
 				t.Fatalf("%#v", err)
@@ -156,7 +158,7 @@ func TestGvtConfig_Import(t *testing.T) {
 		t.Fatal("Expected the importer to detect gvt configuration file")
 	}
 
-	m, l, err := g.Import(projectRoot, importertest.RootProject)
+	m, l, err := g.Import(context.Background(), projectRoot, importertest.RootProject)
 	h.Must(err)
 
 	if m == nil {

--- a/internal/importers/importers.go
+++ b/internal/importers/importers.go
@@ -5,6 +5,7 @@
 package importers
 
 import (
+	"context"
 	"log"
 
 	"github.com/golang/dep"
@@ -25,7 +26,7 @@ type Importer interface {
 	Name() string
 
 	// Import the config found in the directory.
-	Import(path string, pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock, error)
+	Import(ctx context.Context, path string, pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock, error)
 
 	// HasDepMetadata checks if a directory contains config that the importer can handle.
 	HasDepMetadata(dir string) bool

--- a/internal/importers/vndr/importer.go
+++ b/internal/importers/vndr/importer.go
@@ -6,6 +6,7 @@ package vndr
 
 import (
 	"bufio"
+	"context"
 	"log"
 	"os"
 	"path/filepath"
@@ -42,7 +43,7 @@ func (v *Importer) HasDepMetadata(dir string) bool {
 }
 
 // Import the config found in the directory.
-func (v *Importer) Import(dir string, pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock, error) {
+func (v *Importer) Import(ctx context.Context, dir string, pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock, error) {
 	v.Logger.Println("Detected vndr configuration file...")
 
 	err := v.loadVndrFile(dir)
@@ -50,7 +51,7 @@ func (v *Importer) Import(dir string, pr gps.ProjectRoot) (*dep.Manifest, *dep.L
 		return nil, nil, errors.Wrapf(err, "unable to load vndr file")
 	}
 
-	m, l := v.convert(pr)
+	m, l := v.convert(ctx, pr)
 	return m, l, nil
 }
 
@@ -85,7 +86,7 @@ func (v *Importer) loadVndrFile(dir string) error {
 	return nil
 }
 
-func (v *Importer) convert(pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock) {
+func (v *Importer) convert(ctx context.Context, pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock) {
 	packages := make([]base.ImportedPackage, 0, len(v.packages))
 	for _, pkg := range v.packages {
 		// Validate
@@ -110,7 +111,7 @@ func (v *Importer) convert(pr gps.ProjectRoot) (*dep.Manifest, *dep.Lock) {
 		}
 		packages = append(packages, ip)
 	}
-	v.ImportPackages(packages, true)
+	v.ImportPackages(ctx, packages, true)
 	return v.Manifest, v.Lock
 }
 

--- a/internal/importers/vndr/importer_test.go
+++ b/internal/importers/vndr/importer_test.go
@@ -6,6 +6,7 @@ package vndr
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"log"
 	"path/filepath"
@@ -58,6 +59,7 @@ func TestVndrConfig_Convert(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
 	for name, testCase := range testCases {
 		name := name
 		testCase := testCase
@@ -65,7 +67,7 @@ func TestVndrConfig_Convert(t *testing.T) {
 			err := testCase.Execute(t, func(logger *log.Logger, sm gps.SourceManager) (*dep.Manifest, *dep.Lock) {
 				g := NewImporter(logger, true, sm)
 				g.packages = testCase.packages
-				return g.convert(importertest.RootProject)
+				return g.convert(ctx, importertest.RootProject)
 			})
 			if err != nil {
 				t.Fatalf("%#v", err)
@@ -95,7 +97,7 @@ func TestVndrConfig_Import(t *testing.T) {
 		t.Fatal("Expected the importer to detect vndr configuration file")
 	}
 
-	m, l, err := v.Import(projectRoot, importertest.RootProject)
+	m, l, err := v.Import(context.Background(), projectRoot, importertest.RootProject)
 	h.Must(err)
 
 	wantM := dep.NewManifest()

--- a/manifest.go
+++ b/manifest.go
@@ -6,6 +6,7 @@ package dep
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"reflect"
@@ -295,7 +296,7 @@ func checkRedundantPruneOptions(co gps.CascadingPruneOptions) (warns []error) {
 }
 
 // ValidateProjectRoots validates the project roots present in manifest.
-func ValidateProjectRoots(c *Ctx, m *Manifest, sm gps.SourceManager) error {
+func ValidateProjectRoots(ctx context.Context, c *Ctx, m *Manifest, sm gps.SourceManager) error {
 	// Channel to receive all the errors
 	errorCh := make(chan error, len(m.Constraints)+len(m.Ovr))
 
@@ -303,7 +304,7 @@ func ValidateProjectRoots(c *Ctx, m *Manifest, sm gps.SourceManager) error {
 
 	validate := func(pr gps.ProjectRoot) {
 		defer wg.Done()
-		origPR, err := sm.DeduceProjectRoot(string(pr))
+		origPR, err := sm.DeduceProjectRoot(ctx, string(pr))
 		if err != nil {
 			errorCh <- err
 		} else if origPR != pr {

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -6,6 +6,7 @@ package dep
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -629,21 +630,22 @@ func TestValidateProjectRoots(t *testing.T) {
 	// Capture the stderr to verify the warnings
 	stderrOutput := &bytes.Buffer{}
 	errLogger := log.New(stderrOutput, "", 0)
-	ctx := &Ctx{
+	depCtx := &Ctx{
 		GOPATH: pwd,
 		Out:    log.New(ioutil.Discard, "", 0),
 		Err:    errLogger,
 	}
 
-	sm, err := ctx.SourceManager()
+	sm, err := depCtx.SourceManager()
 	h.Must(err)
 	defer sm.Release()
 
+	ctx := context.Background()
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			// Empty the buffer for every case
 			stderrOutput.Reset()
-			err := ValidateProjectRoots(ctx, &c.manifest, sm)
+			err := ValidateProjectRoots(ctx, depCtx, &c.manifest, sm)
 			if err != c.wantError {
 				t.Fatalf("unexpected error while validating project roots:\n\t(GOT): %v\n\t(WNT): %v", err, c.wantError)
 			}

--- a/project.go
+++ b/project.go
@@ -5,6 +5,7 @@
 package dep
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -221,7 +222,7 @@ func (p *Project) parseRootPackageTree() (pkgtree.PackageTree, error) {
 // This function will correctly utilize ignores and requireds from an existing
 // manifest, if one is present, but will also do the right thing without a
 // manifest.
-func (p *Project) GetDirectDependencyNames(sm gps.SourceManager) (map[gps.ProjectRoot]bool, error) {
+func (p *Project) GetDirectDependencyNames(ctx context.Context, sm gps.SourceManager) (map[gps.ProjectRoot]bool, error) {
 	var reach []string
 	if p.ChangedLock != nil {
 		reach = p.ChangedLock.InputImports()
@@ -235,7 +236,7 @@ func (p *Project) GetDirectDependencyNames(sm gps.SourceManager) (map[gps.Projec
 
 	directDeps := map[gps.ProjectRoot]bool{}
 	for _, ip := range reach {
-		pr, err := sm.DeduceProjectRoot(ip)
+		pr, err := sm.DeduceProjectRoot(ctx, ip)
 		if err != nil {
 			return nil, err
 		}
@@ -251,12 +252,12 @@ func (p *Project) GetDirectDependencyNames(sm gps.SourceManager) (map[gps.Projec
 //
 // "Direct dependency" here is as implemented by GetDirectDependencyNames();
 // it correctly incorporates all "ignored" and "required" rules.
-func (p *Project) FindIneffectualConstraints(sm gps.SourceManager) []gps.ProjectRoot {
+func (p *Project) FindIneffectualConstraints(ctx context.Context, sm gps.SourceManager) []gps.ProjectRoot {
 	if p.Manifest == nil {
 		return nil
 	}
 
-	dd, err := p.GetDirectDependencyNames(sm)
+	dd, err := p.GetDirectDependencyNames(ctx, sm)
 	if err != nil {
 		return nil
 	}

--- a/txn_writer_test.go
+++ b/txn_writer_test.go
@@ -5,6 +5,7 @@
 package dep
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -34,7 +35,7 @@ func TestSafeWriter_BadInput_MissingRoot(t *testing.T) {
 	defer pc.Release()
 
 	sw, _ := NewSafeWriter(nil, nil, nil, VendorOnChanged, defaultCascadingPruneOptions(), nil)
-	err := sw.Write("", pc.SourceManager, true, nil)
+	err := sw.Write(context.Background(), "", pc.SourceManager, true, nil)
 
 	if err == nil {
 		t.Fatal("should have errored without a root path, but did not")
@@ -52,7 +53,7 @@ func TestSafeWriter_BadInput_MissingSourceManager(t *testing.T) {
 	pc.Load()
 
 	sw, _ := NewSafeWriter(nil, nil, pc.Project.Lock, VendorAlways, defaultCascadingPruneOptions(), nil)
-	err := sw.Write(pc.Project.AbsRoot, nil, true, nil)
+	err := sw.Write(context.Background(), pc.Project.AbsRoot, nil, true, nil)
 
 	if err == nil {
 		t.Fatal("should have errored without a source manager when forceVendor is true, but did not")
@@ -100,7 +101,7 @@ func TestSafeWriter_BadInput_NonexistentRoot(t *testing.T) {
 	sw, _ := NewSafeWriter(nil, nil, nil, VendorOnChanged, defaultCascadingPruneOptions(), nil)
 
 	missingroot := filepath.Join(pc.Project.AbsRoot, "nonexistent")
-	err := sw.Write(missingroot, pc.SourceManager, true, nil)
+	err := sw.Write(context.Background(), missingroot, pc.SourceManager, true, nil)
 
 	if err == nil {
 		t.Fatal("should have errored with nonexistent dir for root path, but did not")
@@ -118,7 +119,7 @@ func TestSafeWriter_BadInput_RootIsFile(t *testing.T) {
 	sw, _ := NewSafeWriter(nil, nil, nil, VendorOnChanged, defaultCascadingPruneOptions(), nil)
 
 	fileroot := pc.CopyFile("fileroot", "txn_writer/badinput_fileroot")
-	err := sw.Write(fileroot, pc.SourceManager, true, nil)
+	err := sw.Write(context.Background(), fileroot, pc.SourceManager, true, nil)
 
 	if err == nil {
 		t.Fatal("should have errored when root path is a file, but did not")
@@ -153,7 +154,7 @@ func TestSafeWriter_Manifest(t *testing.T) {
 	}
 
 	// Write changes
-	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, nil)
+	err := sw.Write(context.Background(), pc.Project.AbsRoot, pc.SourceManager, true, nil)
 	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
 	// Verify file system changes
@@ -198,7 +199,7 @@ func TestSafeWriter_ManifestAndUnmodifiedLock(t *testing.T) {
 	}
 
 	// Write changes
-	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, nil)
+	err := sw.Write(context.Background(), pc.Project.AbsRoot, pc.SourceManager, true, nil)
 	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
 	// Verify file system changes
@@ -243,7 +244,7 @@ func TestSafeWriter_ManifestAndUnmodifiedLockWithForceVendor(t *testing.T) {
 	}
 
 	// Write changes
-	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, nil)
+	err := sw.Write(context.Background(), pc.Project.AbsRoot, pc.SourceManager, true, nil)
 	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
 	// Verify file system changes
@@ -272,9 +273,10 @@ func TestSafeWriter_ForceVendorWhenVendorAlreadyExists(t *testing.T) {
 	defer pc.Release()
 	pc.CopyFile(LockName, safeWriterGoldenLock)
 	pc.Load()
+	ctx := context.Background()
 
 	sw, _ := NewSafeWriter(nil, pc.Project.Lock, pc.Project.Lock, VendorAlways, defaultCascadingPruneOptions(), nil)
-	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, nil)
+	err := sw.Write(ctx, pc.Project.AbsRoot, pc.SourceManager, true, nil)
 	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
 	// Verify prepared actions
@@ -292,7 +294,7 @@ func TestSafeWriter_ForceVendorWhenVendorAlreadyExists(t *testing.T) {
 		t.Fatal("Expected the payload to contain the vendor directory ")
 	}
 
-	err = sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, nil)
+	err = sw.Write(ctx, pc.Project.AbsRoot, pc.SourceManager, true, nil)
 	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
 	// Verify file system changes
@@ -342,7 +344,7 @@ func TestSafeWriter_NewLock(t *testing.T) {
 	}
 
 	// Write changes
-	err = sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, nil)
+	err = sw.Write(context.Background(), pc.Project.AbsRoot, pc.SourceManager, true, nil)
 	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
 	// Verify file system changes
@@ -389,7 +391,7 @@ func TestSafeWriter_NewLockSkipVendor(t *testing.T) {
 	}
 
 	// Write changes
-	err = sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, nil)
+	err = sw.Write(context.Background(), pc.Project.AbsRoot, pc.SourceManager, true, nil)
 	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
 	// Verify file system changes
@@ -449,7 +451,7 @@ func TestSafeWriter_VendorDotGitPreservedWithForceVendor(t *testing.T) {
 		t.Fatal("Expected the payload to contain the vendor directory")
 	}
 
-	err := sw.Write(pc.Project.AbsRoot, pc.SourceManager, true, nil)
+	err := sw.Write(context.Background(), pc.Project.AbsRoot, pc.SourceManager, true, nil)
 	h.Must(errors.Wrap(err, "SafeWriter.Write failed"))
 
 	// Verify file system changes


### PR DESCRIPTION
### What does this do / why do we need it?

This PR (1) plumbs `context.Context` everywhere as a prerequisite for (2) limiting concurrent sub-processes. When the env var `DEPMAXSUBPROCS` is set (positive integer), a [semaphore is attached to the context](https://github.com/golang/dep/pull/1695/files#diff-4aec0055cfe4a8d9bf8381f80f0cb0edR208) which is picked up and aquired/released from inside [`cmd.CombinedOutput`](https://github.com/golang/dep/pull/1695/files#diff-6acff68f513a062dcdf0536d6af2e2e3).

I went back and forth a bit about whether this is an appropriate use of `context.Context`, but we wanted to plumb it around more anyways (#423), so it won't be wasted even if we go another direction. Other considered solutions for passing the semaphore around: global variable (yuck); attaching to `supervisor` and using from `do()` (too high level) or passing it along to each vcs struct (complicated/messy).

This limits all of our get/fetch/update vcs calls, but not direct use of `masterminds/vcs.Repo` methods, since they don't go through our `gps.commandContext()`.  I don't see a clean way to limit those without going too high level and also limiting method calls which e.g. only look up a struct field.

I got nearly all of the `context.TODO()`s, except for:

- `svnRepo.CommitInfo()`: Overrides a method who's signature we don't control.
- `gps.NewSourceManager`: Creates a context for `supervisor`. Perhaps `SourceManagerConfig` could have a context param (optional?), but this is a non-traditional use of `Context` which doesn't affect our `cmd` semaphore anyhow.

### Do you need help or clarification on anything?

Any bright ideas about how to test this? Measuring the timing of sets of sleep commands under different limits seems sloppy.

Is `DEPMAXSUBPROCS` an appropriate name?

Where should I document this?

### Which issue(s) does this PR fix?

#423, #1689

#### TODO

- [ ] Document
- [ ] Changelog
- [ ] Tests

*I pre-apologize for sending everyone to rebase hell.*