### PR TITLE
gps: git: Force checkout

### DIFF
--- a/gps/vcs_repo.go
+++ b/gps/vcs_repo.go
@@ -95,7 +95,7 @@ func (r *gitRepo) fetch(ctx context.Context) error {
 }
 
 func (r *gitRepo) updateVersion(ctx context.Context, v string) error {
-	cmd := commandContext(ctx, "git", "checkout", v)
+	cmd := commandContext(ctx, "git", "checkout", "-f", v)
 	cmd.SetDir(r.LocalPath())
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return newVcsLocalErrorOr(err, cmd.Args(), string(out),


### PR DESCRIPTION
When looking for a proper version dep does many checkouts
and the tree might become "corrupted", leading to errors like this:

"The following untracked working tree files would be overwritten by checkout:"

Followed by a list of files and then "git checkout" fails.

By forcing the checkout we avoid such errors.

<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

### What does this do / why do we need it?

### What should your reviewer look out for in this PR?

### Do you need help or clarification on anything?

### Which issue(s) does this PR fix?

<!--

fixes #
fixes #

-->
