### PR TITLE
CollectConstraints from root project as well

### DIFF
--- a/cmd/dep/status.go
+++ b/cmd/dep/status.go
@@ -984,9 +984,9 @@ type projectConstraint struct {
 // on a dependency and the projects that apply those constraints.
 type constraintsCollection map[string][]projectConstraint
 
-// collectConstraints collects constraints declared by all the dependencies.
-// It returns constraintsCollection and a slice of errors encountered while
-// collecting the constraints, if any.
+// collectConstraints collects constraints declared by all the dependencies and
+// all effective constraints from the root project. It returns constraintsCollection and
+// a slice of errors encountered while collecting the constraints, if any.
 func collectConstraints(ctx *dep.Ctx, p *dep.Project, sm gps.SourceManager) (constraintsCollection, []error) {
 	logger := ctx.Err
 	if !ctx.Verbose {
@@ -1065,6 +1065,33 @@ func collectConstraints(ctx *dep.Ctx, p *dep.Project, sm gps.SourceManager) (con
 		for e := range errCh {
 			errs = append(errs, e)
 			logger.Println(e.Error())
+		}
+	}
+
+	// Incorporate constraints set in the manifest of the root project.
+	if p.Manifest != nil {
+
+		ineffCon := p.FindIneffectualConstraints(sm)
+
+		// Iterate through regular project constraints, append if it is not
+		// an ineffectual constraint
+		for pr, pp := range p.Manifest.Constraints {
+			i := sort.Search(len(ineffCon), func(i int) bool {
+				return pr == ineffCon[i]
+			})
+			if i < len(ineffCon) && ineffCon[i] == pr {
+				continue
+			}
+
+			tempCC := append(
+				constraintCollection[string(pr)],
+				projectConstraint{pr, pp.Constraint},
+			)
+
+			// Sort the inner projectConstraint slice by Project string.
+			// Required for consistent returned value.
+			sort.Sort(byProject(tempCC))
+			constraintCollection[string(pr)] = tempCC
 		}
 	}
 

--- a/cmd/dep/status_test.go
+++ b/cmd/dep/status_test.go
@@ -351,6 +351,7 @@ func TestCollectConstraints(t *testing.T) {
 	cases := []struct {
 		name            string
 		lock            dep.Lock
+		manifest        dep.Manifest
 		wantConstraints constraintsCollection
 		wantErr         bool
 	}{
@@ -368,7 +369,7 @@ func TestCollectConstraints(t *testing.T) {
 			wantConstraints: constraintsCollection{},
 		},
 		{
-			name: "with multiple constraints",
+			name: "with multiple constraints from dependencies",
 			lock: dep.Lock{
 				P: []gps.LockedProject{
 					gps.NewLockedProject(
@@ -398,6 +399,54 @@ func TestCollectConstraints(t *testing.T) {
 				"github.com/sdboyer/deptest": []projectConstraint{
 					{"github.com/darkowlzz/deptest-project-1", ver1},
 					{"github.com/darkowlzz/deptest-project-2", ver08},
+				},
+			},
+		},
+		{
+			name: "with multiple constraints from dependencies and root project",
+			lock: dep.Lock{
+				P: []gps.LockedProject{
+					gps.NewLockedProject(
+						gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot("github.com/sdboyer/deptest")},
+						gps.NewVersion("v1.0.0"),
+						[]string{"."},
+					),
+					gps.NewLockedProject(
+						gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot("github.com/darkowlzz/deptest-project-1")},
+						gps.NewVersion("v0.1.0"),
+						[]string{"."},
+					),
+					gps.NewLockedProject(
+						gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot("github.com/darkowlzz/deptest-project-2")},
+						gps.NewBranch("master").Pair(gps.Revision("824a8d56a4c6b2f4718824a98cd6d70d3dbd4c3e")),
+						[]string{"."},
+					),
+				},
+			},
+			manifest: dep.Manifest{
+				Constraints: map[gps.ProjectRoot]gps.ProjectProperties{
+					gps.ProjectRoot("github.com/sdboyer/deptest"): {
+						Constraint: gps.Revision("3f4c3bea144e112a69bbe5d8d01c1b09a544253f"),
+					},
+				},
+				Ovr: make(gps.ProjectConstraints),
+				PruneOptions: gps.CascadingPruneOptions{
+					DefaultOptions:    gps.PruneNestedVendorDirs,
+					PerProjectOptions: make(map[gps.ProjectRoot]gps.PruneOptionSet),
+				},
+			},
+			wantConstraints: constraintsCollection{
+				"github.com/sdboyer/deptestdos": []projectConstraint{
+					{"github.com/darkowlzz/deptest-project-2", ver2},
+				},
+				"github.com/sdboyer/dep-test": []projectConstraint{
+					{"github.com/darkowlzz/deptest-project-2", ver1},
+				},
+				"github.com/sdboyer/deptest": []projectConstraint{
+					{"github.com/darkowlzz/deptest-project-1", ver1},
+					{"github.com/darkowlzz/deptest-project-2", ver08},
+					{"github.com/sdboyer/deptest",
+						gps.Revision("3f4c3bea144e112a69bbe5d8d01c1b09a544253f")},
 				},
 			},
 		},
@@ -444,6 +493,31 @@ func TestCollectConstraints(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "skip ineffective constraint from manifest",
+			lock: dep.Lock{
+				P: []gps.LockedProject{
+					gps.NewLockedProject(
+						gps.ProjectIdentifier{ProjectRoot: gps.ProjectRoot("github.com/sdboyer/deptest")},
+						gps.NewVersion("v1.0.0"),
+						[]string{"."},
+					),
+				},
+			},
+			manifest: dep.Manifest{
+				Constraints: map[gps.ProjectRoot]gps.ProjectProperties{
+					gps.ProjectRoot("github.com/darkowlzz/deptest-project-1"): {
+						Constraint: ver1,
+					},
+				},
+				Ovr: make(gps.ProjectConstraints),
+				PruneOptions: gps.CascadingPruneOptions{
+					DefaultOptions:    gps.PruneNestedVendorDirs,
+					PerProjectOptions: make(map[gps.ProjectRoot]gps.PruneOptionSet),
+				},
+			},
+			wantConstraints: constraintsCollection{},
+		},
 	}
 
 	h := test.NewHelper(t)
@@ -474,6 +548,7 @@ func TestCollectConstraints(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			p.Lock = &c.lock
+			p.Manifest = &c.manifest
 			gotConstraints, err := collectConstraints(ctx, p, sm)
 			if len(err) > 0 && !c.wantErr {
 				t.Fatalf("unexpected errors while collecting constraints: %v", err)

--- a/cmd/dep/status_test.go
+++ b/cmd/dep/status_test.go
@@ -445,8 +445,7 @@ func TestCollectConstraints(t *testing.T) {
 				"github.com/sdboyer/deptest": []projectConstraint{
 					{"github.com/darkowlzz/deptest-project-1", ver1},
 					{"github.com/darkowlzz/deptest-project-2", ver08},
-					{"github.com/sdboyer/deptest",
-						gps.Revision("3f4c3bea144e112a69bbe5d8d01c1b09a544253f")},
+					{"root", gps.Revision("3f4c3bea144e112a69bbe5d8d01c1b09a544253f")},
 				},
 			},
 		},


### PR DESCRIPTION
The collectConstraints() function in status.go incorporates effective
constraints from the root projects manifest. Issue #1452.

### What does this do / why do we need it?
This patch includes the collection of constraints as defined in the root projects manifest as described in issue 1452. It ensures that the to-be-included constraint is effective which means that it refers to a direct dependency of the project.

### What should your reviewer look out for in this PR?
At a first glance, it might seem desirable to collect the root projects constraints also in the for loop over the constraints from its direct dependencies. However, since the to-be-iterated data types and the way how the manifest is resolved are different, imho it's cleaner to collect the constraints from the root project separately.

### Do you need help or clarification on anything?
collectConstraints() does currently _not_ resolve the overwrite constraints from the root project's manifest ( if there are any ). A short clarification if this guarantee is desired or if it should be incorporated in a follow-up patch would be nice.

### Which issue(s) does this PR fix?

fixes #1452 

