### PR TITLE
During installation if $GOPATH is unset fallback to `go env`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -66,8 +66,19 @@ downloadFile() {
 
 findGoBinDirectory() {
     if [ -z "$GOPATH" ]; then
-        echo "Installation requires \$GOPATH to be set for your Golang environment."
-        exit 1
+        echo "\$GOPATH environment variable not set, trying to use \"go env GOPATH\".."
+        if test -x "$(command -v go)"; then
+            path=$(go env GOPATH)
+            if [ -z "$path" ]; then
+                echo "Could not find the default GOPATH."
+                exit 1
+            else
+                GOPATH="$path"
+            fi
+        else
+            echo "Go binary not found when trying to use \"go env GOPATH\""
+            exit 1
+        fi
     fi
     if [ -z "$GOBIN" ]; then
         GOBIN="$GOPATH/bin"


### PR DESCRIPTION
### What does this do / why do we need it?
If $GOPATH is not set, the installation script tries to use `go env GOPATH` instead of exiting the installation process.

### What should your reviewer look out for in this PR?
Check if the installation continues with the default `go env GOPATH` when $GOPATH is not set.

### Do you need help or clarification on anything?
No

### Which issue(s) does this PR fix?
None