### PR TITLE
[WIP] Remove filter for prefixed underscore in directory name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ NEW FEATURES:
 
 BUG FIXES:
 
+* Allow underscores to prefix directory names ([#1688](https://github.com/golang/dep/issues/1688))
+
 IMPROVEMENTS:
 
 * Add template operations support in dep status template output.

--- a/gps/pkgtree/reachmap.go
+++ b/gps/pkgtree/reachmap.go
@@ -18,14 +18,14 @@ type ReachMap map[string]struct {
 	Internal, External []string
 }
 
-// Eliminate import paths with any elements having leading dots, leading
-// underscores, or testdata. If these are internally reachable (which is
-// a no-no, but possible), any external imports will have already been
+// Eliminate import paths with any elements having leading dots or
+// testdata. If these are internally reachable (which is a no-no, but
+// possible), any external imports will have already been
 // pulled up through ExternalReach. The key here is that we don't want
 // to treat such packages as themselves being sources.
 func pkgFilter(pkg string) bool {
 	for _, elem := range strings.Split(pkg, "/") {
-		if strings.HasPrefix(elem, ".") || strings.HasPrefix(elem, "_") || elem == "testdata" {
+		if strings.HasPrefix(elem, ".") || elem == "testdata" {
 			return false
 		}
 	}


### PR DESCRIPTION
### What does this do / why do we need it?
This removes the package filter for pakages with directories prefixed by `_`. This is necessary because currently some git repo providers (VSTS) have a directory path containing the directory `_git` or `_ssh`.

### What should your reviewer look out for in this PR?
I'm not sure if there was another reason for that filter, so if someone could point out to me why it existed in the first place that would be great!

### Do you need help or clarification on anything?
As above, the reason for the original filter on directories prefixed by `_`.

### Which issue(s) does this PR fix?
#1688 
