### PR TITLE
Run latest gofmt on project

### DIFF
--- a/cmd/dep/status_test.go
+++ b/cmd/dep/status_test.go
@@ -7,6 +7,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
 	"path/filepath"
@@ -15,8 +16,6 @@ import (
 	"testing"
 	"text/tabwriter"
 	"text/template"
-
-	"io"
 
 	"github.com/golang/dep"
 	"github.com/golang/dep/gps"
@@ -28,7 +27,7 @@ func TestStatusFormatVersion(t *testing.T) {
 	t.Parallel()
 
 	tests := map[gps.Version]string{
-		nil: "",
+		nil:                            "",
 		gps.NewBranch("master"):        "branch master",
 		gps.NewVersion("1.0.0"):        "1.0.0",
 		gps.Revision("flooboofoobooo"): "flooboo",

--- a/gps/verify/lockdiff.go
+++ b/gps/verify/lockdiff.go
@@ -106,7 +106,7 @@ func DiffLocks(l1, l2 gps.Lock) LockDelta {
 			switch strings.Compare(string(pr1), string(pr2)) {
 			case 0: // Found a matching project
 				lpd = LockedProjectDelta{
-					Name: pr1,
+					Name:                         pr1,
 					LockedProjectPropertiesDelta: DiffLockedProjectProperties(lp1, lp2),
 				}
 				i2next = i2 + 1 // Don't visit this project again

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -917,8 +917,8 @@ func TestIsRegular(t *testing.T) {
 		exists bool
 		err    bool
 	}{
-		wd: {false, true},
-		filepath.Join(wd, "testdata"):                       {false, true},
+		wd:                            {false, true},
+		filepath.Join(wd, "testdata"): {false, true},
 		filepath.Join(wd, "testdata", "test.file"):          {true, false},
 		filepath.Join(wd, "this_file_does_not_exist.thing"): {false, false},
 		fn: {false, true},
@@ -972,9 +972,9 @@ func TestIsDir(t *testing.T) {
 		exists bool
 		err    bool
 	}{
-		wd: {true, false},
-		filepath.Join(wd, "testdata"):                       {true, false},
-		filepath.Join(wd, "main.go"):                        {false, true},
+		wd:                            {true, false},
+		filepath.Join(wd, "testdata"): {true, false},
+		filepath.Join(wd, "main.go"):  {false, true},
 		filepath.Join(wd, "this_file_does_not_exist.thing"): {false, true},
 		dn: {false, true},
 	}


### PR DESCRIPTION
Gofmt in Go 1.11 beta 2 handles struct alignment differently, as
demonstrated in this diff. Running "make test" makes these same
whitespace changes to the files in question.

 ### What does this do / why do we need it?

Without this change, running "make test" on tip will consistently generate Git
diffs.