### PR TITLE
Don't exclude Godeps folder. Fixes #1822

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ IMPROVEMENTS:
 * Add template operations support in dep status template output ([#1549](https://github.com/golang/dep/pull/1549)).
 * Reduce network access by trusting local source information and only pulling from upstream when necessary ([#1250](https://github.com/golang/dep/pull/1250)).
 * Update our dependency on Masterminds/semver to follow upstream again now that [Masterminds/semver#67](https://github.com/Masterminds/semver/pull/67) is merged([#1792](https://github.com/golang/dep/pull/1792)).
+* Don't exclude `Godeps` folder ([#1822](https://github.com/golang/dep/issues/1822)).
 
 WIP:
 * Enable importing external configuration from dependencies during init (#1277). This is feature flagged and disabled by default.

--- a/gps/pkgtree/pkgtree.go
+++ b/gps/pkgtree/pkgtree.go
@@ -89,7 +89,7 @@ func ListPackages(fileRoot, importRoot string) (PackageTree, error) {
 		// We don't skip _*, or testdata dirs because, while it may be poor
 		// form, importing them is not a compilation error.
 		switch fi.Name() {
-		case "vendor", "Godeps":
+		case "vendor":
 			return filepath.SkipDir
 		}
 


### PR DESCRIPTION
Fixes #1822. Talked with @sdboyer and I think its safe to remove this. Tested this on a project with an old `Godeps` folder and it solved perfectly.
