### PR TITLE
Improve handling of paths containing repeated separators (fix #1946).

### DIFF
--- a/context.go
+++ b/context.go
@@ -302,7 +302,7 @@ func (c *Ctx) detectGOPATH(path string) (string, error) {
 			return "", errors.Wrap(err, "failed to detect GOPATH")
 		}
 		if isPrefix {
-			return gp, nil
+			return filepath.Clean(gp), nil
 		}
 	}
 	return "", errors.Errorf("%s is not within a known GOPATH/src", path)

--- a/context_test.go
+++ b/context_test.go
@@ -524,10 +524,14 @@ func TestDetectGOPATH(t *testing.T) {
 	th.TempDir(filepath.Join("code", "src", "github.com", "username", "package"))
 	th.TempDir(filepath.Join("go", "src", "github.com", "username", "package"))
 	th.TempDir(filepath.Join("gotwo", "src", "github.com", "username", "package"))
+	th.TempDir(filepath.Join("gothree", "sep", "src", "github.com", "username", "package"))
+
+	sep := string(os.PathSeparator)
 
 	ctx := &Ctx{GOPATHs: []string{
 		th.Path("go"),
 		th.Path("gotwo"),
+		th.Path("gothree") + sep + sep + "sep",
 	}}
 
 	testcases := []struct {
@@ -538,6 +542,8 @@ func TestDetectGOPATH(t *testing.T) {
 		{th.Path("go"), th.Path(filepath.Join("go", "src", "github.com", "username", "package")), false},
 		{th.Path("go"), th.Path(filepath.Join("go", "src", "github.com", "username", "package")), false},
 		{th.Path("gotwo"), th.Path(filepath.Join("gotwo", "src", "github.com", "username", "package")), false},
+		{th.Path(filepath.Join("gothree", "sep")),
+			th.Path(filepath.Join("gothree", "sep", "src", "github.com", "username", "package")), false},
 		{"", th.Path(filepath.Join("code", "src", "github.com", "username", "package")), true},
 	}
 

--- a/context_test.go
+++ b/context_test.go
@@ -547,7 +547,7 @@ func TestDetectGOPATH(t *testing.T) {
 			t.Error("expected error but got none")
 		}
 		if GOPATH != tc.GOPATH {
-			t.Errorf("expected GOPATH to be %s, got %s", GOPATH, tc.GOPATH)
+			t.Errorf("expected GOPATH to be %s, got %s", tc.GOPATH, GOPATH)
 		}
 	}
 }

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -61,8 +61,8 @@ func HasFilepathPrefix(path, prefix string) (bool, error) {
 		dn = filepath.Dir(path)
 	}
 
-	dn = strings.TrimSuffix(dn, string(os.PathSeparator))
-	prefix = strings.TrimSuffix(prefix, string(os.PathSeparator))
+	dn = filepath.Clean(dn)
+	prefix = filepath.Clean(prefix)
 
 	// [1:] in the lines below eliminates empty string on *nix and volume name on Windows
 	dirs := strings.Split(dn, string(os.PathSeparator))[1:]

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -47,12 +47,19 @@ func TestHasFilepathPrefix(t *testing.T) {
 		dir2 = dir
 	}
 
+	// For testing trailing and repeated separators
+	sep := string(os.PathSeparator)
+
 	cases := []struct {
 		path   string
 		prefix string
 		want   bool
 	}{
 		{filepath.Join(dir, "a", "b"), filepath.Join(dir2), true},
+		{filepath.Join(dir, "a", "b"), dir2 + sep + sep + "a", true},
+		{filepath.Join(dir, "a", "b"), filepath.Join(dir2, "a") + sep, true},
+		{filepath.Join(dir, "a", "b") + sep, filepath.Join(dir2), true},
+		{dir + sep + sep + filepath.Join("a", "b"), filepath.Join(dir2, "a"), true},
 		{filepath.Join(dir, "a", "b"), filepath.Join(dir2, "a"), true},
 		{filepath.Join(dir, "a", "b"), filepath.Join(dir2, "a", "b"), true},
 		{filepath.Join(dir, "a", "b"), filepath.Join(dir2, "c"), false},


### PR DESCRIPTION
### What does this do / why do we need it?

Issue: https://github.com/golang/dep/issues/1946

Host system GOPATH may contain repeated separators or other artifacts which can cause an error
when not needed. E.g:

GOPATH:
```
/home/user//.gopath
/home/user/./.gopath
/home/user/code/../.gopath
```

Error:
```
/home/user/.gopath/src/github.com/project/repo is not within a known GOPATH/src
```

The function `filepath.Clean()` is used in order to simplify filepaths and remove the artifacts.

### What should your reviewer look out for in this PR?

In order to fix the issue only the changes to `internal/fs/fs.go` are required. However `context.go` is also
updated to further clean the GOPATH as it gets returned from `TestDetectGOPATH`.

Test cases were added in `context_test.go` and `internal/fs/fs_test.go`, which currently only cover repeated
slashes, since this was what the bugfix is targeting.

There is also one small fix to the test case `TestDetectGOPATH` where the two string values were reversed in the error statement.

### Do you need help or clarification on anything?

I'm not sure if the test case changes should live in separate commits to the actual code fix.

### Which issue(s) does this PR fix?

fixes #[1649](https://github.com/golang/dep/issues/1946)

