### PR TITLE
[WIP] minimal module awareness

### DIFF
--- a/gps/pkgtree/gomod.go
+++ b/gps/pkgtree/gomod.go
@@ -1,0 +1,63 @@
+package pkgtree
+
+import (
+	"bytes"
+	"io/ioutil"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// goModPath was taken verbatim from: go1.10.3/src/cmd/go/internal/load/pkg.go
+
+var (
+	modulePrefix   = []byte("\nmodule ")
+	goModPathCache = make(map[string]string)
+)
+
+// goModPath returns the module path in the go.mod in dir, if any.
+func goModPath(dir string) (path string) {
+	path, ok := goModPathCache[dir]
+	if ok {
+		return path
+	}
+	defer func() {
+		goModPathCache[dir] = path
+	}()
+
+	data, err := ioutil.ReadFile(filepath.Join(dir, "go.mod"))
+	if err != nil {
+		return ""
+	}
+	var i int
+	if bytes.HasPrefix(data, modulePrefix[1:]) {
+		i = 0
+	} else {
+		i = bytes.Index(data, modulePrefix)
+		if i < 0 {
+			return ""
+		}
+		i++
+	}
+	line := data[i:]
+
+	// Cut line at \n, drop trailing \r if present.
+	if j := bytes.IndexByte(line, '\n'); j >= 0 {
+		line = line[:j]
+	}
+	if line[len(line)-1] == '\r' {
+		line = line[:len(line)-1]
+	}
+	line = line[len("module "):]
+
+	// If quoted, unquote.
+	path = strings.TrimSpace(string(line))
+	if path != "" && path[0] == '"' {
+		s, err := strconv.Unquote(path)
+		if err != nil {
+			return ""
+		}
+		path = s
+	}
+	return path
+}

--- a/gps/pkgtree/gomod.go
+++ b/gps/pkgtree/gomod.go
@@ -1,3 +1,7 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package pkgtree
 
 import (

--- a/gps/pkgtree/pkgtree_test.go
+++ b/gps/pkgtree/pkgtree_test.go
@@ -2247,6 +2247,8 @@ func TestCanaryPackageTreeCopy(t *testing.T) {
 	packageFields := []string{
 		"Name",
 		"ImportPath",
+		"RelModPath",
+		"Module",
 		"CommentPath",
 		"Imports",
 		"TestImports",

--- a/gps/source_manager.go
+++ b/gps/source_manager.go
@@ -556,7 +556,7 @@ func (sm *SourceMgr) ExportProject(ctx context.Context, id ProjectIdentifier, v 
 		return err
 	}
 
-	return srcg.exportVersionTo(ctx, v, to)
+	return srcg.exportVersionTo(ctx, v, to, id.ProjectRoot)
 }
 
 // ExportPrunedProject writes out a tree of the provided LockedProject, applying

--- a/gps/source_test.go
+++ b/gps/source_test.go
@@ -151,7 +151,7 @@ func testSourceGateway(t *testing.T) {
 				t.Fatalf("wanted nonexistent err when passing bad version, got: %s", err)
 			}
 
-			err = sg.exportVersionTo(ctx, badver, cachedir)
+			err = sg.exportVersionTo(ctx, badver, cachedir, ProjectRoot("github.com/sdboyer/deptest"))
 			if err == nil {
 				t.Fatal("wanted err on nonexistent version")
 			} else if err.Error() != wanterr.Error() {


### PR DESCRIPTION
- [x] Update pkgtree.ListPackages to set the correct import path based on the `go.mod` file
- [x] Ensure that the `vendor/` directory is populated correctly (import `x/y/v2/foo` should not be stored as `vendor/x/y/foo`)
- [ ] Add tests
- [ ] Update `CHANGELOG.md`

### What does this do / why do we need it?

Adds minimal module awareness, as [Go 1.10.3 did](https://go.googlesource.com/go/+/d4e21288e444d3ffd30d1a0737f15ea3fc3b8ad9).

### Which issue(s) does this PR fix?

Fixes #1962