### PR TITLE
Fix bug in preservation of vendor/.git

### DIFF
--- a/txn_writer.go
+++ b/txn_writer.go
@@ -668,8 +668,8 @@ func (dw *DeltaWriter) Write(path string, sm gps.SourceManager, examples bool, l
 
 	// Ensure vendor/.git is preserved if present
 	if hasDotGit(vpath) {
-		err = fs.RenameWithFallback(filepath.Join(vpath, ".git"), filepath.Join(vnewpath, "vendor/.git"))
-		if _, ok := err.(*os.LinkError); ok {
+		err = fs.RenameWithFallback(filepath.Join(vpath, ".git"), filepath.Join(vnewpath, ".git"))
+		if err != nil {
 			return errors.Wrap(err, "failed to preserve vendor/.git")
 		}
 	}


### PR DESCRIPTION
The previous code was attempting to copy the .git directory into
vendor/vendor/.git, i.e., with an extra level of nesting. It was
then failing to notice the error because it was only reporting errors of
type *os.LinkError.

Fix the bug by removing the layer of nesting and reporting all errors.

Fix #1997.