### PR TITLE
test: unset GIT_DIR for git operations in integration tests

### DIFF
--- a/internal/test/integration/testproj.go
+++ b/internal/test/integration/testproj.go
@@ -42,6 +42,13 @@ type TestProject struct {
 
 // NewTestProject initializes a new test's project directory.
 func NewTestProject(t *testing.T, initPath, wd string, run RunFunc) *TestProject {
+	// Cleaning up the GIT_DIR variable is useful when running tests under git
+	// rebase. In any case, since we're operating with temporary clones,
+	// no pre-existing value could be useful here.
+	// We do it globally because the internal runs don't actually use the
+	// TestProject's environment.
+	os.Unsetenv("GIT_DIR")
+
 	new := &TestProject{
 		t:      t,
 		origWd: wd,


### PR DESCRIPTION
### What does this do / why do we need it?

This allows integration tests to run during git rebase operations.
Without this, GIT_DIR points to the dep repo itself, which makes git checkout
operations fail miserably.

```
$ GOCACHE=off git rebase -x "go test github.com/golang/dep/cmd/dep -run TestIntegration/ensure/add/desync" 'HEAD^'
Executing: go test github.com/golang/dep/cmd/dep -run TestIntegration/ensure/add/desync
--- FAIL: TestIntegration (0.01s)
    --- FAIL: TestIntegration/ensure/add/desync (0.00s)
        --- FAIL: TestIntegration/ensure/add/desync/internal (2.79s)
        	testcase.go:165: error raised where none was expected: 
        		(1/1) github.com/sdboyer/deptesttres@master
        		
        		Root project is "github.com/golang/notexist"
        		 1 transitively valid internal packages
        		 3 external packages imported from 3 projects
        		(0)   ✓ select (root)
        		(1)	? attempt github.com/sdboyer/deptesttres with 1 pkgs; at least 1 versions to try
        		(1)	    try github.com/sdboyer/deptesttres@master
        		(1)	✗   unable to update checked out version: fatal: reference is not a tree: 54aaeb0023e1f3dcf5f98f31dd8c565457945a12
        		(1)	  : command failed: [git checkout 54aaeb0023e1f3dcf5f98f31dd8c565457945a12]: exit status 128
        		(1)	    try github.com/sdboyer/deptesttres@master
        		(1)	✗   unable to update checked out version: fatal: reference is not a tree: 54aaeb0023e1f3dcf5f98f31dd8c565457945a12
        		(1)	  : command failed: [git checkout 54aaeb0023e1f3dcf5f98f31dd8c565457945a12]: exit status 128
        		(1)	  ← no more versions of github.com/sdboyer/deptesttres to try; begin backtrack
        		  ✗ solving failed
        		
        		Solver wall times by segment:
        		     b-list-versions: 773.290367ms
        		         b-list-pkgs:   6.983762ms
        		         select-root:    107.395µs
        		            new-atom:     58.489µs
        		             satisfy:     37.263µs
        		  b-deduce-proj-root:     11.902µs
        		               other:     10.495µs
        		     b-source-exists:      2.847µs
        		
        		  TOTAL: 780.50252ms
        		
        		Solving failure: No versions of github.com/sdboyer/deptesttres met constraints:
        			master: unable to update checked out version: fatal: reference is not a tree: 54aaeb0023e1f3dcf5f98f31dd8c565457945a12
        		: command failed: [git checkout 54aaeb0023e1f3dcf5f98f31dd8c565457945a12]: exit status 128
        			master: unable to update checked out version: fatal: reference is not a tree: 54aaeb0023e1f3dcf5f98f31dd8c565457945a12
        		: command failed: [git checkout 54aaeb0023e1f3dcf5f98f31dd8c565457945a12]: exit status 128
        --- FAIL: TestIntegration/ensure/add/desync/external (3.40s)
        	testcase.go:165: error raised where none was expected: 
        		(1/1) github.com/sdboyer/deptesttres@master
        		
        		Root project is "github.com/golang/notexist"
        		 1 transitively valid internal packages
        		 3 external packages imported from 3 projects
        		(0)   ✓ select (root)
        		(1)	? attempt github.com/sdboyer/deptesttres with 1 pkgs; at least 1 versions to try
        		(1)	    try github.com/sdboyer/deptesttres@master
        		(1)	✗   unable to update checked out version: fatal: reference is not a tree: 54aaeb0023e1f3dcf5f98f31dd8c565457945a12
        		(1)	  : command failed: [git checkout 54aaeb0023e1f3dcf5f98f31dd8c565457945a12]: exit status 128
        		(1)	    try github.com/sdboyer/deptesttres@master
        		(1)	✗   unable to update checked out version: fatal: reference is not a tree: 54aaeb0023e1f3dcf5f98f31dd8c565457945a12
        		(1)	  : command failed: [git checkout 54aaeb0023e1f3dcf5f98f31dd8c565457945a12]: exit status 128
        		(1)	  ← no more versions of github.com/sdboyer/deptesttres to try; begin backtrack
        		  ✗ solving failed
        		
        		Solver wall times by segment:
        		     b-list-versions: 1.336373581s
        		         b-list-pkgs:   5.263873ms
        		         select-root:    142.784µs
        		             satisfy:     63.792µs
        		            new-atom:     63.545µs
        		               other:     10.724µs
        		  b-deduce-proj-root:     10.516µs
        		     b-source-exists:      2.346µs
        		
        		  TOTAL: 1.341931161s
        		
        		Solving failure: No versions of github.com/sdboyer/deptesttres met constraints:
        			master: unable to update checked out version: fatal: reference is not a tree: 54aaeb0023e1f3dcf5f98f31dd8c565457945a12
        		: command failed: [git checkout 54aaeb0023e1f3dcf5f98f31dd8c565457945a12]: exit status 128
        			master: unable to update checked out version: fatal: reference is not a tree: 54aaeb0023e1f3dcf5f98f31dd8c565457945a12
        		: command failed: [git checkout 54aaeb0023e1f3dcf5f98f31dd8c565457945a12]: exit status 128
FAIL
FAIL	github.com/golang/dep/cmd/dep	5.453s
warning: execution failed: go test github.com/golang/dep/cmd/dep -run TestIntegration/ensure/add/desync
You can fix the problem, and then run

  git rebase --continue
```

### What should your reviewer look out for in this PR?

### Do you need help or clarification on anything?

### Which issue(s) does this PR fix?
