### PR TITLE
Makefile: use simple variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-SHELL="/bin/bash"
-PLATFORM=$(shell go env GOOS)
-ARCH=$(shell go env GOARCH)
-GOPATH=$(shell go env GOPATH)
-GOBIN=$(GOPATH)/bin
+SHELL := /bin/bash
+PLATFORM := $(shell go env GOOS)
+ARCH := $(shell go env GOARCH)
+GOPATH := $(shell go env GOPATH)
+GOBIN := $(GOPATH)/bin
 
 default: build validate test
 


### PR DESCRIPTION
### What does this do / why do we need it?

This aligns the Makefile with usual practices, which differ from shell scripting.

There is no reason to run go env at variable expansion time, run it at
initialization time instead.
Also remove extra quoting for SHELL, as those are kept verbatim in the $(shell)
calls, which can lead to the attempted execution of a "/bin/bash" process
depending on the system, leading to errors like:

  make: "/bin/bash": Command not found

### What should your reviewer look out for in this PR?

### Do you need help or clarification on anything?

### Which issue(s) does this PR fix?
