### PR TITLE
travis.yml: upgrade to Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: go
 sudo: false
+dist: xenial
 notifications:
   email: false
 jobs:


### PR DESCRIPTION
Older Ubuntus cause Mercurial connections to fail with this error:

Error on cloning hg repo: unable to get repository: warning:
connecting to bitbucket.org using legacy security technology (TLS
1.0); see https://mercurial-scm.org/wiki/SecureConnections for more
info
(using CA certificates from /etc/ssl/certs/ca-certificates.crt; if you
see this message, your Mercurial install is not properly configured;
see https://mercurial-scm.org/wiki/SecureConnections for how to
configure Mercurial to avoid this message)

Per
https://travis-ci.community/t/travis-ci-linux-build-environments-cant-clone-from-bitbucket-anymore-mercurial/1182/3,
the recommendation is to upgrade to Xenial, which has either a newer
Mercurial, a newer Python, a newer OpenSSL or some combination of
those.

<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

Updates #2071.
Updates #2089.  