### PR TITLE
[WIP] RFC: a k8s-friendly extension of dep

### DIFF
--- a/cmd/dep/ensure_test.go
+++ b/cmd/dep/ensure_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/golang/dep"
 	"github.com/golang/dep/gps"
 	"github.com/golang/dep/gps/pkgtree"
+	"github.com/golang/dep/internal/kdep"
 	"github.com/golang/dep/internal/test"
 )
 
@@ -212,10 +213,12 @@ func TestValidateUpdateArgs(t *testing.T) {
 
 	stderrOutput := &bytes.Buffer{}
 	errLogger := log.New(stderrOutput, "", 0)
-	ctx := &dep.Ctx{
-		GOPATH: pwd,
-		Out:    log.New(ioutil.Discard, "", 0),
-		Err:    errLogger,
+	ctx := &kdep.Ctx{
+		&dep.Ctx{
+			GOPATH: pwd,
+			Out:    log.New(ioutil.Discard, "", 0),
+			Err:    errLogger,
+		},
 	}
 
 	sm, err := ctx.SourceManager()
@@ -240,7 +243,8 @@ func TestValidateUpdateArgs(t *testing.T) {
 			// Add lock to project
 			p.Lock = &dep.Lock{P: lockedProjects}
 
-			err := validateUpdateArgs(ctx, c.args, p, sm, &params)
+			kp, _ := kdep.WrapProject(p, ctx)
+			err := validateUpdateArgs(ctx, c.args, kp, sm, &params)
 			if err != c.wantError {
 				t.Fatalf("Unexpected error while validating update args:\n\t(GOT): %v\n\t(WNT): %v", err, c.wantError)
 			}

--- a/cmd/dep/ensure_test.go
+++ b/cmd/dep/ensure_test.go
@@ -214,7 +214,7 @@ func TestValidateUpdateArgs(t *testing.T) {
 	stderrOutput := &bytes.Buffer{}
 	errLogger := log.New(stderrOutput, "", 0)
 	ctx := &kdep.Ctx{
-		&dep.Ctx{
+		Ctx: &dep.Ctx{
 			GOPATH: pwd,
 			Out:    log.New(ioutil.Discard, "", 0),
 			Err:    errLogger,

--- a/cmd/dep/gopath_scanner.go
+++ b/cmd/dep/gopath_scanner.go
@@ -17,13 +17,14 @@ import (
 	"github.com/golang/dep/gps/pkgtree"
 	fb "github.com/golang/dep/internal/feedback"
 	"github.com/golang/dep/internal/fs"
+	"github.com/golang/dep/internal/kdep"
 	"github.com/pkg/errors"
 )
 
 // gopathScanner supplies manifest/lock data by scanning the contents of GOPATH
 // It uses its results to fill-in any missing details left by the rootAnalyzer.
 type gopathScanner struct {
-	ctx        *dep.Ctx
+	ctx        *kdep.Ctx
 	directDeps map[gps.ProjectRoot]bool
 	sm         gps.SourceManager
 
@@ -32,7 +33,7 @@ type gopathScanner struct {
 	origL *dep.Lock
 }
 
-func newGopathScanner(ctx *dep.Ctx, directDeps map[gps.ProjectRoot]bool, sm gps.SourceManager) *gopathScanner {
+func newGopathScanner(ctx *kdep.Ctx, directDeps map[gps.ProjectRoot]bool, sm gps.SourceManager) *gopathScanner {
 	return &gopathScanner{
 		ctx:        ctx,
 		directDeps: directDeps,

--- a/cmd/dep/gopath_scanner_test.go
+++ b/cmd/dep/gopath_scanner_test.go
@@ -53,7 +53,7 @@ func TestGopathScanner_OverlayManifestConstraints(t *testing.T) {
 	gs := gopathScanner{
 		origM: origM,
 		origL: &dep.Lock{},
-		ctx:   &kdep.Ctx{ctx},
+		ctx:   &kdep.Ctx{Ctx: ctx},
 		pd: projectData{
 			ondisk: map[gps.ProjectRoot]gps.Version{
 				pi1.ProjectRoot: v2,
@@ -109,7 +109,7 @@ func TestGopathScanner_OverlayLockProjects(t *testing.T) {
 				gps.NewLockedProject(pi2, v3, []string{}), // should be added to the lock
 			},
 		},
-		ctx: &kdep.Ctx{ctx},
+		ctx: &kdep.Ctx{Ctx: ctx},
 		pd: projectData{
 			ondisk: map[gps.ProjectRoot]gps.Version{
 				pi1.ProjectRoot: v2,

--- a/cmd/dep/gopath_scanner_test.go
+++ b/cmd/dep/gopath_scanner_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/golang/dep"
 	"github.com/golang/dep/gps"
+	"github.com/golang/dep/internal/kdep"
 	"github.com/golang/dep/internal/test"
 )
 
@@ -52,7 +53,7 @@ func TestGopathScanner_OverlayManifestConstraints(t *testing.T) {
 	gs := gopathScanner{
 		origM: origM,
 		origL: &dep.Lock{},
-		ctx:   ctx,
+		ctx:   &kdep.Ctx{ctx},
 		pd: projectData{
 			ondisk: map[gps.ProjectRoot]gps.Version{
 				pi1.ProjectRoot: v2,
@@ -108,7 +109,7 @@ func TestGopathScanner_OverlayLockProjects(t *testing.T) {
 				gps.NewLockedProject(pi2, v3, []string{}), // should be added to the lock
 			},
 		},
-		ctx: ctx,
+		ctx: &kdep.Ctx{ctx},
 		pd: projectData{
 			ondisk: map[gps.ProjectRoot]gps.Version{
 				pi1.ProjectRoot: v2,

--- a/cmd/dep/hash_in.go
+++ b/cmd/dep/hash_in.go
@@ -7,9 +7,9 @@ package main
 import (
 	"flag"
 
-	"github.com/golang/dep"
 	"github.com/golang/dep/gps"
 	"github.com/golang/dep/gps/pkgtree"
+	"github.com/golang/dep/internal/kdep"
 	"github.com/pkg/errors"
 )
 
@@ -23,7 +23,7 @@ func (cmd *hashinCommand) Register(fs *flag.FlagSet) {}
 
 type hashinCommand struct{}
 
-func (hashinCommand) Run(ctx *dep.Ctx, args []string) error {
+func (hashinCommand) Run(ctx *kdep.Ctx, args []string) error {
 	p, err := ctx.LoadProject()
 	if err != nil {
 		return err

--- a/cmd/dep/init.go
+++ b/cmd/dep/init.go
@@ -15,6 +15,7 @@ import (
 	"github.com/golang/dep"
 	"github.com/golang/dep/gps"
 	"github.com/golang/dep/internal/fs"
+	"github.com/golang/dep/internal/kdep"
 	"github.com/pkg/errors"
 )
 
@@ -68,7 +69,7 @@ type initCommand struct {
 	gopath     bool
 }
 
-func (cmd *initCommand) Run(ctx *dep.Ctx, args []string) error {
+func (cmd *initCommand) Run(ctx *kdep.Ctx, args []string) error {
 	if len(args) > 1 {
 		return errors.Errorf("too many args (%d)", len(args))
 	}
@@ -203,7 +204,7 @@ func (cmd *initCommand) Run(ctx *dep.Ctx, args []string) error {
 // GOPATH.
 //
 // If successful, it returns a dep.Project, ready for further use.
-func (cmd *initCommand) establishProjectAt(root string, ctx *dep.Ctx) (*dep.Project, error) {
+func (cmd *initCommand) establishProjectAt(root string, ctx *kdep.Ctx) (*dep.Project, error) {
 	var err error
 	p := new(dep.Project)
 	if err = p.SetRoot(root); err != nil {

--- a/cmd/dep/main.go
+++ b/cmd/dep/main.go
@@ -39,6 +39,15 @@ type command interface {
 	Run(*kdep.Ctx, []string) error
 }
 
+func init() {
+	// integration tests use a binary named "testdep" and definitely expect dep
+	// semantics...
+	basename := filepath.Base(os.Args[0])
+	if strings.TrimSuffix(basename, filepath.Ext(basename)) == "testdep" {
+		kdep.FallbackToDep = true
+	}
+}
+
 func main() {
 	p := &profile{}
 	flag.StringVar(&p.cpuProfile, "cpuprofile", "", "Writes a CPU profile to the specified file before exiting.")

--- a/cmd/dep/main.go
+++ b/cmd/dep/main.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/golang/dep"
 	"github.com/golang/dep/internal/fs"
+	"github.com/golang/dep/internal/kdep"
 )
 
 var (
@@ -35,7 +36,7 @@ type command interface {
 	LongHelp() string       // "Foo the first bar meeting the following conditions..."
 	Register(*flag.FlagSet) // command-specific flags
 	Hidden() bool           // indicates whether the command should be hidden from help output
-	Run(*dep.Ctx, []string) error
+	Run(*kdep.Ctx, []string) error
 }
 
 func main() {
@@ -225,11 +226,13 @@ func (c *Config) Run() int {
 				Cachedir:       cachedir,
 			}
 
+			kctx := &kdep.Ctx{ctx}
+
 			GOPATHS := filepath.SplitList(getEnv(c.Env, "GOPATH"))
 			ctx.SetPaths(c.WorkingDir, GOPATHS...)
 
 			// Run the command with the post-flag-processing args.
-			if err := cmd.Run(ctx, flags.Args()); err != nil {
+			if err := cmd.Run(kctx, flags.Args()); err != nil {
 				errLogger.Printf("%v\n", err)
 				return errorExitCode
 			}

--- a/cmd/dep/main.go
+++ b/cmd/dep/main.go
@@ -235,7 +235,7 @@ func (c *Config) Run() int {
 				Cachedir:       cachedir,
 			}
 
-			kctx := &kdep.Ctx{ctx}
+			kctx := &kdep.Ctx{Ctx: ctx}
 
 			GOPATHS := filepath.SplitList(getEnv(c.Env, "GOPATH"))
 			ctx.SetPaths(c.WorkingDir, GOPATHS...)

--- a/cmd/dep/main_test.go
+++ b/cmd/dep/main_test.go
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import "github.com/golang/dep/internal/kdep"
+
+func init() {
+	// tests in this package expect dep semantics
+	kdep.FallbackToDep = true
+}

--- a/cmd/dep/prune.go
+++ b/cmd/dep/prune.go
@@ -18,6 +18,7 @@ import (
 	"github.com/golang/dep/gps"
 	"github.com/golang/dep/gps/pkgtree"
 	"github.com/golang/dep/internal/fs"
+	"github.com/golang/dep/internal/kdep"
 	"github.com/pkg/errors"
 )
 
@@ -40,7 +41,7 @@ func (cmd *pruneCommand) Hidden() bool      { return false }
 func (cmd *pruneCommand) Register(fs *flag.FlagSet) {
 }
 
-func (cmd *pruneCommand) Run(ctx *dep.Ctx, args []string) error {
+func (cmd *pruneCommand) Run(ctx *kdep.Ctx, args []string) error {
 	ctx.Err.Printf("Pruning is now performed automatically by dep ensure.\n")
 	ctx.Err.Printf("Set prune settings in %s and it will be applied when running ensure.\n", dep.ManifestName)
 	ctx.Err.Printf("\nThis command currently still prunes as it always has, to ease the transition.\n")
@@ -92,7 +93,7 @@ func (cmd *pruneCommand) Run(ctx *dep.Ctx, args []string) error {
 	if !ctx.Verbose {
 		pruneLogger = log.New(ioutil.Discard, "", 0)
 	}
-	return pruneProject(p, sm, pruneLogger)
+	return pruneProject(p.Project, sm, pruneLogger)
 }
 
 // pruneProject removes unused packages from a project.

--- a/cmd/dep/root_analyzer.go
+++ b/cmd/dep/root_analyzer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/golang/dep/gps"
 	fb "github.com/golang/dep/internal/feedback"
 	"github.com/golang/dep/internal/importers"
+	"github.com/golang/dep/internal/kdep"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -23,12 +24,12 @@ import (
 //   then external tools.
 type rootAnalyzer struct {
 	skipTools  bool
-	ctx        *dep.Ctx
+	ctx        *kdep.Ctx
 	sm         gps.SourceManager
 	directDeps map[gps.ProjectRoot]bool
 }
 
-func newRootAnalyzer(skipTools bool, ctx *dep.Ctx, directDeps map[gps.ProjectRoot]bool, sm gps.SourceManager) *rootAnalyzer {
+func newRootAnalyzer(skipTools bool, ctx *kdep.Ctx, directDeps map[gps.ProjectRoot]bool, sm gps.SourceManager) *rootAnalyzer {
 	return &rootAnalyzer{
 		skipTools:  skipTools,
 		ctx:        ctx,

--- a/cmd/dep/status.go
+++ b/cmd/dep/status.go
@@ -22,6 +22,7 @@ import (
 	"github.com/golang/dep"
 	"github.com/golang/dep/gps"
 	"github.com/golang/dep/gps/paths"
+	"github.com/golang/dep/internal/kdep"
 	"github.com/pkg/errors"
 )
 
@@ -304,7 +305,7 @@ func (out *templateOutput) MissingLine(ms *MissingStatus) error {
 	return out.tmpl.Execute(out.w, ms)
 }
 
-func (cmd *statusCommand) Run(ctx *dep.Ctx, args []string) error {
+func (cmd *statusCommand) Run(ctx *kdep.Ctx, args []string) error {
 	if cmd.examples {
 		ctx.Err.Println(strings.TrimSpace(statusExamples))
 		return nil
@@ -326,7 +327,7 @@ func (cmd *statusCommand) Run(ctx *dep.Ctx, args []string) error {
 	sm.UseDefaultSignalHandling()
 	defer sm.Release()
 
-	if err := dep.ValidateProjectRoots(ctx, p.Manifest, sm); err != nil {
+	if err := dep.ValidateProjectRoots(ctx.Ctx, p.Manifest.Manifest, sm); err != nil {
 		return err
 	}
 
@@ -341,7 +342,7 @@ func (cmd *statusCommand) Run(ctx *dep.Ctx, args []string) error {
 		}
 	case cmd.dot:
 		out = &dotOutput{
-			p: p,
+			p: p.Project,
 			o: cmd.output,
 			w: &buf,
 		}
@@ -487,7 +488,7 @@ func (os OldStatus) marshalJSON() *rawOldStatus {
 	}
 }
 
-func (cmd *statusCommand) runOld(ctx *dep.Ctx, out oldOutputter, p *dep.Project, sm gps.SourceManager) error {
+func (cmd *statusCommand) runOld(ctx *kdep.Ctx, out oldOutputter, p *kdep.Project, sm gps.SourceManager) error {
 	// While the network churns on ListVersions() requests, statically analyze
 	// code from the current project.
 	ptree, err := p.ParseRootPackageTree()
@@ -658,7 +659,7 @@ type MissingStatus struct {
 	MissingPackages []string
 }
 
-func runStatusAll(ctx *dep.Ctx, out outputter, p *dep.Project, sm gps.SourceManager) (hasMissingPkgs bool, errCount int, err error) {
+func runStatusAll(ctx *kdep.Ctx, out outputter, p *kdep.Project, sm gps.SourceManager) (hasMissingPkgs bool, errCount int, err error) {
 	// While the network churns on ListVersions() requests, statically analyze
 	// code from the current project.
 	ptree, err := p.ParseRootPackageTree()
@@ -987,7 +988,7 @@ type constraintsCollection map[string][]projectConstraint
 // collectConstraints collects constraints declared by all the dependencies.
 // It returns constraintsCollection and a slice of errors encountered while
 // collecting the constraints, if any.
-func collectConstraints(ctx *dep.Ctx, p *dep.Project, sm gps.SourceManager) (constraintsCollection, []error) {
+func collectConstraints(ctx *kdep.Ctx, p *kdep.Project, sm gps.SourceManager) (constraintsCollection, []error) {
 	logger := ctx.Err
 	if !ctx.Verbose {
 		logger = log.New(ioutil.Discard, "", 0)

--- a/cmd/dep/status_test.go
+++ b/cmd/dep/status_test.go
@@ -475,7 +475,7 @@ func TestCollectConstraints(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			p.Lock = &c.lock
-			kctx := &kdep.Ctx{ctx}
+			kctx := &kdep.Ctx{Ctx: ctx}
 			kp, _ := kdep.WrapProject(p, kctx)
 			gotConstraints, err := collectConstraints(kctx, kp, sm)
 			if len(err) > 0 && !c.wantErr {

--- a/cmd/dep/status_test.go
+++ b/cmd/dep/status_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/golang/dep"
 	"github.com/golang/dep/gps"
+	"github.com/golang/dep/internal/kdep"
 	"github.com/golang/dep/internal/test"
 	"github.com/pkg/errors"
 )
@@ -474,7 +475,9 @@ func TestCollectConstraints(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			p.Lock = &c.lock
-			gotConstraints, err := collectConstraints(ctx, p, sm)
+			kctx := &kdep.Ctx{ctx}
+			kp, _ := kdep.WrapProject(p, kctx)
+			gotConstraints, err := collectConstraints(kctx, kp, sm)
 			if len(err) > 0 && !c.wantErr {
 				t.Fatalf("unexpected errors while collecting constraints: %v", err)
 			} else if len(err) == 0 && c.wantErr {

--- a/cmd/dep/version.go
+++ b/cmd/dep/version.go
@@ -8,7 +8,7 @@ import (
 	"flag"
 	"runtime"
 
-	"github.com/golang/dep"
+	"github.com/golang/dep/internal/kdep"
 )
 
 var (
@@ -31,7 +31,7 @@ func (cmd *versionCommand) Register(fs *flag.FlagSet) {}
 
 type versionCommand struct{}
 
-func (cmd *versionCommand) Run(ctx *dep.Ctx, args []string) error {
+func (cmd *versionCommand) Run(ctx *kdep.Ctx, args []string) error {
 	ctx.Out.Printf(`dep:
  version     : %s
  build date  : %s

--- a/internal/dependencies/deps.go
+++ b/internal/dependencies/deps.go
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dependencies
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// DepsBuilder provides a way to compute direct dependencies of a package
+type DepsBuilder struct {
+	Root          string
+	Package       string
+	LocalPackages []string
+	SkipSubdirs   []string
+	internal      *internalBuilder
+}
+
+type internalBuilder struct {
+	Root          string
+	Package       string
+	LocalPackages map[string]interface{}
+	SkipSubdirs   map[string]interface{}
+}
+
+func (b *DepsBuilder) compile() *internalBuilder {
+	if b.internal != nil {
+		return b.internal
+	}
+
+	loc := make(map[string]interface{})
+	for _, p := range b.LocalPackages {
+		loc[p] = nil
+	}
+
+	skip := make(map[string]interface{})
+	for _, d := range b.SkipSubdirs {
+		skip[d] = nil
+	}
+
+	return &internalBuilder{
+		Root:          b.Root,
+		Package:       b.Package,
+		LocalPackages: loc,
+		SkipSubdirs:   skip,
+	}
+}
+
+// GetPackageDependencies gives back the list of direct dependencies for the current context
+func (b *DepsBuilder) GetPackageDependencies() ([]string, error) {
+	return b.compile().getPackageDependencies()
+}
+
+func (b *internalBuilder) getPackageDependencies() ([]string, error) {
+	deps := make(map[string]interface{})
+
+	err := filepath.Walk(b.Root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info == nil || !info.IsDir() {
+			return nil
+		}
+
+		base := filepath.Base(path)
+		if base == "vendor" || base == "testdata" || strings.HasPrefix(".", base) || strings.HasPrefix("_", base) {
+			return filepath.SkipDir
+		}
+
+		if _, ok := b.SkipSubdirs[path]; ok {
+			return filepath.SkipDir
+		}
+
+		subdeps, err := b.packageDeps(path)
+		if err != nil {
+			return err
+		}
+
+		for k := range subdeps {
+			deps[k] = nil
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	res := make([]string, 0)
+	for k := range deps {
+		res = append(res, k)
+	}
+	return res, nil
+}
+
+func (b *internalBuilder) packageDeps(pack string) (map[string]interface{}, error) {
+	depsMap := make(map[string]interface{})
+
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, pack, nil, parser.ImportsOnly)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, p := range pkgs {
+		for _, f := range p.Files {
+			for _, i := range f.Imports {
+				d := i.Path.Value
+				d = d[1 : len(d)-1] // remove quotes
+				if b.isExternalDependency(d) {
+					depsMap[d] = nil
+				}
+			}
+		}
+	}
+
+	return depsMap, nil
+}
+
+func (b *internalBuilder) isExternalDependency(pack string) bool {
+	if strings.HasPrefix(pack, b.Package) {
+		return false
+	}
+
+	for lp := range b.LocalPackages {
+		if strings.HasPrefix(pack, lp) {
+			return false
+		}
+	}
+
+	cpts := strings.Split(pack, "/")
+	lead := cpts[0]
+	if strings.Contains(lead, ".") {
+		return true
+	}
+
+	return false
+}

--- a/internal/dependencies/deps.go
+++ b/internal/dependencies/deps.go
@@ -149,9 +149,5 @@ func (b *internalBuilder) isExternalDependency(pack string) bool {
 
 	cpts := strings.Split(pack, "/")
 	lead := cpts[0]
-	if strings.Contains(lead, ".") {
-		return true
-	}
-
-	return false
+	return strings.Contains(lead, ".")
 }

--- a/internal/kdep/context.go
+++ b/internal/kdep/context.go
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kdep
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/golang/dep"
+)
+
+// Ctx wraps dep.Ctx to support kdep projects
+type Ctx struct {
+	*dep.Ctx
+}
+
+// LoadProject finds the first dep project with a kdep-project flag
+func (c *Ctx) LoadProject() (*Project, error) {
+	for {
+		p, err := c.Ctx.LoadProject()
+		if err != nil {
+			return nil, err
+		}
+
+		proj, err := newProject(p, c)
+		if err == nil {
+			return proj, err
+		}
+
+		parent := filepath.Dir(c.WorkingDir)
+		if parent == c.WorkingDir {
+			return nil, fmt.Errorf("no project found")
+		}
+		c.SetPaths(parent, c.GOPATHs...)
+	}
+}

--- a/internal/kdep/context.go
+++ b/internal/kdep/context.go
@@ -30,13 +30,18 @@ type Ctx struct {
 
 // LoadProject finds the first dep project with a kdep-project flag
 func (c *Ctx) LoadProject() (*Project, error) {
+	if FallbackToDep {
+		p, err := c.Ctx.LoadProject()
+		kp, _ := WrapProject(p, c)
+		return kp, err
+	}
 	for {
 		p, err := c.Ctx.LoadProject()
 		if err != nil {
 			return nil, err
 		}
 
-		proj, err := newProject(p, c)
+		proj, err := WrapProject(p, c)
 		if err == nil {
 			return proj, err
 		}

--- a/internal/kdep/kdep.go
+++ b/internal/kdep/kdep.go
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kdep
+
+var (
+	// FallbackToDep makes kdep behave like dep. This is solely to reuse dep
+	// tests.
+	FallbackToDep = false
+)

--- a/internal/kdep/manifest.go
+++ b/internal/kdep/manifest.go
@@ -48,6 +48,11 @@ type Manifest struct {
 	Dependencies []string
 }
 
+// WrapManifest generates a kdep Manifest
+func WrapManifest(m *dep.Manifest) *Manifest {
+	return &Manifest{m, nil, nil, "", nil}
+}
+
 func manifestFromProject(p *dep.Project) *Manifest {
 	fname := filepath.Join(p.AbsRoot, dep.ManifestName)
 

--- a/internal/kdep/manifest.go
+++ b/internal/kdep/manifest.go
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kdep
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/golang/dep"
+	"github.com/golang/dep/gps"
+	"github.com/golang/dep/gps/pkgtree"
+	toml "github.com/pelletier/go-toml"
+)
+
+// Metadata holds kdep metadata information
+type Metadata struct {
+	IsKdepRoot   bool     `toml:"kdep-project,omitempty"`
+	LocalGopaths []string `toml:"kdep-local-gopaths"`
+	LocalDeps    []string `toml:"kdep-local-deps"`
+}
+
+type manifest struct {
+	Meta Metadata `toml:"metadata,omitempty"`
+}
+
+// Manifest wraps dep.Manifest to support kdep projects
+type Manifest struct {
+	*dep.Manifest
+	Meta         *Metadata
+	SubManifests map[string]*dep.Manifest
+	ImportRoot   string
+	Dependencies []string
+}
+
+func manifestFromProject(p *dep.Project) *Manifest {
+	fname := filepath.Join(p.AbsRoot, dep.ManifestName)
+
+	meta := extractMetadata(fname)
+	m := &Manifest{p.Manifest, meta, nil, string(p.ImportRoot), nil}
+	return m
+}
+
+func extractMetadata(fname string) *Metadata {
+	mf, _ := os.Open(fname)
+	defer mf.Close()
+
+	buf := &bytes.Buffer{}
+	// dep has read it already, we're good
+	_, _ = buf.ReadFrom(mf)
+	m := manifest{}
+
+	err := toml.Unmarshal(buf.Bytes(), &m)
+	if err != nil {
+		return &Metadata{}
+	}
+
+	return &m.Meta
+}
+
+// DependencyConstraints computes the aggregate set of dependency constraints for a kdep project
+func (m *Manifest) DependencyConstraints() gps.ProjectConstraints {
+	constraints := m.Manifest.DependencyConstraints()
+
+	for _, sub := range m.SubManifests {
+		extra := sub.DependencyConstraints()
+		for root, props := range extra {
+			p, ok := constraints[root]
+			if ok {
+				p.Constraint = p.Constraint.Intersect(props.Constraint)
+			} else {
+				constraints[root] = props
+			}
+		}
+	}
+
+	return constraints
+}
+
+// Overrides computes the aggregate set of overrides for a kdep project
+func (m *Manifest) Overrides() gps.ProjectConstraints {
+	constraints := m.Manifest.Overrides()
+
+	for _, sub := range m.SubManifests {
+		extra := sub.Overrides()
+		for root, props := range extra {
+			p, ok := constraints[root]
+			if ok {
+				p.Constraint = p.Constraint.Intersect(props.Constraint)
+			} else {
+				constraints[root] = props
+			}
+		}
+	}
+	return constraints
+}
+
+// IgnoredPackages computes the aggregate set of ignored packages for a kdep project
+func (m *Manifest) IgnoredPackages() *pkgtree.IgnoredRuleset {
+	ignored := make([]string, len(m.SubManifests)+1)
+	i := 0
+	for k := range m.SubManifests {
+		ignored[i] = fmt.Sprintf("%s/*", k)
+		i++
+	}
+	ignored[i] = m.ImportRoot
+	return pkgtree.NewIgnoredRuleset(append(ignored, m.Manifest.IgnoredPackages().ToSlice()...))
+}
+
+// RequiredPackages computes the aggregate set of required packages for a kdep project
+func (m *Manifest) RequiredPackages() map[string]bool {
+	required := m.Manifest.RequiredPackages()
+	for _, sub := range m.SubManifests {
+		for k, v := range sub.RequiredPackages() {
+			required[k] = v
+		}
+	}
+
+	// since we ignore all the root packages, let's require all their
+	// dependencies
+	for _, v := range m.Dependencies {
+		required[v] = true
+	}
+	return required
+}
+
+var _ gps.RootManifest = (*Manifest)(nil)

--- a/internal/kdep/project.go
+++ b/internal/kdep/project.go
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kdep
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/golang/dep"
+	"github.com/golang/dep/gps"
+	"github.com/golang/dep/gps/pkgtree"
+	"github.com/golang/dep/internal/dependencies"
+)
+
+// Project wraps dep.Project to support kdep projects
+type Project struct {
+	*dep.Project
+	Manifest    *Manifest
+	SubProjects []*dep.Project
+
+	extraVendorEntries map[string]string
+}
+
+func newProject(p *dep.Project, c *Ctx) (*Project, error) {
+	m := manifestFromProject(p)
+	if m == nil || !m.Meta.IsKdepRoot {
+		return nil, fmt.Errorf("not a kdep project")
+	}
+
+	sps := make([]*dep.Project, len(m.Meta.LocalDeps))
+	sms := make(map[string]*dep.Manifest)
+	extra := make(map[string]string)
+
+	for i, sub := range m.Meta.LocalDeps {
+		for _, path := range m.Meta.LocalGopaths {
+			candidate := filepath.Join(p.ResolvedAbsRoot, path, "src", sub)
+			if _, err := os.Stat(candidate); err == nil {
+				ctxt := *c.Ctx
+				ctxt.WorkingDir = candidate
+				proj, err := ctxt.LoadProject()
+				if err != nil {
+					return nil, err
+				}
+
+				// make sure we have the proper import name
+				proj.ImportRoot = gps.ProjectRoot(sub)
+				sps[i] = proj
+				imp := string(proj.ImportRoot)
+				sms[imp] = proj.Manifest
+
+				// no need to look further in gopaths
+				extra[imp] = candidate
+				break
+			}
+		}
+	}
+	res := &Project{p, m, sps, extra}
+	m.SubManifests = sms
+
+	b := &dependencies.DepsBuilder{
+		Root:          p.AbsRoot,
+		Package:       string(p.ImportRoot),
+		LocalPackages: m.Meta.LocalDeps,
+		SkipSubdirs:   m.Meta.LocalGopaths,
+	}
+	deps, err := b.GetPackageDependencies()
+	if err != nil {
+		return nil, err
+	}
+
+	m.Dependencies = deps
+
+	return res, nil
+}
+
+// MakeParams generates resolution parameters
+func (p *Project) MakeParams() gps.SolveParameters {
+	params := gps.SolveParameters{
+		RootDir:         p.AbsRoot,
+		ProjectAnalyzer: dep.Analyzer{},
+	}
+
+	params.Manifest = p.Manifest
+
+	if p.Lock != nil {
+		params.Lock = p.Lock
+	}
+
+	return params
+}
+
+// ParseRootPackageTree generates the pkgtree.PackageTree for a kdep multi-repo
+func (p *Project) ParseRootPackageTree() (pkgtree.PackageTree, error) {
+	tree, err := p.Project.ParseRootPackageTree()
+	if err != nil {
+		return tree, err
+	}
+
+	// cleanup packages that will be re-added from subprojects
+	for imp := range tree.Packages {
+		for _, gp := range p.Manifest.Meta.LocalGopaths {
+			if strings.HasPrefix(imp, string(p.ImportRoot)+"/"+gp) {
+				delete(tree.Packages, imp)
+			}
+		}
+	}
+
+	for _, sub := range p.SubProjects {
+		t, _ := sub.ParseRootPackageTree()
+		for imp, pack := range t.Packages {
+			tree.Packages[imp] = pack
+		}
+	}
+	return tree, nil
+}
+
+// HackExtraVendorEntries generates extra vendor entries for local packages
+func (p *Project) HackExtraVendorEntries() error {
+	vendorPath := filepath.Join(p.AbsRoot, "vendor")
+
+	for imp, path := range p.extraVendorEntries {
+		vendorProjectPath := filepath.Join(vendorPath, imp)
+		vendorProjectDirPath := filepath.Dir(vendorProjectPath)
+		os.MkdirAll(vendorProjectDirPath, 0755)
+		relVendorProjectPath, _ := filepath.Rel(vendorProjectDirPath, path)
+		_ = os.Symlink(relVendorProjectPath, vendorProjectPath)
+	}
+	return nil
+}


### PR DESCRIPTION
This PR is NOT for merging. I'm interested in collecting feedback on the viability of the approach, and how much of it could potentially make it into a proper `dep` feature, or the `dep` public API.

I also have a standalone version of that tool (which is refered to below as `kdep`), that vendors `dep` instead of modifying it, which is the reason for some otherwise potentially weird implementation choices around extending `dep`'s structures. That's basically the same thing, modulo the `dep/cmd` changes of course. Since it's simpler to discuss around a PR, I'll leave this standalone version aside for now.

@sdboyer @carolynvs @sttts your input would be highly appreciated

A Kubernetes-friendly dep extension
===================================

Rationale
---------

Kubernetes is, to this day, using `godep` for dependency management. Talks of
migrating to `dep` have been in progress for a long time and are facing the
following main challenge: kubernetes is managed as a mono-repo.

As such, there are sub-repositories (in the `staging/` directory) that have a
relatively independent life. *But* the set of dependencies needs to be
maintained consistent across the main repository and those sub-repositories to
guarantee the good behavior of Kubernetes-the-solution.

Proposal
--------

`kdep` is built on top of `dep`, by synthesizing a composite project from all
the sub-repositories we have in Kubernetes (using the `dep` metadata extension
point), then running the regular `dep` solver to reach a solution.

Therefore, we get a few interesting properties.

On the `dep` side:

  * the descriptor (`Gopkg.toml` file) is a standard `dep` descriptor, although
    obviously insufficient to compute the right solution
  * the solution (`Gopkg.lock` file) is a standard `dep` solution without any
    addition (so for example `dep status` can be used with it as is)
    
On the Kubernetes side:

  * `kdep` understands and obeys the uncommon `staging/` scheme, reducing
    friction when updating dependencies
  * we now have a semver-aware tool to manage dependencies

Obviously, extending `dep` externally triggers some limitations:

  * a `kdep`-maintained project cannot be vendored properly by downstream projects.
    Actually more generally a mono-repository cannot be vendored using usual tools.
    So that limitation is not new in the Kubernetes case.

Synthetic project
-----------------

The synthetic `dep` project is generated using the following approach.

In the global dependency graph G, let Root(G) be the set of root nodes (each
sub-repository corresponds to a root node).
For a package P in G, Dep(P) is the set of direct dependencies for P.

Let's consider the following set: 
  Dep1(G) = Union(Dep(r) for r in Root(G)) - Root(G)
  
That is conceptually the set of direct dependencies of the root nodes in the graph.

Now, running the `dep` solver with:
  * required == Dep1(G)
  * ignored == Root(G)
  
computes a dependency solution for the synthetic project. It relatively
naturally extends `dep`'s notion of a single root package, while not requiring
any modifications in the solver.

Status
------

A working `ensure` command is provided. It consumes a `Gopkg.toml` of the following form:

```toml
# regular stuff
# ...

[metadata]
  kdep-project = true
  kdep-local-gopaths = [
                     "staging",
                     ]
  kdep-local-deps = [
                  "k8s.io/api",
                  "k8s.io/apiextensions-apiserver",
                  "k8s.io/apimachinery",
                  "k8s.io/apiserver",
                  "k8s.io/client-go",
                  "k8s.io/code-generator",
                  "k8s.io/kube-aggregator",
                  "k8s.io/metrics",
                  "k8s.io/sample-apiserver",
                  "k8s.io/sample-controller",
                  ]
```

POC in action
-------------

K8s demo:

  * Git clone converted kubernetes repo (https://github.com/sigma/kubernetes/tree/kdep where I removed vendor/ altogether for simplicity, and added dep manifests)
  * Run `dep ensure -v && hack/update-bazel.sh`
  * Run `bazel build //cmd/kubeadm`
  * Run `dep status`
    See that github.com/coreos/etcd could be updated from 3.2.13
  * Run `dep ensure -v -update github.com/coreos/etcd && hack/update-bazel.sh`
    Latest 3.2.x (3.2.17 as of this writing) should be installed 
  * Run `bazel build //cmd/kubeadm`
  * Run `sed -i "s/~3.2.13/^3.2.13/" Gopkg.toml`
    This opens the door to minor version updates
  * Run `dep ensure -v -update github.com/coreos/etcd && hack/update-bazel.sh`
    Latest 3.x.y (3.3.2 as of this writing) should now be installed
  * Run `bazel build //cmd/kubeadm` (this should fail)

What this shows:
  * Etcd can be safely updated to 3.2.17 using kdep
  * Etcd doesn’t respect semver, and version 3.3.x is not safe to use

Next steps
----------

One of 4 things needs to happen (from preferred to least preferred), depending
on feedback:

  * `kdep` (or a large part of it) collapses into `dep`
  * `dep`'s public API is extended to provide better hooks for `kdep` logic
  * `kdep` stays an independent tool forever, and the code is simplified (by
    removing the parts that are there solely for future merging with `dep`)
  * the whole approach is canned
#