### PR TITLE
Fix issue 1742 by replacing '>' with '>='

### DIFF
--- a/gps/pkgtree/pkgtree.go
+++ b/gps/pkgtree/pkgtree.go
@@ -349,7 +349,7 @@ func findImportComment(pkgName *ast.Ident, c *ast.CommentGroup) string {
 			return ""
 		}
 		text = text[:end]
-		if bytes.IndexByte(text, '\n') > 0 {
+		if bytes.IndexByte(text, '\n') >= 0 {
 			// multiline comment, can't be an import comment
 			return ""
 		}


### PR DESCRIPTION
Signed-off-by: Tao Wang <twang2218@gmail.com>

<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

### What does this do / why do we need it?

`bytes.IndexByte` will return `-1` if it cannot find anything, so to check whether there is a `\n` in the comment, the condition should be `>= 0`, rather than `> 0`.

### What should your reviewer look out for in this PR?

### Do you need help or clarification on anything?

### Which issue(s) does this PR fix?

fixes #1742
