### PR TITLE
Update build-all.bash

### DIFF
--- a/hack/build-all.bash
+++ b/hack/build-all.bash
@@ -58,7 +58,8 @@ for OS in ${DEP_BUILD_PLATFORMS[@]}; do
         GOARCH=${ARCH} GOOS=${OS} CGO_ENABLED=${CGO_ENABLED} ${GO_BUILD_CMD} -ldflags "${GO_BUILD_LDFLAGS}"\
             -o "${DEP_ROOT}/release/${NAME}" ./cmd/dep/
         pushd "${DEP_ROOT}/release" > /dev/null
-        shasum -a 256 "${NAME}" > "${NAME}.sha256"
+        which shasum > /dev/null 2>&1 && shasum -a 256 "${NAME}" > "${NAME}.sha256"
+        which sha256sum > /dev/null 2>&1 && sha256sum "${NAME}" > "${NAME}.sha256"
         popd > /dev/null
     fi
   done


### PR DESCRIPTION
Use either `shasum` or `sha256sum` whichever is available. Fixes #2065.

### What does this do / why do we need it?
This allows Archlinux builds to succeed.

### What should your reviewer look out for in this PR?
I did not update the changelog, because I'm no sure under what version to add a line.

### Do you need help or clarification on anything?
I tested on Archlinux, works!

### Which issue(s) does this PR fix?

fixes #2065 