### PR TITLE
pkgtree: fix handling of cyclic import graphs

### DIFF
--- a/gps/pkgtree/pkgtree_test.go
+++ b/gps/pkgtree/pkgtree_test.go
@@ -435,6 +435,103 @@ func TestWorkmapToReach(t *testing.T) {
 				},
 			},
 		},
+		"self cycle": {
+			workmap: map[string]wm{
+				"A": {in: map[string]bool{"A": true}},
+			},
+			rm: ReachMap{
+				"A": {Internal: []string{"A"}},
+			},
+		},
+		"simple cycle": {
+			workmap: map[string]wm{
+				"A": {in: map[string]bool{"B": true}},
+				"B": {in: map[string]bool{"A": true}},
+			},
+			rm: ReachMap{
+				"A": {Internal: []string{"A", "B"}},
+				"B": {Internal: []string{"A", "B"}},
+			},
+		},
+		"cycle with external dependency": {
+			workmap: map[string]wm{
+				"A": {
+					in: map[string]bool{"B": true},
+				},
+				"B": {
+					ex: map[string]bool{"C": true},
+					in: map[string]bool{"A": true},
+				},
+			},
+			rm: ReachMap{
+				"A": {
+					External: []string{"C"},
+					Internal: []string{"A", "B"},
+				},
+				"B": {
+					External: []string{"C"},
+					Internal: []string{"A", "B"},
+				},
+			},
+		},
+		"cycle with transitive external dependency": {
+			workmap: map[string]wm{
+				"A": {
+					in: map[string]bool{"B": true},
+				},
+				"B": {
+					in: map[string]bool{"A": true, "C": true},
+				},
+				"C": {
+					ex: map[string]bool{"D": true},
+				},
+			},
+			rm: ReachMap{
+				"A": {
+					External: []string{"D"},
+					Internal: []string{"A", "B", "C"},
+				},
+				"B": {
+					External: []string{"D"},
+					Internal: []string{"A", "B", "C"},
+				},
+				"C": {
+					External: []string{"D"},
+				},
+			},
+		},
+		"internal cycle": {
+			workmap: map[string]wm{
+				"A": {
+					ex: map[string]bool{"B": true},
+					in: map[string]bool{"C": true},
+				},
+				"C": {
+					in: map[string]bool{"D": true},
+				},
+				"D": {
+					in: map[string]bool{"E": true},
+				},
+				"E": {
+					in: map[string]bool{"C": true},
+				},
+			},
+			rm: ReachMap{
+				"A": {
+					External: []string{"B"},
+					Internal: []string{"C", "D", "E"},
+				},
+				"C": {
+					Internal: []string{"C", "D", "E"},
+				},
+				"D": {
+					Internal: []string{"C", "D", "E"},
+				},
+				"E": {
+					Internal: []string{"C", "D", "E"},
+				},
+			},
+		},
 	}
 
 	for name, fix := range table {


### PR DESCRIPTION
Determining reachability in the face of cyclic imports requires
"merging" the reachsets of the packages in the cycle. Previously, dep
could nondeterministically lose dependencies in cyclic graphs depending
on the order in which it traversed the graph.

Fix #2001.

<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

### What does this do / why do we need it?

### What should your reviewer look out for in this PR?

### Do you need help or clarification on anything?

### Which issue(s) does this PR fix?

<!--

fixes #
fixes #

-->
