### PR TITLE
gps: ignore "mod" VCS type in parseMetaGoImports

### DIFF
--- a/gps/discovery.go
+++ b/gps/discovery.go
@@ -35,6 +35,9 @@ type metaImport struct {
 
 // parseMetaGoImports returns meta imports from the HTML in r.
 // Parsing ends at the end of the <head> section or the beginning of the <body>.
+//
+// This copy of cmd/go/internal/vcs.parseMetaGoImports always operates
+// in IgnoreMod ModuleMode.
 func parseMetaGoImports(r io.Reader) (imports []metaImport, err error) {
 	d := xml.NewDecoder(r)
 	d.CharsetReader = charsetReader
@@ -62,6 +65,10 @@ func parseMetaGoImports(r io.Reader) (imports []metaImport, err error) {
 			continue
 		}
 		if f := strings.Fields(attrValue(e.Attr, "content")); len(f) == 3 {
+			// Ignore VCS type "mod", which is applicable only in module mode.
+			if f[1] == "mod" {
+				continue
+			}
 			imports = append(imports, metaImport{
 				Prefix:   f[0],
 				VCS:      f[1],


### PR DESCRIPTION
Apply the same change as in [golang.org/cl/175219](https://golang.org/cl/175219) to this copy of the
`parseMetaGoImports` function, helping keep them in sync.

The "mod" type is not a real version control system (VCS), it applies
only when in module mode. Skip it and continue to consider only real
VCS types.

This resolves `parseMetaGoImports` returning a "multiple meta tags match
import path" error on packages that offer `go-import` meta tags with both
a true VCS and the "mod" type.

Reference: https://golang.org/cmd/go/#hdr-Remote_import_paths

Fixes #2151