### PR TITLE
Adding more emphasis to the need of create a go file before running ensure

### DIFF
--- a/docs/new-project.md
+++ b/docs/new-project.md
@@ -28,7 +28,7 @@ In a new project like this one, both files and the `vendor` directory will be ef
 
 This would also be a good time to set up a version control, such as [git](https://git-scm.com/). While dep in no way requires version control for your project, it can make inspecting the changes made by normal dep operations easier. Plus, it's basically best practice #1 of modern software development!
 
-At this point, our project is initialized, and we're ready to start writing code. You can open up a `.go` file in an editor and start hacking away. Or, after creating your first `.go` file, you can go ahead and pre-populate your `vendor` directory with some projects that you already know that you'll need:
+At this point, our project is initialized, and we're ready to start writing code. You can open up a `.go` file in an editor and start hacking away. Or, **after creating your first `.go` file**, you can go ahead and pre-populate your `vendor` directory with some projects that you already know that you'll need:
 
 ```bash
 $ dep ensure -add github.com/foo/bar github.com/baz/quux


### PR DESCRIPTION


<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

### What does this do / why do we need it?
Hello, first-time contributor here!

I was following along dep's tutorial right now and got stuck while trying to add new packages right before running `dep init`. It turns out I was missing creating a valid `.go` file beforehand.

After reading through some issues I found some references about the need to create a file before adding the first dependencies. When I went back to the documentation with more attention, I found the part I skipped. 

I guess most users pay more attention to the highlighted code parts than to the overall text. I know it was my mistake but one that I think might happen to more users and can easily be prevented by changing the docs a little bit. I considered changing the paragraph structure but I think that a simple emphasis in bold text is enough

### What should your reviewer look out for in this PR?

### Do you need help or clarification on anything?

### Which issue(s) does this PR fix?

<!--

fixes #
fixes #

-->
