### PR TITLE
Fix ARM (v6/7) CI release to Github and resulting install script erroring out on 404

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,8 +106,8 @@ jobs:
             - release/dep-linux-ppc64le.sha256
             - release/dep-linux-s390x
             - release/dep-linux-s390x.sha256
-            - release/dep-linux-armv6
-            - release/dep-linux-armv6.sha256
+            - release/dep-linux-arm
+            - release/dep-linux-arm.sha256
             - release/dep-linux-arm64
             - release/dep-linux-arm64.sha256
           skip_cleanup: true


### PR DESCRIPTION
In January, PR #2102 was closed with 5ae9d8b to build ARMv6/7 binaries. This seems to be working, but there are no release files uploaded to Github for this architecture, because the wrong filenames are used in `.travis-ci`. This PR fixes that.

It must be noted that the `dep` install script is already modified to expect a ARMv6/7 binary in the Github releases, so it errors out on 404 instead of emitting a clear error message which it did before:

    Fetching https://github.com/golang/dep/releases/download/v0.5.1/dep-linux-arm
    Request failed with code 404

To fix this, perhaps the binary can be manually added to the v0.5.1 release, or the Travis CI job be rerun as v0.5.2.