### PR TITLE
travis.yml, hack: fix tests on tip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ jobs:
         - npm install -g codeclimate-test-reporter
       env:
         - DEPTESTBYPASS501=1
+        - TZ=UTC
       os: linux
       go: 1.11.x
       script:
@@ -29,11 +30,20 @@ jobs:
         - ssh-keyscan -t $TRAVIS_SSH_KEY_TYPES -H bitbucket.org >> ~/.ssh/known_hosts
       env:
         - DEPTESTBYPASS501=1
+        - TZ=UTC
       script: make test
     - <<: *simple-test
       go: 1.9.x
     - <<: *simple-test
       go: tip
+      install:
+        - ssh-keyscan -t $TRAVIS_SSH_KEY_TYPES -H bitbucket.org >> ~/.ssh/known_hosts
+        - mkdir -p /home/travis/var/cache
+      env:
+        - GOCACHE=/home/travis/var/cache
+        - DEPTESTBYPASS501=1
+        - TZ=UTC
+
     - <<: *simple-test
       os: osx
       go: 1.11.x
@@ -45,6 +55,7 @@ jobs:
       env:
         - HOMEBREW_NO_AUTO_UPDATE=1
         - DEPTESTBYPASS501=1
+        - TZ=UTC
       script:
         # OSX as of El Capitan sets an exit trap that interacts poorly with how
         # travis seems to spawn these shells; if set -e is set, then it can cause

--- a/hack/coverage.bash
+++ b/hack/coverage.bash
@@ -3,12 +3,9 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 #
-# This script will generate coverage.txt
+# This script will generate coverage.txt.
 
-if [[ "${CI:-}" != 'true' ]]; then
-    # https://github.com/golang/dep/issues/2089
-    set -e
-fi
+set -e
 
 PKGS=$(go list ./... | grep -v /vendor/)
 for pkg in $PKGS; do

--- a/hack/test.bash
+++ b/hack/test.bash
@@ -8,10 +8,7 @@
 # DEP_BUILD_PLATFORMS="linux" DEP_BUILD_ARCHS="amd64" ./hack/build-all.bash
 # can be called to build only for linux-amd64
 
-if [[ "${CI:-}" != 'true' ]]; then
-    # https://github.com/golang/dep/issues/2089
-    set -e
-fi
+set -e
 
 IMPORT_DURING_SOLVE=${IMPORT_DURING_SOLVE:-false}
 


### PR DESCRIPTION
The tip tests were failing due to the lack of a GOCACHE environment
variable, and bad defaults in tests where home directories did not
exist. Fix these by setting the GOCACHE to a place we know exists.

This and the Xenial fix combined allow us to re-enable the test suite,
e.g. to permit failures in the test suite to actually fail the build.

(We may still want to address the GOCACHE tests locally for users that
do not have a GOCACHE environment variable set; as it stands, they
still fail.)

<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

### What does this do / why do we need it?

### What should your reviewer look out for in this PR?

### Do you need help or clarification on anything?

### Which issue(s) does this PR fix?

<!--

fixes #
fixes #

-->
