### PR TITLE
gps: unset some GIT_* variables for git operations

### DIFF
--- a/gps/cmd.go
+++ b/gps/cmd.go
@@ -4,6 +4,10 @@
 
 package gps
 
+import (
+	"os"
+)
+
 func (c cmd) Args() []string {
 	return c.Cmd.Args
 }
@@ -14,4 +18,16 @@ func (c cmd) SetDir(dir string) {
 
 func (c cmd) SetEnv(env []string) {
 	c.Cmd.Env = env
+}
+
+func init() {
+	// For our git repositories, we very much assume a "regular" topology.
+	// Therefore, no value for the following variables can be relevant to
+	// us. Unsetting globally properly propagates to libraries like
+	// github.com/Masterminds/vcs, which cannot make the same assumption in
+	// general.
+	parasiteGitVars := []string{"GIT_DIR", "GIT_INDEX_FILE", "GIT_OBJECT_DIRECTORY", "GIT_WORK_TREE"}
+	for _, e := range parasiteGitVars {
+		os.Unsetenv(e)
+	}
 }


### PR DESCRIPTION
### What does this do / why do we need it?

This fixes 2 classes of bugs:
- running unit tests as part of a git rebase invocation
- running dep from a repository that has a separate GIT_DIR/GIT_WORK_TREE

### What should your reviewer look out for in this PR?

the location of the code might not be ideal.

### Do you need help or clarification on anything?

### Which issue(s) does this PR fix?

fixes #1871 
