### PR TITLE
add documentation explaining how to uninstall

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -56,3 +56,7 @@ go get -u github.com/golang/dep/cmd/dep
 ```
 
 Note that dep requires a functioning Go workspace and GOPATH. If you're unfamiliar with Go workspaces and GOPATH, have a look at [the language documentation](https://golang.org/doc/code.html#Organization) and get your local workspace set up. Dep's model could lead to being able to work without GOPATH, but we're not there yet.
+
+## Uninstalling
+
+Looking for a way to uninstall `dep`? There's a separate [doc page](uninstalling.md) for that!

--- a/docs/uninstalling.md
+++ b/docs/uninstalling.md
@@ -1,0 +1,35 @@
+---
+title: Uninstalling Dep
+---
+
+## Uninstalling
+
+To uninstall `dep` itself, follow these instructions, depending on how you installed `dep` originally.
+
+### If you installed `dep` by executing the `install.sh` script via curl
+
+If you installed `dep` by `curl`'ing the `install.sh` script, it is safe to simply delete the installed binary file.
+
+On Linux and MacOS, the `install.sh` script installs a pre-compiled binary to `$GOPATH/bin/dep`. It is safe to simply `rm` the installed `$GOPATH/bin/dep` file:
+
+```sh
+$ rm $GOPATH/bin/dep
+```
+
+On Windows, the `install.sh` script installs a pre-compiled binary to `$GOPATH/bin/dep.exe`. It is safe to simply delete this file to uninstall `dep`.
+
+### If you installed `dep` using Homebrew on MacOS
+
+If you installed `dep` using Homebrew on MacOS, uninstall `dep` also using Homebrew:
+
+```sh
+$ brew uninstall dep
+```
+
+### If you installed `dep` using `pacman` on Arch Linux
+
+If you installed `dep` using `pacman` on Arch Linux, uninstall `dep` like so:
+
+```sh
+$ pacman -R dep
+```

--- a/docs/uninstalling.md
+++ b/docs/uninstalling.md
@@ -8,7 +8,7 @@ To uninstall `dep` itself, follow these instructions, depending on how you insta
 
 ### If you installed `dep` by executing the `install.sh` script via curl
 
-If you installed `dep` by `curl`'ing the `install.sh` script, it is safe to simply delete the installed binary file.
+If you installed `dep` using the `install.sh` script, it is safe to simply delete the installed binary file.
 
 On Linux and MacOS, the `install.sh` script installs a pre-compiled binary to `$GOPATH/bin/dep`. It is safe to simply `rm` the installed `$GOPATH/bin/dep` file:
 

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,6 +1,6 @@
 {
   "docs": {
-    "Guides": ["introduction", "installation", "new-project", "migrating", "daily-dep"],
+    "Guides": ["introduction", "installation", "new-project", "migrating", "daily-dep", "uninstalling"],
     "References": ["ensure-mechanics", "failure-modes", "the-solver", "deduction", "Gopkg.toml", "Gopkg.lock", "FAQ", "env-vars", "glossary"]
   }
 }


### PR DESCRIPTION
There's good docs on how to install dep, but we're missing docs on how
to uninstall dep. This adds them. I thought about adding some text to
the top-level README.md file but figured uninstalling dep wasn't a vital
topic for top-level docs and that a separate doc in the docs/ tree was
more than enough.

Issue #1953