### PR TITLE
install.sh: add s390x to the install script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,6 +100,8 @@ jobs:
             - release/dep-linux-ppc64.sha256
             - release/dep-linux-ppc64le
             - release/dep-linux-ppc64le.sha256
+            - release/dep-linux-s390x
+            - release/dep-linux-s390x.sha256
           skip_cleanup: true
           on:
             repo: golang/dep

--- a/hack/build-all.bash
+++ b/hack/build-all.bash
@@ -31,7 +31,7 @@ if [[ -z "${DEP_BUILD_PLATFORMS}" ]]; then
 fi
 
 if [[ -z "${DEP_BUILD_ARCHS}" ]]; then
-    DEP_BUILD_ARCHS="amd64 386 ppc64 ppc64le"
+    DEP_BUILD_ARCHS="amd64 386 ppc64 ppc64le s390x"
 fi
 
 mkdir -p "${DEP_ROOT}/release"
@@ -50,8 +50,8 @@ for OS in ${DEP_BUILD_PLATFORMS[@]}; do
     else
       CGO_ENABLED=0
     fi
-    if [[ "${ARCH}" == "ppc64" || "${ARCH}" == "ppc64le" ]] && [[ "${OS}" != "linux" ]]; then
-        # ppc64 and ppc64le are only supported on Linux.
+    if [[ "${ARCH}" == "ppc64" || "${ARCH}" == "ppc64le" || "${ARCH}" == "s390x" ]] && [[ "${OS}" != "linux" ]]; then
+        # ppc64, ppc64le, and s390x are only supported on Linux.
         echo "Building for ${OS}/${ARCH} not supported."
     else
         echo "Building for ${OS}/${ARCH} with CGO_ENABLED=${CGO_ENABLED}"

--- a/install.sh
+++ b/install.sh
@@ -96,6 +96,7 @@ initArch() {
         i386) ARCH="386";;
         ppc64) ARCH="ppc64";;
         ppc64le) ARCH="ppc64le";;
+        s390x) ARCH="s390x";;
         *) echo "Architecture ${ARCH} is not supported by this installation script"; exit 1;;
     esac
     echo "ARCH = $ARCH"


### PR DESCRIPTION
Updates #2062. 

### What does this do / why do we need it?

Users have requested releases that use the s390x architecture
<!--

fixes #
fixes #

-->