### PR TITLE
Removes "echo" statement introduced with commit 918c75

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -66,7 +66,7 @@ downloadFile() {
 
 findGoBinDirectory() {
     EFFECTIVE_GOPATH=$(go env GOPATH)
-    # CYGWIN: Convert Windows-style path into sh-compatible style paths
+    # CYGWIN: Convert Windows-style path into sh-compatible path
     if [ "$OS_CYGWIN" = "1" ]; then
 	EFFECTIVE_GOPATH=$(cygpath "$EFFECTIVE_GOPATH")
     fi
@@ -75,7 +75,6 @@ findGoBinDirectory() {
         exit 1
     fi
     if [ -z "$GOBIN" ]; then
-	echo "${EFFECTIVE_GOPATH%%:*}/bin" | sed s#//*#/#g
         GOBIN=$(echo "${EFFECTIVE_GOPATH%%:*}/bin" | sed s#//*#/#g)
     fi
     if [ ! -d "$GOBIN" ]; then


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

### What does this do / why do we need it?
This PR removes an echo statement I accidentally introduced with commit 918c75

### What should your reviewer look out for in this PR?
For paper trail, this is the output on my machine when running the install.sh under cygwin
```
[DESKTOP-ARH5TT0: dep]$ sh install.sh
ARCH = amd64
OS = windows
Will install into /cygdrive/c/Users/johnl/go/bin
Fetching https://github.com/golang/dep/releases/latest..
Release Tag = v0.4.1
Fetching https://github.com/golang/dep/releases/tag/v0.4.1..
Fetching https://github.com/golang/dep/releases/download/v0.4.1/dep-windows-amd64.exe..
Setting executable permissions.
Moving executable to /cygdrive/c/Users/johnl/go/bin/dep.exe
```

### Do you need help or clarification on anything?
No

### Which issue(s) does this PR fix?
None. But it removes a silly mistake in the fix to #1740 

<!--

fixes #
fixes #

-->
