### PR TITLE
cmd/dep: replace `len(x)<=0` with `len(x)==0`

### DIFF
--- a/cmd/dep/init.go
+++ b/cmd/dep/init.go
@@ -74,7 +74,7 @@ func (cmd *initCommand) Run(ctx *dep.Ctx, args []string) error {
 	}
 
 	var root string
-	if len(args) <= 0 {
+	if len(args) == 0 {
 		root = ctx.WorkingDir
 	} else {
 		root = args[0]


### PR DESCRIPTION
Length never returns negative values.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>
