### PR TITLE
Wrap the "Gopkg.lock" text with back-ticks

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -373,14 +373,14 @@ It's up to you:
 
 * It's the only way to get truly reproducible builds, as it guards against upstream renames,
   deletes and commit history overwrites.
-* You don't need an extra `dep ensure` step to sync `vendor/` with Gopkg.lock after most operations,
+* You don't need an extra `dep ensure` step to sync `vendor/` with `Gopkg.lock` after most operations,
   such as `go get`, cloning, getting latest, merging, etc.
 
 **Cons**
 
 * Your repo will be bigger, potentially a lot bigger,
   though [`prune`](Gopkg.toml.md#prune) can help minimize this problem.
-* PR diffs will include changes for files under `vendor/` when Gopkg.lock is modified,
+* PR diffs will include changes for files under `vendor/` when `Gopkg.lock` is modified,
   however files in `vendor/` are [hidden by default](https://github.com/github/linguist/blob/v5.2.0/lib/linguist/generated.rb#L328) on GitHub.
 
 ## How do I roll releases that `dep` will be able to use?


### PR DESCRIPTION
### What does this do / why do we need it?

There are 2 **Gopkg.lock** without back-ticks around. So I wrapped those text with back-ticks for consistency. All others is already wrapped with back-ticks.

### What should your reviewer look out for in this PR?

Just check **Gopkg.lock** text in FAQ pages

### Do you need help or clarification on anything?

No. It is easy to review.

### Which issue(s) does this PR fix?

Broken paragraph consistency
