### PR TITLE
*: fmt and lint from `make`

### DIFF
--- a/cmd/dep/status.go
+++ b/cmd/dep/status.go
@@ -340,7 +340,7 @@ func (out *dotOutput) BasicHeader() error {
 
 func (out *dotOutput) BasicFooter() error {
 	gvo := out.g.output("")
-	_, err := fmt.Fprintf(out.w, gvo.String())
+	_, err := fmt.Fprint(out.w, gvo.String())
 	return err
 }
 

--- a/cmd/dep/status_test.go
+++ b/cmd/dep/status_test.go
@@ -28,7 +28,7 @@ func TestStatusFormatVersion(t *testing.T) {
 	t.Parallel()
 
 	tests := map[gps.Version]string{
-		nil: "",
+		nil:                            "",
 		gps.NewBranch("master"):        "branch master",
 		gps.NewVersion("1.0.0"):        "1.0.0",
 		gps.Revision("flooboofoobooo"): "flooboo",

--- a/gps/verify/lockdiff.go
+++ b/gps/verify/lockdiff.go
@@ -106,7 +106,7 @@ func DiffLocks(l1, l2 gps.Lock) LockDelta {
 			switch strings.Compare(string(pr1), string(pr2)) {
 			case 0: // Found a matching project
 				lpd = LockedProjectDelta{
-					Name: pr1,
+					Name:                         pr1,
 					LockedProjectPropertiesDelta: DiffLockedProjectProperties(lp1, lp2),
 				}
 				i2next = i2 + 1 // Don't visit this project again

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -144,7 +144,7 @@ func EquivalentPaths(p1, p2 string) (bool, error) {
 				return false, nil
 			}
 		} else {
-			if strings.ToLower(p1Filename) != strings.ToLower(p2Filename) {
+			if !strings.EqualFold(p1Filename, p2Filename) {
 				return false, nil
 			}
 		}

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -917,8 +917,8 @@ func TestIsRegular(t *testing.T) {
 		exists bool
 		err    bool
 	}{
-		wd: {false, true},
-		filepath.Join(wd, "testdata"):                       {false, true},
+		wd:                            {false, true},
+		filepath.Join(wd, "testdata"): {false, true},
 		filepath.Join(wd, "testdata", "test.file"):          {true, false},
 		filepath.Join(wd, "this_file_does_not_exist.thing"): {false, false},
 		fn: {false, true},
@@ -972,9 +972,9 @@ func TestIsDir(t *testing.T) {
 		exists bool
 		err    bool
 	}{
-		wd: {true, false},
-		filepath.Join(wd, "testdata"):                       {true, false},
-		filepath.Join(wd, "main.go"):                        {false, true},
+		wd:                            {true, false},
+		filepath.Join(wd, "testdata"): {true, false},
+		filepath.Join(wd, "main.go"):  {false, true},
 		filepath.Join(wd, "this_file_does_not_exist.thing"): {false, true},
 		dn: {false, true},
 	}


### PR DESCRIPTION
### What does this do / why do we need it?
```shell
cmd/dep/status.go:343:31: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
internal/fs/fs.go:147:7: should use !strings.EqualFold(a, b) instead of strings.ToLower(a) != strings.ToLower(b) (SA6005)
```

### What should your reviewer look out for in this PR?
consistent functionality

### Do you need help or clarification on anything?

### Which issue(s) does this PR fix?

<!--

fixes #
fixes #

-->
