### PR TITLE
change CI to 1.10.x; update docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jobs:
       env:
         - DEPTESTBYPASS501=1
       os: linux
-      go: "1.10"
+      go: 1.10.x
       script:
         - make validate test
         - ./hack/coverage.bash
@@ -31,7 +31,7 @@ jobs:
       go: tip
     - <<: *simple-test
       os: osx
-      go: "1.10"
+      go: 1.10.x
       install:
         # brew takes horribly long to update itself despite the above caching
         # attempt; only bzr install if it's not on the $PATH
@@ -47,7 +47,7 @@ jobs:
         # Related: https://superuser.com/questions/1044130/why-am-i-having-how-can-i-fix-this-error-shell-session-update-command-not-f
         - trap EXIT
         - go test -race ./...
-    - go: "1.10"
+    - go: 1.10.x
       stage: deploy
       go_import_path: github.com/golang/dep
       install: skip

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Dep
 
-`dep` is a prototype dependency management tool for Go. It requires Go 1.8 or newer to compile. **`dep` is safe for production use.**
+`dep` is a prototype dependency management tool for Go. It requires Go 1.9 or newer to compile. **`dep` is safe for production use.**
 
 `dep` is the official _experiment_, but not yet the official tool. Check out the [Roadmap](https://github.com/golang/dep/wiki/Roadmap) for more on what this means!
 


### PR DESCRIPTION
### What does this do / why do we need it?

Test using `1.10.x` since gimme has been updated: https://github.com/travis-ci/gimme/pull/130

Updates the minimum in the docs.