### PR TITLE
gps: simplify `x = x <op> y` to `x <op>= y`

### DIFF
--- a/gps/metrics.go
+++ b/gps/metrics.go
@@ -31,7 +31,7 @@ func newMetrics() *metrics {
 
 func (m *metrics) push(name string) {
 	cn := m.stack[len(m.stack)-1]
-	m.times[cn] = m.times[cn] + time.Since(m.last)
+	m.times[cn] += time.Since(m.last)
 
 	m.stack = append(m.stack, name)
 	m.last = time.Now()
@@ -39,7 +39,7 @@ func (m *metrics) push(name string) {
 
 func (m *metrics) pop() {
 	on := m.stack[len(m.stack)-1]
-	m.times[on] = m.times[on] + time.Since(m.last)
+	m.times[on] += time.Since(m.last)
 
 	m.stack = m.stack[:len(m.stack)-1]
 	m.last = time.Now()

--- a/gps/selection.go
+++ b/gps/selection.go
@@ -112,7 +112,7 @@ func (s *selection) getRequiredPackagesIn(id ProjectIdentifier) map[string]int {
 	uniq := make(map[string]int)
 	for _, dep := range s.deps[id.ProjectRoot] {
 		for _, pkg := range dep.dep.pl {
-			uniq[pkg] = uniq[pkg] + 1
+			uniq[pkg]++
 		}
 	}
 
@@ -134,7 +134,7 @@ func (s *selection) getSelectedPackagesIn(id ProjectIdentifier) map[string]int {
 	for _, p := range s.projects {
 		if p.a.a.id.eq(id) {
 			for _, pkg := range p.a.pl {
-				uniq[pkg] = uniq[pkg] + 1
+				uniq[pkg]++
 			}
 		}
 	}

--- a/gps/trace.go
+++ b/gps/trace.go
@@ -47,7 +47,7 @@ func (s *solver) traceCheckQueue(q *versionQueue, bmi bimodalIdentifier, cont bo
 	if cont {
 		// Continue is an "inner" message.. indenting
 		verb = "continue"
-		vlen = vlen + " more"
+		vlen += " more"
 		indent = innerIndent
 	} else {
 		verb = "attempt"


### PR DESCRIPTION
Simplify `x += 1` further to `x++`.

Already open as #2028 but the fork doesn't exist anymore and I can't push changes to it.

Originally submitted by @quasilyte 