### PR TITLE
gps: return error if 'git fsck' checks are enabled and repo is corrupt

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -128,6 +128,7 @@
     "github.com/pkg/errors",
     "github.com/sdboyer/constext",
     "golang.org/x/sync/errgroup",
+    "golang.org/x/sys/unix",
     "gopkg.in/yaml.v2",
   ]
   solver-name = "gps-cdcl"

--- a/gps/cmd_unix.go
+++ b/gps/cmd_unix.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
 )
 
 type cmd struct {
@@ -66,10 +67,10 @@ func (c cmd) CombinedOutput() ([]byte, error) {
 			if err := c.Cmd.Process.Signal(os.Interrupt); err != nil {
 				// If an error comes back from attempting to signal, proceed
 				// immediately to hard kill.
-				_ = c.Cmd.Process.Kill()
+				_ = unix.Kill(-c.Cmd.Process.Pid, syscall.SIGKILL)
 			} else {
 				defer time.AfterFunc(time.Minute, func() {
-					_ = c.Cmd.Process.Kill()
+					_ = unix.Kill(-c.Cmd.Process.Pid, syscall.SIGKILL)
 				}).Stop()
 				<-waitDone
 			}


### PR DESCRIPTION
Previously, if dep tried to clone a repository over ssh that contained
zero padded file modes, dep would fail to clone and then hang. You can
reproduce this failure with the following .gitconfig:

    [url "git@github.com:"]
        insteadOf = https://github.com/

    [transfer]
        fsckobjects = true

    [fetch]
        fsckobjects = true

    [receive]
        fsckobjects = true

and the following Gopkg.toml. (It is not my intention to single out
this project - I searched Github for Go projects with zero padded file
mode errors, and found this one.)

    [[constraint]]
      name = "github.com/remogatto/gospeccy"
      branch = "master"

`dep ensure` hangs because the git clone operation spins up an `ssh`
process as a child process. `cmd.Process.Kill` kills the parent `git`
operation, but not the child `ssh` operation, so it's orphaned and we
don't return properly from the function. (It's unclear to me at this
point why the ssh operation did not return when it completed.)

By sending the negative Pgrp value to the Kill() function we can kill
the entire child process group, not just the "parent child." See
https://medium.com/@felixge/killing-a-child-process-and-all-of-its-children-in-go-54079af94773
for more information.

Updates #1257.