### PR TITLE
upgrade toml import

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -8,7 +8,7 @@
 
 [[constraint]]
   name = "github.com/pelletier/go-toml"
-  version = "1.1.0"
+  version = "1.2.0"
 
 [[constraint]]
   name = "github.com/pkg/errors"


### PR DESCRIPTION
This PR is a follow up from 6dfe5e25f0c3444a2be3637377b28e98899c4765 to set the locked https://github.com/pelletier/go-toml version in the `Gopkg.toml`.
