### PR TITLE
gps: support loading credentials from a netrc file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GOBIN := $(GOPATH)/bin
 default: build validate test
 
 get-deps:
-	go get -u golang.org/x/lint/golint honnef.co/go/tools/cmd/megacheck
+	go get -u golang.org/x/lint/golint honnef.co/go/tools/cmd/staticcheck
 
 build:
 	go fmt ./...

--- a/hack/lint.bash
+++ b/hack/lint.bash
@@ -9,4 +9,4 @@ set -e
 PKGS=$(go list ./... | grep -vF /vendor/)
 go vet $PKGS
 golint $PKGS
-megacheck -unused.exported -ignore "github.com/golang/dep/internal/test/test.go:U1000 github.com/golang/dep/gps/prune.go:U1000 github.com/golang/dep/manifest.go:U1000" $PKGS
+staticcheck -ignore "github.com/golang/dep/internal/test/test.go:U1000 github.com/golang/dep/gps/prune.go:U1000 github.com/golang/dep/manifest.go:U1000" $PKGS


### PR DESCRIPTION
This enables support for private gitlab files and other places where
the URL requires basic authentication.

The idea and the large majority of the implementation comes from @wesgur.

Fixes #2061.
Fixes #1898.