### PR TITLE
Use `go env GOPATH` instead of env variable

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -65,12 +65,13 @@ downloadFile() {
 }
 
 findGoBinDirectory() {
-    if [ -z "$GOPATH" ]; then
-        echo "Installation requires \$GOPATH to be set for your Golang environment."
+    EFFECTIVE_GOPATH=$(go env GOPATH)
+    if [ -z "$EFFECTIVE_GOPATH" ]; then
+        echo "Installation could not determine your \$GOPATH."
         exit 1
     fi
     if [ -z "$GOBIN" ]; then
-        GOBIN="$GOPATH/bin"
+        GOBIN="$EFFECTIVE_GOPATH/bin"
     fi
     if [ ! -d "$GOBIN" ]; then
         echo "Installation requires your GOBIN directory $GOBIN to exist. Please create it."


### PR DESCRIPTION

### What does this do / why do we need it?

Uses the `go env GOPATH´ which has its own logic to determine default GOPATH 

### What should your reviewer look out for in this PR?

Other usages of GOPATH that I have missed

### Do you need help or clarification on anything?

### Which issue(s) does this PR fix?

Fixes #1733
