### PR TITLE
Support configuring CGO_ENABLED in hack/build-all script

### DIFF
--- a/hack/build-all.bash
+++ b/hack/build-all.bash
@@ -33,6 +33,10 @@ if [[ -z "${DEP_BUILD_ARCHS}" ]]; then
     DEP_BUILD_ARCHS="amd64 386"
 fi
 
+if [[ -z "${DEP_CGO_ENABLED}" ]]; then
+    DEP_CGO_ENABLED="0"
+fi
+
 mkdir -p "${DEP_ROOT}/release"
 
 for OS in ${DEP_BUILD_PLATFORMS[@]}; do
@@ -42,7 +46,7 @@ for OS in ${DEP_BUILD_PLATFORMS[@]}; do
       NAME="${NAME}.exe"
     fi
     echo "Building for ${OS}/${ARCH}"
-    GOARCH=${ARCH} GOOS=${OS} CGO_ENABLED=0 ${GO_BUILD_CMD} -ldflags "${GO_BUILD_LDFLAGS}"\
+    GOARCH=${ARCH} GOOS=${OS} CGO_ENABLED=${DEP_CGO_ENABLED} ${GO_BUILD_CMD} -ldflags "${GO_BUILD_LDFLAGS}"\
      -o "${DEP_ROOT}/release/${NAME}" ./cmd/dep/
     shasum -a 256 "${DEP_ROOT}/release/${NAME}" > "${DEP_ROOT}/release/${NAME}".sha256
   done


### PR DESCRIPTION
### What does this do / why do we need it?
This change supports setting `CGO_ENABLED=1` in the`hack/build-all` script. A follow-up change will update the dep homebrew formula (https://github.com/Homebrew/homebrew-core/blob/90b98d9184045a8b221d549acdfec224f0bc30da/Formula/dep.rb) to build macOS binaries with cgo enabled; the latter enables proper DNS resolution on this platform.

### What should your reviewer look out for in this PR?

### Do you need help or clarification on anything?
No.

### Which issue(s) does this PR fix?
https://github.com/golang/dep/issues/1838