### PR TITLE
Limit number of concurrent goroutines in dep status

### DIFF
--- a/cmd/dep/utils/fd_limit_default.go
+++ b/cmd/dep/utils/fd_limit_default.go
@@ -1,0 +1,17 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !darwin,!freebsd,!linux,!netbsd,!openbsd
+
+package utils
+
+import (
+	"fmt"
+)
+
+// FileDescriptorLimit returns the current file descriptor limit set in the OS
+// TODO: add implementations for all OS, especially Windows
+func FileDescriptorLimit() (uint64, error) {
+	return 0, fmt.Errorf("Unable to get FD limit on this operating system")
+}

--- a/cmd/dep/utils/fd_limit_nix.go
+++ b/cmd/dep/utils/fd_limit_nix.go
@@ -1,0 +1,22 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build darwin freebsd linux netbsd openbsd
+
+package utils
+
+import (
+	"fmt"
+	"syscall"
+)
+
+// FileDescriptorLimit returns the current file descriptor limit set in the OS
+func FileDescriptorLimit() (uint64, error) {
+	var rLimit syscall.Rlimit
+	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+	if err != nil {
+		return 0, fmt.Errorf("unable to get RLIMIT")
+	}
+	return rLimit.Cur, nil
+}


### PR DESCRIPTION
Avoid exceeding the file descriptor limit by limiting the
number of concurrent goroutines in dep status. See
getConcurrentProjectLimit comment for details. Issue #1727.

### What does this do / why do we need it?

Issue #1727 describes the problem that dep status can exceed the FD limit. 

### What should your reviewer look out for in this PR?

### Do you need help or clarification on anything?

Lmk if you like the approach in general ( or if you prefer something else ). I have _not_ done extensive testing with large projects and varying rlimits. This should be done if the solution is generally accepted and before it gets merged.

### Which issue(s) does this PR fix?

fixes #1727 
fixes #1923