### PR TITLE
Add support for multiple directories in GOPATH environment variable in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -70,7 +70,7 @@ findGoBinDirectory() {
         exit 1
     fi
     if [ -z "$GOBIN" ]; then
-        GOBIN="$GOPATH/bin"
+        GOBIN=$(echo "${GOPATH%%:*}/bin" | sed s#//*#/#g)
     fi
     if [ ! -d "$GOBIN" ]; then
         echo "Installation requires your GOBIN directory $GOBIN to exist. Please create it."


### PR DESCRIPTION
### What does this do / why do we need it?

According to the current implementation, `install.sh` script doesn't support multiple directories in `GOPATH` environment variable, in this case it just throws error saying installation directory does not exist.
It should use the first entry path from `GOPATH` instead of throwing error.

### What should your reviewer look out for in this PR?

### Do you need help or clarification on anything?

### Which issue(s) does this PR fix?

fixes #1749 
