### PR TITLE
External file-based registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ NEW FEATURES:
 * Added `install.sh` script. ([#1533](https://github.com/golang/dep/pull/1533))
 * List out of date projects in dep status. ([#1553](https://github.com/golang/dep/pull/1553)).
 * Enabled opt-in persistent caching via $DEPCACHEAGE env var. ([#1711](https://github.com/golang/dep/pull/1711))
+* Added support for a file-based registry, `Gopkg.reg`, for resolving import paths. #174
 
 BUG FIXES:
 

--- a/Dockerfile.1.10
+++ b/Dockerfile.1.10
@@ -1,0 +1,8 @@
+FROM golang:1.10
+#RUN apk --no-cache add build-base git bzr mercurial gcc make coreutils
+#RUN apk --no-cache add bash
+#RUN apk add --no-cache perl-utils  # shasum needed by make
+ADD . /go/src/github.com/golang/dep
+RUN cd /go/src/github.com/golang/dep && \
+    make SHELL=/bin/bash install
+RUN rm -rf /go/src/*

--- a/Dockerfile.1.9
+++ b/Dockerfile.1.9
@@ -1,0 +1,8 @@
+FROM golang:1.9
+#RUN apk --no-cache add build-base git bzr mercurial gcc make coreutils
+#RUN apk --no-cache add bash
+#RUN apk add --no-cache perl-utils  # shasum needed by make
+ADD . /go/src/github.com/golang/dep
+RUN cd /go/src/github.com/golang/dep && \
+    make SHELL=/bin/bash install
+RUN rm -rf /go/src/*

--- a/Dockerfile.alpine-1.10
+++ b/Dockerfile.alpine-1.10
@@ -1,0 +1,8 @@
+FROM golang:1.10-alpine
+RUN apk --no-cache add build-base git bzr mercurial gcc make coreutils
+RUN apk --no-cache add bash
+RUN apk add --no-cache perl-utils  # shasum needed by make
+ADD . /go/src/github.com/golang/dep
+RUN cd /go/src/github.com/golang/dep && \
+    make SHELL=/bin/bash install
+RUN rm -rf /go/src/*

--- a/Dockerfile.alpine-1.9
+++ b/Dockerfile.alpine-1.9
@@ -1,0 +1,8 @@
+FROM golang:1.9-alpine
+RUN apk --no-cache add build-base git bzr mercurial gcc make coreutils
+RUN apk --no-cache add bash
+RUN apk add --no-cache perl-utils  # shasum needed by make
+ADD . /go/src/github.com/golang/dep
+RUN cd /go/src/github.com/golang/dep && \
+    make SHELL=/bin/bash install
+RUN rm -rf /go/src/*

--- a/README.md
+++ b/README.md
@@ -1,58 +1,40 @@
-<p align="center"><img src="docs/assets/DigbyShadows.png" width="360"></p>
-<p align="center">
-  <a href="https://travis-ci.org/golang/dep"><img src="https://travis-ci.org/golang/dep.svg?branch=master" alt="Build Status"></img></a>
-  <a href="https://ci.appveyor.com/project/golang/dep"><img src="https://ci.appveyor.com/api/projects/status/github/golang/dep?svg=true&branch=master&passingText=Windows%20-%20OK&failingText=Windows%20-%20failed&pendingText=Windows%20-%20pending" alt="Windows Build Status"></a>
-  <a href="https://goreportcard.com/report/github.com/golang/dep"><img src="https://goreportcard.com/badge/github.com/golang/dep" /></a>
-</p>
+# Dep with a local file registry
 
-## Dep
+## Use case: vendoring `foo.com/bar/*`
 
-`dep` is a prototype dependency management tool for Go. It requires Go 1.9 or newer to compile. **`dep` is safe for production use.**
+Add the following to `Gopkg.reg`:
 
-`dep` is the official _experiment_, but not yet the official tool. Check out the [Roadmap](https://github.com/golang/dep/wiki/Roadmap) for more on what this means!
-
-For guides and reference materials about `dep`, see [the documentation](https://golang.github.io/dep).
-
-## Installation
-
-It is strongly recommended that you use a released version. Release binaries are available on the [releases](https://github.com/golang/dep/releases) page.
-
-On MacOS you can install or upgrade to the latest released version with Homebrew:
-
-```sh
-$ brew install dep
-$ brew upgrade dep
+```
+^foo\.com/bar/([^/]*)(/.*)?$ foo.com/bar/$1 ssh://git@repo.internal:7999/my_mirror/$1
 ```
 
-On other platforms you can use the `install.sh` script:
+Here:
 
-```sh
-$ curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+- the first field `^foo\.com/bar/([^/]*)(/.*)?$` matches import paths
+- the second field `foo.com/bar/$1` gives the resulting repo base path
+- the third field `ssh://git@repo.interal:7999/my_mirror/$1` gives the location to clone.
+
+Lines are matched on a first-match-wins basis.
+
+Subpackages work as expected.
+
+## use case: mirroring everything into a local proxy repo
+
+(Untested: I've only needed the first version for faas at present, but you might find this handy.)
+
+```
+^github.com/([^/]*)(/.*)?$ github.com/$1 https://my.proxy/github.com/$1
 ```
 
-It will install into your `$GOPATH/bin` directory by default or any other directory you specify using the `INSTALL_DIRECTORY` environment variable.
+# Docker files
 
-If your platform is not supported, you'll need to build it manually or let the team know and we'll consider adding your platform
-to the release builds.
+The various docker files should build libs and alpine versions of golang 1.9 and 1.10 with the modified
+`dep` command installed in `$GOBIN`.
 
-If you're interested in hacking on `dep`, you can install via `go get`:
+    docker build -t my-dep-image -f Dockerfile.alpine-1.10 .
 
-```sh
-go get -u github.com/golang/dep/cmd/dep
-```
 
-## Feedback
 
-Feedback is greatly appreciated.
-At this stage, the maintainers are most interested in feedback centered on the user experience (UX) of the tool.
-Do you have workflows that the tool supports well, or doesn't support at all?
-Do any of the commands have surprising effects, output, or results?
-Let us know by filing an issue, describing what you did or wanted to do, what you expected to happen, and what actually happened.
+## Dep itself
 
-## Contributing
-
-Contributions are greatly appreciated.
-The maintainers actively manage the issues list, and try to highlight issues suitable for newcomers.
-The project follows the typical GitHub pull request model.
-See [CONTRIBUTING.md](CONTRIBUTING.md) for more details.
-Before starting any work, please either comment on an existing issue, or file a new one.
+If you're reading this you probably already know what dep is. See https://github.com/golang/dep for details.

--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -163,6 +163,7 @@ func (cmd *ensureCommand) Run(ctx *dep.Ctx, args []string) error {
 	if err != nil {
 		return err
 	}
+	ctx.Registry = gps.NewFileRegistry(p.AbsRoot)
 
 	sm, err := ctx.SourceManager()
 	if err != nil {

--- a/cmd/dep/status.go
+++ b/cmd/dep/status.go
@@ -318,6 +318,7 @@ func (cmd *statusCommand) Run(ctx *dep.Ctx, args []string) error {
 	if err != nil {
 		return err
 	}
+	ctx.Registry = gps.NewFileRegistry(p.AbsRoot)
 
 	sm, err := ctx.SourceManager()
 	if err != nil {

--- a/context.go
+++ b/context.go
@@ -43,6 +43,7 @@ type Ctx struct {
 	DisableLocking bool          // When set, no lock file will be created to protect against simultaneous dep processes.
 	Cachedir       string        // Cache directory loaded from environment.
 	CacheAge       time.Duration // Maximum valid age of cached source data. <=0: Don't cache.
+	Registry       gps.Deducer   // If there's an external registry
 }
 
 // SetPaths sets the WorkingDir and GOPATHs fields. If GOPATHs is empty, then
@@ -105,6 +106,7 @@ func (c *Ctx) SourceManager() (*gps.SourceMgr, error) {
 		Cachedir:       cachedir,
 		Logger:         c.Out,
 		DisableLocking: c.DisableLocking,
+		Registry:       c.Registry,
 	})
 }
 

--- a/gps/deduce_test.go
+++ b/gps/deduce_test.go
@@ -672,7 +672,7 @@ func TestVanityDeductionSchemeMismatch(t *testing.T) {
 
 	ctx := context.Background()
 	cm := newSupervisor(ctx)
-	dc := newDeductionCoordinator(cm)
+	dc := newDeductionCoordinator(cm, nil)
 	_, err := dc.deduceRootPath(ctx, "ssh://golang.org/exp")
 	// TODO(sdboyer) this is not actually the error that it should be
 	if err == nil {

--- a/gps/registry.go
+++ b/gps/registry.go
@@ -1,0 +1,105 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gps
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"github.com/golang/dep/internal/fs"
+	"net/url"
+	"os"
+	"path"
+	"regexp"
+	"strings"
+)
+
+const fileRegistryName = "Gopkg.reg"
+
+type fileRegistry struct {
+	locations []*fileRegistryLine
+}
+
+type fileRegistryLine struct {
+	sourcePattern string
+	matcher       *regexp.Regexp
+	root          string
+	gitSources    []string
+}
+
+var _ Deducer = &fileRegistry{}
+
+// NewFileRegistry constructs a default Registry, iff the Gopkg.reg file exists at the
+// project root; otherwise, return nil.
+func NewFileRegistry(rootPath string) Deducer {
+	// Is there a Gopkg.reg file?
+	names, err := fs.ReadActualFilenames(rootPath, []string{fileRegistryName})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Problems looking to instantiate the FileRegistry: %v\n", err)
+		return nil
+	}
+	if fn, ok := names[fileRegistryName]; ok {
+		// We just load the file contents on creation; let's not be snazzy here.
+		reg, err := loadFileRegistry(path.Join(rootPath, fn))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Problems looking to load the FileRegistry: %v\n", err)
+			return nil
+		}
+		return reg
+	}
+	return nil
+}
+
+func loadFileRegistry(fn string) (*fileRegistry, error) {
+	f, err := os.Open(fn)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	locations := []*fileRegistryLine{}
+
+	for scanner.Scan() {
+		parts := strings.Split(scanner.Text(), " ")
+		re, err2 := regexp.Compile(parts[0])
+		if err2 != nil {
+			err = err2
+			fmt.Fprintln(os.Stderr, "Bad syntax in regexp:", err2)
+		} else {
+			locations = append(locations, &fileRegistryLine{
+				sourcePattern: scanner.Text(),
+				matcher:       re,
+				root:          parts[1],
+				gitSources:    parts[2:],
+			})
+		}
+	}
+	return &fileRegistry{locations: locations}, err
+}
+
+func (fr *fileRegistry) deduceRootPath(ctx context.Context, path string) (pathDeduction, error) {
+	var err error
+	for _, frl := range fr.locations {
+		if frl.matcher.MatchString(path) {
+			mbs := []maybeSource{}
+			root := frl.matcher.ReplaceAllString(path, frl.root)
+			for _, gs := range frl.gitSources {
+				res := frl.matcher.ReplaceAllString(path, gs)
+				u, err2 := url.Parse(res)
+				if err2 != nil {
+					fmt.Fprintln(os.Stderr, "Trouble parsing URL:", err2)
+					err = err2
+				} else {
+					mbs = append(mbs, maybeGitSource{url: u})
+				}
+			}
+			return pathDeduction{
+				root: root,
+				mb:   mbs,
+			}, err
+		}
+	}
+	return pathDeduction{}, errNoKnownPathMatch
+}

--- a/gps/source.go
+++ b/gps/source.go
@@ -60,7 +60,7 @@ type srcReturn struct {
 
 type sourceCoordinator struct {
 	supervisor *supervisor
-	deducer    deducer
+	deducer    Deducer
 	srcmut     sync.RWMutex // guards srcs and srcIdx
 	srcs       map[string]*sourceGateway
 	nameToURL  map[string]string
@@ -73,7 +73,7 @@ type sourceCoordinator struct {
 
 // newSourceCoordinator returns a new sourceCoordinator.
 // Passing a nil sourceCache defaults to an in-memory cache.
-func newSourceCoordinator(superv *supervisor, deducer deducer, cachedir string, cache sourceCache, logger *log.Logger) *sourceCoordinator {
+func newSourceCoordinator(superv *supervisor, deducer Deducer, cachedir string, cache sourceCache, logger *log.Logger) *sourceCoordinator {
 	if cache == nil {
 		cache = memoryCache{}
 	}
@@ -184,7 +184,7 @@ func (sc *sourceCoordinator) getSourceGatewayFor(ctx context.Context, id Project
 
 	pd, err := sc.deducer.deduceRootPath(ctx, normalizedName)
 	if err != nil {
-		// As in the deducer, don't cache errors so that externally-driven retry
+		// As in the Deducer, don't cache errors so that externally-driven retry
 		// strategies can be constructed.
 		doReturn(nil, err)
 		return nil, err

--- a/gps/source_manager.go
+++ b/gps/source_manager.go
@@ -181,6 +181,7 @@ type SourceManagerConfig struct {
 	Cachedir       string        // Where to store local instances of upstream sources.
 	Logger         *log.Logger   // Optional info/warn logger. Discards if nil.
 	DisableLocking bool          // True if the SourceManager should NOT use a lock file to protect the Cachedir from multiple processes.
+	Registry       Deducer       // Overriding deducer
 }
 
 // NewSourceManager produces an instance of gps's built-in SourceManager.
@@ -282,7 +283,7 @@ func NewSourceManager(c SourceManagerConfig) (*SourceMgr, error) {
 
 	ctx, cf := context.WithCancel(context.TODO())
 	superv := newSupervisor(ctx)
-	deducer := newDeductionCoordinator(superv)
+	deducer := newDeductionCoordinator(superv, c.Registry)
 
 	var sc sourceCache
 	if c.CacheAge > 0 {

--- a/gps/source_test.go
+++ b/gps/source_test.go
@@ -41,7 +41,7 @@ func testSourceGateway(t *testing.T) {
 	do := func(wantstate sourceState) func(t *testing.T) {
 		return func(t *testing.T) {
 			superv := newSupervisor(ctx)
-			deducer := newDeductionCoordinator(superv)
+			deducer := newDeductionCoordinator(superv, nil)
 			logger := log.New(test.Writer{TB: t}, "", 0)
 			sc := newSourceCoordinator(superv, deducer, cachedir, nil, logger)
 			defer sc.close()


### PR DESCRIPTION
### What does this do / why do we need it?

This is an example of an approach to #174 

Projects building behind a corporate firewall need a way to deal with local projects - and, potentially, locally-cached versions of upstream projects.

Such builds may exist behind a strict firewall; additionally, it's not always the case that the import path "example.com/xyz/bar" actually has the go vanity metadata being served from it.

For these builds, we want a *local* way to intercept and redirect the actions of dep, to get it to fetch from alternative locations - *without* first attempting the HTTP(s) dereference of the importpath location.

We do this by introducing a _registry_. The only functionality that this object must supply is that of the Deducer interface (which is now exported).

The example code only has one kind of registry to resolve these import paths. It reads from the top-level file `Gopkg.reg, which should consist of lines containing whitespace-separated elements. These are:

- the import path to match; this is a Golang regexp
- the registry root corresponding to that import path. This may contain
  references to capture groups in the import path pattern.
- one or more git URLs; these may also contain `$1`-style backreferences.

Example content:

```
^example\.com/xyz/([^/]*)(/.*)?$ example.com/xyz/$1 ssh://git@local-repo.org/foo/$1
```

Imports of "example.com/xyz/bar" will be cloned from "local-repo.org/foo/bar".

The current implementation is just a POC: its parsing of Gopkg.reg is
rudimentary. It only supports git repositories. However, the principle
is demonstrated: it requires minimal code-change to get the registry
behaviour into dep. Registry implementations that talk to alternative
repository APIs are, of course, possible.

Note: the behaviour specified in Gopkg.reg is *not* inherited by any
importing packages; it is a function solely of the local environment.


### What should your reviewer look out for in this PR?

Mostly, if this is a suitable approach; the code is just a quick sketch.

### Do you need help or clarification on anything?

### Which issue(s) does this PR fix?

(partially) fixes #174

### NOTE:

README needs fixing prior to merge; you might or might not want to drop the Dockerfiles.