### PR TITLE
enabled persistent source caching by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# (next version)
+
+NEW FEATURES:
+
+* Enable persistent source caching by default (`DEPCACHEAGE`). ([#2163][2163])
+
 # v0.5.3
 
 Released on May 13, 2019

--- a/cmd/dep/main.go
+++ b/cmd/dep/main.go
@@ -262,13 +262,31 @@ var examples = [...][2]string{
 	},
 }
 
+var envVars = [...][2]string{
+	{
+		"DEPCACHEAGE",
+		"Maximum age of cached source metadata to use. Default 24h. Set <= 0 to disable.",
+	},
+	{
+		"DEPCACHEDIR",
+		"Directory for local cache. Defaults to $GOPATH/pkg/dep.",
+	},
+	{
+		"DEPPROJECTROOT",
+		"Override the GOPATH inferred project root.",
+	},
+	{
+		"DEPNOLOCK",
+		"Bypass local cache lock file creation.",
+	},
+}
+
 func fprintUsage(w io.Writer) {
 	fmt.Fprintln(w, "Dep is a tool for managing dependencies for Go projects")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Usage: \"dep [command]\"")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Commands:")
-	fmt.Fprintln(w)
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 
 	commands := commandList()
@@ -282,6 +300,12 @@ func fprintUsage(w io.Writer) {
 	fmt.Fprintln(w, "Examples:")
 	for _, example := range examples {
 		fmt.Fprintf(tw, "\t%s\t%s\n", example[0], example[1])
+	}
+	tw.Flush()
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Environment Variables:")
+	for _, envVar := range envVars {
+		fmt.Fprintf(tw, "\t%s\t%s\n", envVar[0], envVar[1])
 	}
 	tw.Flush()
 	fmt.Fprintln(w)

--- a/cmd/dep/main.go
+++ b/cmd/dep/main.go
@@ -24,6 +24,8 @@ import (
 	"github.com/golang/dep/internal/fs"
 )
 
+const defaultCacheAge = 24 * time.Hour
+
 var (
 	successExitCode = 0
 	errorExitCode   = 1
@@ -185,7 +187,7 @@ func (c *Config) Run() int {
 				}
 			}
 
-			var cacheAge time.Duration
+			cacheAge := defaultCacheAge
 			if env := getEnv(c.Env, "DEPCACHEAGE"); env != "" {
 				var err error
 				cacheAge, err = time.ParseDuration(env)

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -22,7 +22,9 @@ If set to a [duration](https://golang.org/pkg/time/#ParseDuration) (e.g. `24h`),
 * The contents of a project's `Gopkg.toml` file, at a particular version
 * A project's tree of packages and imports, at a particular version
 
-A duration must be set to enable caching. (In future versions of dep, it will be on by default). The duration is used as a TTL, but only for mutable information, like version lists. Information associated with an immutable VCS revision (packages and imports; `Gopkg.toml` declarations) is cached indefinitely.
+The default duration is `24h`, and values <= 0 will disable the cache.
+The duration is used as a TTL, but only for mutable information, like version lists.
+Information associated with an immutable VCS revision (packages and imports; `Gopkg.toml` declarations) is cached indefinitely.
 
 The cache lives in `$DEPCACHEDIR/bolt-v1.db`, where the version number is an internal number associated with a particular data schema dep uses.
 


### PR DESCRIPTION
### What does this do / why do we need it?

Enables persistent source caching by default (`24h`). Documents environment variables in the help/usage text.

```diff
Dep is a tool for managing dependencies for Go projects

Usage: "dep [command]"

Commands:
  init     Set up a new Go project, or migrate an existing one
  status   Report the status of the project's dependencies
  ensure   Ensure a dependency is safely vendored in the project
  version  Show the dep version information
  check    Check if imports, Gopkg.toml, and Gopkg.lock are in sync

Examples:
  dep init                               set up a new project
  dep ensure                             install the project's dependencies
  dep ensure -update                     update the locked versions of all dependencies
  dep ensure -add github.com/pkg/errors  add a dependency to the project

+Environment Variables:
+  DEPCACHEAGE     Maximum age of cached source metadata to use. Default 24h. Set <= 0 to disable.
+  DEPCACHEDIR     Directory for local cache. Defaults to $GOPATH/pkg/dep.
+  DEPPROJECTROOT  Override the GOPATH inferred project root.
+  DEPNOLOCK       Bypass local cache lock file creation.
+
Use "dep help [command]" for more information about a command.

```

### What should your reviewer look out for in this PR?

Is `24h` an appropriate default value? Are the env var descriptions clear?