### PR TITLE
feat(deducer): Add staticDeducer to avoid doing HTTP request if the...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ BUG FIXES:
 
 * Correctly handle certain cases where `dep ensure` removed projects from Gopkg.lock. ([#1945](https://github.com/golang/dep/issue/1945)).
 
+IMPROVEMENTS:
+
+* Avoid doing HTTP requests (go get metadata) if the `source` is known from `Gopkg.toml` file
+
 # v0.5.0
 
 NEW FEATURES:

--- a/cmd/dep/check.go
+++ b/cmd/dep/check.go
@@ -69,7 +69,7 @@ func (cmd *checkCommand) Run(ctx *dep.Ctx, args []string) error {
 		return err
 	}
 
-	sm, err := ctx.SourceManager()
+	sm, err := ctx.SourceManager(p)
 	if err != nil {
 		return err
 	}

--- a/cmd/dep/ensure.go
+++ b/cmd/dep/ensure.go
@@ -164,7 +164,7 @@ func (cmd *ensureCommand) Run(ctx *dep.Ctx, args []string) error {
 		return err
 	}
 
-	sm, err := ctx.SourceManager()
+	sm, err := ctx.SourceManager(p)
 	if err != nil {
 		return err
 	}

--- a/cmd/dep/ensure_test.go
+++ b/cmd/dep/ensure_test.go
@@ -218,12 +218,12 @@ func TestValidateUpdateArgs(t *testing.T) {
 		Err:    errLogger,
 	}
 
-	sm, err := ctx.SourceManager()
-	h.Must(err)
-	defer sm.Release()
-
 	p := new(dep.Project)
 	params := p.MakeParams()
+
+	sm, err := ctx.SourceManager(p)
+	h.Must(err)
+	defer sm.Release()
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/cmd/dep/init.go
+++ b/cmd/dep/init.go
@@ -91,7 +91,7 @@ func (cmd *initCommand) Run(ctx *dep.Ctx, args []string) error {
 		return err
 	}
 
-	sm, err := ctx.SourceManager()
+	sm, err := ctx.SourceManager(p)
 	if err != nil {
 		return errors.Wrap(err, "init failed: unable to create a source manager")
 	}

--- a/cmd/dep/prune.go
+++ b/cmd/dep/prune.go
@@ -52,7 +52,7 @@ func (cmd *pruneCommand) Run(ctx *dep.Ctx, args []string) error {
 		return err
 	}
 
-	sm, err := ctx.SourceManager()
+	sm, err := ctx.SourceManager(p)
 	if err != nil {
 		return err
 	}

--- a/cmd/dep/status.go
+++ b/cmd/dep/status.go
@@ -445,7 +445,7 @@ func (cmd *statusCommand) Run(ctx *dep.Ctx, args []string) error {
 		return err
 	}
 
-	sm, err := ctx.SourceManager()
+	sm, err := ctx.SourceManager(p)
 	if err != nil {
 		return err
 	}

--- a/cmd/dep/status_test.go
+++ b/cmd/dep/status_test.go
@@ -28,7 +28,7 @@ func TestStatusFormatVersion(t *testing.T) {
 	t.Parallel()
 
 	tests := map[gps.Version]string{
-		nil: "",
+		nil:                            "",
 		gps.NewBranch("master"):        "branch master",
 		gps.NewVersion("1.0.0"):        "1.0.0",
 		gps.Revision("flooboofoobooo"): "flooboo",
@@ -762,14 +762,14 @@ func TestCollectConstraints(t *testing.T) {
 		Err:    discardLogger,
 	}
 
-	sm, err := ctx.SourceManager()
-	h.Must(err)
-	defer sm.Release()
-
 	// Create new project and set root. Setting root is required for PackageList
 	// to run properly.
 	p := new(dep.Project)
 	p.SetRoot(testProjPath)
+
+	sm, err := ctx.SourceManager(p)
+	h.Must(err)
+	defer sm.Release()
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/context_test.go
+++ b/context_test.go
@@ -587,7 +587,7 @@ func TestDepCachedir(t *testing.T) {
 			Out:      discardLgr,
 			Err:      discardLgr,
 		}
-		sm, err := ctx.SourceManager()
+		sm, err := ctx.SourceManager(nil)
 		h.Must(err)
 		defer sm.Release()
 

--- a/gps/example.go
+++ b/gps/example.go
@@ -44,7 +44,7 @@ func main() {
 
 	// Set up a SourceManager. This manages interaction with sources (repositories).
 	tempdir, _ := ioutil.TempDir("", "gps-repocache")
-	sourcemgr, _ := gps.NewSourceManager(gps.SourceManagerConfig{Cachedir: filepath.Join(tempdir)})
+	sourcemgr, _ := gps.NewSourceManager(gps.SourceManagerConfig{Cachedir: filepath.Join(tempdir)}, nil)
 	defer sourcemgr.Release()
 
 	// Prep and run the solver

--- a/gps/manager_test.go
+++ b/gps/manager_test.go
@@ -49,7 +49,7 @@ func mkNaiveSM(t *testing.T) (*SourceMgr, func()) {
 	sm, err := NewSourceManager(SourceManagerConfig{
 		Cachedir: cpath,
 		Logger:   log.New(test.Writer{TB: t}, "", 0),
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error on SourceManager creation: %s", err)
 	}
@@ -70,7 +70,7 @@ func remakeNaiveSM(osm *SourceMgr, t *testing.T) (*SourceMgr, func()) {
 	sm, err := NewSourceManager(SourceManagerConfig{
 		Cachedir: cpath,
 		Logger:   log.New(test.Writer{TB: t}, "", 0),
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error on SourceManager recreation: %s", err)
 	}
@@ -94,13 +94,13 @@ func TestSourceManagerInit(t *testing.T) {
 		Logger:   log.New(test.Writer{TB: t}, "", 0),
 	}
 
-	sm, err := NewSourceManager(cfg)
+	sm, err := NewSourceManager(cfg, nil)
 
 	if err != nil {
 		t.Errorf("Unexpected error on SourceManager creation: %s", err)
 	}
 
-	_, err = NewSourceManager(cfg)
+	_, err = NewSourceManager(cfg, nil)
 	if err == nil {
 		t.Errorf("Creating second SourceManager should have failed due to file lock contention")
 	} else if te, ok := err.(CouldNotCreateLockError); !ok {
@@ -132,7 +132,7 @@ func TestSourceManagerInit(t *testing.T) {
 		}
 	}()
 	// Set another one up at the same spot now, just to be sure
-	sm, err = NewSourceManager(cfg)
+	sm, err = NewSourceManager(cfg, nil)
 	if err != nil {
 		t.Fatalf("Creating a second SourceManager should have succeeded when the first was released, but failed with err %s", err)
 	}
@@ -154,7 +154,7 @@ func TestSourceInit(t *testing.T) {
 	sm, err := NewSourceManager(SourceManagerConfig{
 		Cachedir: cpath,
 		Logger:   log.New(test.Writer{TB: t}, "", 0),
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error on SourceManager creation: %s", err)
 	}

--- a/gps/solution_test.go
+++ b/gps/solution_test.go
@@ -128,7 +128,7 @@ func BenchmarkCreateVendorTree(b *testing.B) {
 	sm, err := NewSourceManager(SourceManagerConfig{
 		Cachedir: path.Join(tmp, "cache"),
 		Logger:   log.New(test.Writer{TB: b}, "", 0),
-	})
+	}, nil)
 	if err != nil {
 		b.Fatalf("failed to create SourceManager: %q", err)
 	}

--- a/gps/solver_inputs_test.go
+++ b/gps/solver_inputs_test.go
@@ -183,7 +183,7 @@ func TestValidateParams(t *testing.T) {
 	sm, err := NewSourceManager(SourceManagerConfig{
 		Cachedir: h.Path(cacheDir),
 		Logger:   log.New(test.Writer{TB: t}, "", 0),
-	})
+	}, nil)
 	h.Must(err)
 	defer sm.Release()
 

--- a/gps/source_manager_test.go
+++ b/gps/source_manager_test.go
@@ -95,7 +95,7 @@ func TestSourceManager_InferConstraint(t *testing.T) {
 			sm, err := NewSourceManager(SourceManagerConfig{
 				Cachedir: h.Path(cacheDir),
 				Logger:   log.New(test.Writer{TB: t}, "", 0),
-			})
+			}, nil)
 			h.Must(err)
 
 			got, err := sm.InferConstraint(tc.str, tc.project)

--- a/gps/vcs_source_test.go
+++ b/gps/vcs_source_test.go
@@ -679,7 +679,7 @@ func TestGitSourceAdaptiveCleanup(t *testing.T) {
 		sm, err = NewSourceManager(SourceManagerConfig{
 			Cachedir: cpath,
 			Logger:   log.New(test.Writer{TB: t}, "", 0),
-		})
+		}, nil)
 		if err != nil {
 			t.Fatalf("Unexpected error on SourceManager creation: %s", err)
 		}

--- a/gps/verify/lockdiff.go
+++ b/gps/verify/lockdiff.go
@@ -106,7 +106,7 @@ func DiffLocks(l1, l2 gps.Lock) LockDelta {
 			switch strings.Compare(string(pr1), string(pr2)) {
 			case 0: // Found a matching project
 				lpd = LockedProjectDelta{
-					Name: pr1,
+					Name:                         pr1,
 					LockedProjectPropertiesDelta: DiffLockedProjectProperties(lp1, lp2),
 				}
 				i2next = i2 + 1 // Don't visit this project again

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -917,8 +917,8 @@ func TestIsRegular(t *testing.T) {
 		exists bool
 		err    bool
 	}{
-		wd: {false, true},
-		filepath.Join(wd, "testdata"):                       {false, true},
+		wd:                            {false, true},
+		filepath.Join(wd, "testdata"): {false, true},
 		filepath.Join(wd, "testdata", "test.file"):          {true, false},
 		filepath.Join(wd, "this_file_does_not_exist.thing"): {false, false},
 		fn: {false, true},
@@ -972,9 +972,9 @@ func TestIsDir(t *testing.T) {
 		exists bool
 		err    bool
 	}{
-		wd: {true, false},
-		filepath.Join(wd, "testdata"):                       {true, false},
-		filepath.Join(wd, "main.go"):                        {false, true},
+		wd:                            {true, false},
+		filepath.Join(wd, "testdata"): {true, false},
+		filepath.Join(wd, "main.go"):  {false, true},
 		filepath.Join(wd, "this_file_does_not_exist.thing"): {false, true},
 		dn: {false, true},
 	}

--- a/internal/importers/base/importer_test.go
+++ b/internal/importers/base/importer_test.go
@@ -57,7 +57,7 @@ func TestBaseImporter_IsTag(t *testing.T) {
 			//h.Parallel()
 
 			ctx := importertest.NewTestContext(h)
-			sm, err := ctx.SourceManager()
+			sm, err := ctx.SourceManager(nil)
 			h.Must(err)
 			defer sm.Release()
 
@@ -126,7 +126,7 @@ func TestBaseImporter_LookupVersionForLockedProject(t *testing.T) {
 			//h.Parallel()
 
 			ctx := importertest.NewTestContext(h)
-			sm, err := ctx.SourceManager()
+			sm, err := ctx.SourceManager(nil)
 			h.Must(err)
 			defer sm.Release()
 

--- a/internal/importers/glide/importer_test.go
+++ b/internal/importers/glide/importer_test.go
@@ -178,7 +178,7 @@ func TestGlideConfig_Import(t *testing.T) {
 	defer h.Cleanup()
 
 	ctx := importertest.NewTestContext(h)
-	sm, err := ctx.SourceManager()
+	sm, err := ctx.SourceManager(nil)
 	h.Must(err)
 	defer sm.Release()
 

--- a/internal/importers/glock/importer_test.go
+++ b/internal/importers/glock/importer_test.go
@@ -94,7 +94,7 @@ func TestGlockConfig_Import(t *testing.T) {
 	defer h.Cleanup()
 
 	ctx := importertest.NewTestContext(h)
-	sm, err := ctx.SourceManager()
+	sm, err := ctx.SourceManager(nil)
 	h.Must(err)
 	defer sm.Release()
 

--- a/internal/importers/godep/importer_test.go
+++ b/internal/importers/godep/importer_test.go
@@ -125,7 +125,7 @@ func TestGodepConfig_Import(t *testing.T) {
 	sm, err := gps.NewSourceManager(gps.SourceManagerConfig{
 		Cachedir: h.Path(cacheDir),
 		Logger:   log.New(test.Writer{TB: t}, "", 0),
-	})
+	}, nil)
 	h.Must(err)
 	defer sm.Release()
 

--- a/internal/importers/govend/importer_test.go
+++ b/internal/importers/govend/importer_test.go
@@ -96,7 +96,7 @@ func TestGovendConfig_Import(t *testing.T) {
 	h.TempCopy(filepath.Join(importertest.RootProject, govendYAMLName), "vendor.yml")
 
 	projectRoot := h.Path(importertest.RootProject)
-	sm, err := gps.NewSourceManager(gps.SourceManagerConfig{Cachedir: h.Path(cacheDir)})
+	sm, err := gps.NewSourceManager(gps.SourceManagerConfig{Cachedir: h.Path(cacheDir)}, nil)
 	h.Must(err)
 	defer sm.Release()
 

--- a/internal/importers/govendor/importer_test.go
+++ b/internal/importers/govendor/importer_test.go
@@ -24,7 +24,7 @@ func TestGovendorConfig_Import(t *testing.T) {
 	defer h.Cleanup()
 
 	ctx := importertest.NewTestContext(h)
-	sm, err := ctx.SourceManager()
+	sm, err := ctx.SourceManager(nil)
 	h.Must(err)
 	defer sm.Release()
 

--- a/internal/importers/gvt/importer_test.go
+++ b/internal/importers/gvt/importer_test.go
@@ -143,7 +143,7 @@ func TestGvtConfig_Import(t *testing.T) {
 	sm, err := gps.NewSourceManager(gps.SourceManagerConfig{
 		Cachedir: h.Path(cacheDir),
 		Logger:   log.New(test.Writer{TB: t}, "", 0),
-	})
+	}, nil)
 	h.Must(err)
 	defer sm.Release()
 

--- a/internal/importers/importertest/testcase.go
+++ b/internal/importers/importertest/testcase.go
@@ -53,7 +53,7 @@ func (tc TestCase) Execute(t *testing.T, convert func(logger *log.Logger, sm gps
 	//h.Parallel()
 
 	ctx := NewTestContext(h)
-	sm, err := ctx.SourceManager()
+	sm, err := ctx.SourceManager(nil)
 	h.Must(err)
 	defer sm.Release()
 

--- a/internal/importers/vndr/importer_test.go
+++ b/internal/importers/vndr/importer_test.go
@@ -79,7 +79,7 @@ func TestVndrConfig_Import(t *testing.T) {
 	defer h.Cleanup()
 
 	ctx := importertest.NewTestContext(h)
-	sm, err := ctx.SourceManager()
+	sm, err := ctx.SourceManager(nil)
 	h.Must(err)
 	defer sm.Release()
 

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -635,7 +635,7 @@ func TestValidateProjectRoots(t *testing.T) {
 		Err:    errLogger,
 	}
 
-	sm, err := ctx.SourceManager()
+	sm, err := ctx.SourceManager(nil)
 	h.Must(err)
 	defer sm.Release()
 

--- a/test_project_context_test.go
+++ b/test_project_context_test.go
@@ -42,7 +42,7 @@ func NewTestProjectContext(h *test.Helper, projectName string) *TestProjectConte
 		Out:    discardLogger(),
 		Err:    discardLogger(),
 	}
-	pc.SourceManager, err = pc.Context.SourceManager()
+	pc.SourceManager, err = pc.Context.SourceManager(pc.Project)
 	h.Must(errors.Wrap(err, "Unable to create a SourceManager"))
 
 	return pc


### PR DESCRIPTION
...`source` is known from Gopkg.toml/lock files

<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

### What does this do / why do we need it?
When developper specify the `source` in a `[[constraint]]` or an `[[override]]` in the `Gopkg.toml` or `Gopkg.lock` files, it's not taken in account at deduction time. But no need to deduce anything, we know the source. So we save an HTTP request to `go-import metadata`.

It's also useful when you want to reach a private gitlab subgroup repo... So by specifying the `source`, `dep` will no make an HTTP request to retrieve a bad repo root path.

For example, for the private gitlab repo `https://gitlab.com/lhauspie-private-group/subgroup/my-awesome-project`, the `go-import metadata` request responds `https://gitlab.com/lhauspie-private-group/subgroup.git` what it's wrong.  
But for the public gitlab repo `https://gitlab.com/lhauspie-private-group/my-awesome-project`, the `go-import metadata` request responds `https://gitlab.com/lhauspie-private-group/my-awesome-project.git` what it's correct.

But for the public gitlab repo `https://gitlab.com/lhauspie-public-group/subgroup/my-awesome-project`, the `go-import metadata` request responds `https://gitlab.com/lhauspie-public-group/subgroup/my-awesome-project.git` what it's correct.

There is some issues about that in gitlab, and [this one in particular](https://gitlab.com/gitlab-org/gitlab-ce/issues/1337) where gitlab's mainteners said:
> If a user marks their group or project as private, GitLab will do everything it can do keep every detail about this group or project private, down to the name/existence.
> 
> I don't think we should compromise on the confidentiality of these users' data for the sake of go get, especially since there is a good workaround available (manually specifying .git in the URL). 

As far as I know, adding `.git` in the import path is not acceptable because of transitive dependencies.

If my project `github.com/lhauspie/project` imports `gitlab.com/lhauspie-private-group/subgroup/my-awesome-project.git/utils` and the `my-awesome-project` imports `gitlab.com/lhauspie-private-group/subgroup/my-awesome-project/math`, `dep` will anyway try to resolve (or deduce) the `rootPath` of `gitlab.com/lhauspie-private-group/subgroup/my-awesome-project/math` and retrieve `https://gitlab.com/lhauspie-private-group/subgroup.git` from `go-import metadata` and then will fail.

### What should your reviewer look out for in this PR?
If you add a `[[constraint]]` with `name` that is not matching a default `deducer` (for instance `gitlab.com/...`) and specifying a `source`, there will be no request to `go-import metadata` endpoint.

Normally, there will be no regression on other `knownPath` because the `staticDeducers` will be only added for `[[constraint]]` or `[[override]]` (with `source` specified) that don't already has deducer associated to.  
But I think it could be nice to check despite all my own tests.

### Do you need help or clarification on anything?
Nop, I don't think so... but don't hesitate :wink:

### Which issue(s) does this PR fix?
fixes #1961
fixes #1371
<!--

fixes #
fixes #

-->
