### PR TITLE
codeclimate.yml: disable go fmt check

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -22,7 +22,9 @@ checks:
     enabled: false
 plugins:
   gofmt:
-    enabled: true
+    # Codeclimate go fmt does not agree with tip go fmt; consider re-enabling
+    # CC when the advice matches up with tip again.
+    enabled: false
   govet:
     enabled: true
   golint:


### PR DESCRIPTION
The go fmt recommendation from Code Climate does not line up with the
go fmt recommendation on tip. Ignore it.
