### PR TITLE
fix install script when curl is not available

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -23,14 +23,15 @@ downloadJSON() {
     url="$2"
 
     echo "Fetching $url.."
-    if type curl > /dev/null; then
+    if test -x "$(command -v curl)"; then
         response=$(curl -s -L -w 'HTTPSTATUS:%{http_code}' -H 'Accept: application/json' "$url")
         body=$(echo "$response" | sed -e 's/HTTPSTATUS\:.*//g')
         code=$(echo "$response" | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
-    elif type wget > /dev/null; then
+    elif test -x "$(command -v wget)"; then
         temp=$(mktemp)
-        body=$(wget -q --header='Accept: application/json' -O - --server-response --content-on-error "$url" 2> "$temp")
-        code=$(awk '/^  HTTP/{print $2}' < "$temp")
+        body=$(wget -q --header='Accept: application/json' -O - --server-response "$url" 2> "$temp")
+        code=$(awk '/^  HTTP/{print $2}' < "$temp" | tail -1)
+        rm "$temp"
     else
         echo "Neither curl nor wget was available to perform http requests."
         exit 1
@@ -48,10 +49,10 @@ downloadFile() {
     destination="$2"
 
     echo "Fetching $url.."
-    if type curl > /dev/null; then
+    if test -x "$(command -v curl)"; then
         code=$(curl -s -w '%{http_code}' -L "$url" -o "$destination")
-    elif type wget > /dev/null; then
-        code=$(wget -q -O "$destination" --server-response "$url" 2>&1 | awk '/^  HTTP/{print $2}')
+    elif test -x "$(command -v wget)"; then
+        code=$(wget -q -O "$destination" --server-response "$url" 2>&1 | awk '/^  HTTP/{print $2}' | tail -1)
     else
         echo "Neither curl nor wget was available to perform http requests."
         exit 1


### PR DESCRIPTION
Fix multiple issues when curl is not available and wget is used:

- Downloading JSON for the latest release results in HTTP 302 and wget
  redirects to the new location.  Read HTTP status only from the last
  line of output else the code wouldn't match 200 even if the request
  was successful.

- Don't set `--content-on-error` when using wget.  It is of no
  consequence since we are checking the HTTP status code and exit if the
  response isn't 200 OK.

- `type` is undefined in POSIX sh, use `command` instead.

- Clean up the temp file.

Fixes #1728.