### PR TITLE
[WIP] Expose prune option "nested-vendor-dirs"

### DIFF
--- a/cmd/dep/init.go
+++ b/cmd/dep/init.go
@@ -117,8 +117,10 @@ func (cmd *initCommand) Run(ctx *dep.Ctx, args []string) error {
 		return errors.Wrap(err, "init failed: unable to prepare an initial manifest and lock for the solver")
 	}
 
-	// Set default prune options for go-tests and unused-packages
-	p.Manifest.PruneOptions.DefaultOptions = gps.PruneNestedVendorDirs | gps.PruneGoTestFiles | gps.PruneUnusedPackages
+	// Set default prune options for nested-vendor-dirs, go-tests and unused-packages
+	p.Manifest.PruneOptions.DefaultOptions = gps.PruneNestedVendorDirs |
+		gps.PruneGoTestFiles |
+		gps.PruneUnusedPackages
 
 	if cmd.gopath {
 		gs := newGopathScanner(ctx, directDeps, sm)

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -485,6 +485,7 @@ func TestCheckRedundantPruneOptions(t *testing.T) {
 				},
 			},
 			wantWarn: []error{
+				fmt.Errorf("redundant prune option %q set for %q", "nested-vendor-dirs", "github.com/golang/dep"),
 				fmt.Errorf("redundant prune option %q set for %q", "unused-packages", "github.com/golang/dep"),
 				fmt.Errorf("redundant prune option %q set for %q", "non-go", "github.com/golang/dep"),
 				fmt.Errorf("redundant prune option %q set for %q", "go-tests", "github.com/golang/dep"),
@@ -493,10 +494,10 @@ func TestCheckRedundantPruneOptions(t *testing.T) {
 		{
 			name: "all redundant on false",
 			pruneOptions: gps.CascadingPruneOptions{
-				DefaultOptions: 1,
+				DefaultOptions: 0,
 				PerProjectOptions: map[gps.ProjectRoot]gps.PruneOptionSet{
 					"github.com/golang/dep": {
-						NestedVendor:   pvtrue,
+						NestedVendor:   pvfalse,
 						UnusedPackages: pvfalse,
 						NonGoFiles:     pvfalse,
 						GoTests:        pvfalse,
@@ -504,6 +505,7 @@ func TestCheckRedundantPruneOptions(t *testing.T) {
 				},
 			},
 			wantWarn: []error{
+				fmt.Errorf("redundant prune option %q set for %q", "nested-vendor-dirs", "github.com/golang/dep"),
 				fmt.Errorf("redundant prune option %q set for %q", "unused-packages", "github.com/golang/dep"),
 				fmt.Errorf("redundant prune option %q set for %q", "non-go", "github.com/golang/dep"),
 				fmt.Errorf("redundant prune option %q set for %q", "go-tests", "github.com/golang/dep"),
@@ -767,18 +769,20 @@ func TestToRawPruneOptions(t *testing.T) {
 			name:         "all options",
 			pruneOptions: gps.CascadingPruneOptions{DefaultOptions: 15},
 			wantOptions: rawPruneOptions{
-				UnusedPackages: true,
-				NonGoFiles:     true,
-				GoTests:        true,
+				UnusedPackages:   true,
+				NestedVendorDirs: true,
+				NonGoFiles:       true,
+				GoTests:          true,
 			},
 		},
 		{
 			name:         "no options",
 			pruneOptions: gps.CascadingPruneOptions{DefaultOptions: 1},
 			wantOptions: rawPruneOptions{
-				UnusedPackages: false,
-				NonGoFiles:     false,
-				GoTests:        false,
+				UnusedPackages:   false,
+				NestedVendorDirs: false,
+				NonGoFiles:       false,
+				GoTests:          false,
 			},
 		},
 	}

--- a/txn_writer.go
+++ b/txn_writer.go
@@ -44,6 +44,7 @@ var exampleTOML = []byte(`# Gopkg.toml example
 #
 # [prune]
 #   non-go = false
+#   nested-vendor-dirs = true
 #   go-tests = true
 #   unused-packages = true
 


### PR DESCRIPTION
This prune option was already present, but not exposed. It was always enabled. This PR tries to fully export this option.

### What does this do / why do we need it?

It exposes the prune option `nested-vendor-dirs`, enabled by default, to allow users to disable vendor dir pruning for certain projects.

### What should your reviewer look out for in this PR?

Somehow a lot of tests fail since this option was already present, but unexposed, and it shows up everywhere in manifest files, while it should be hidden. I think I might have looked over a place where prune options that are equal to the default are ignored.

### Do you need help or clarification on anything?

See previous.

### Which issue(s) does this PR fix?

#1701 

### TODO

- [ ] solve failing tests
- [ ] add CHANGELOG entry

