### PR TITLE
Fix clean of submodules

### DIFF
--- a/gps/vcs_repo.go
+++ b/gps/vcs_repo.go
@@ -146,8 +146,7 @@ func (r *gitRepo) defendAgainstSubmodules(ctx context.Context) error {
 			"submodule",
 			"foreach",
 			"--recursive",
-			"git",
-			"clean", "-x", "-d", "-f", "-f",
+			"git clean -x -d -f -f",
 		)
 		cmd.SetDir(r.LocalPath())
 		if out, err := cmd.CombinedOutput(); err != nil {


### PR DESCRIPTION
Fix execution with the vendor with submodules.

### What does this do / why do we need it?
This fix error:

```
#$# dep ensure -add github.com/openSUSE/umoci
Fetching sources...

Solving failure: No versions of github.com/openSUSE/umoci met constraints:
	v0.3.1: Could not introduce github.com/openSUSE/umoci@v0.3.1, as it is not allowed by constraints from the following projects:
	master from (root)
	master from github.com/geaaru/docker-companion@master

	v0.4.4: Could not introduce github.com/openSUSE/umoci@v0.4.4, as it is not allowed by constraints from the following projects:
	master from (root)
	master from github.com/geaaru/docker-companion@master

	v0.4.3: Could not introduce github.com/openSUSE/umoci@v0.4.3, as it is not allowed by constraints from the following projects:
	master from (root)
	master from github.com/geaaru/docker-companion@master

	v0.4.2: Could not introduce github.com/openSUSE/umoci@v0.4.2, as it is not allowed by constraints from the following projects:
	master from (root)
	master from github.com/geaaru/docker-companion@master

	v0.4.1: Could not introduce github.com/openSUSE/umoci@v0.4.1, as it is not allowed by constraints from the following projects:
	master from (root)
	master from github.com/geaaru/docker-companion@master

	v0.4.0: Could not introduce github.com/openSUSE/umoci@v0.4.0, as it is not allowed by constraints from the following projects:
	master from (root)
	master from github.com/geaaru/docker-companion@master

	v0.3.0: Could not introduce github.com/openSUSE/umoci@v0.3.0, as it is not allowed by constraints from the following projects:
	master from (root)
	master from github.com/geaaru/docker-companion@master

	v0.2.1: Could not introduce github.com/openSUSE/umoci@v0.2.1, as it is not allowed by constraints from the following projects:
	master from (root)
	master from github.com/geaaru/docker-companion@master

	v0.2.0: Could not introduce github.com/openSUSE/umoci@v0.2.0, as it is not allowed by constraints from the following projects:
	master from (root)
	master from github.com/geaaru/docker-companion@master

	v0.1.0: Could not introduce github.com/openSUSE/umoci@v0.1.0, as it is not allowed by constraints from the following projects:
	master from (root)
	master from github.com/geaaru/docker-companion@master

	v0.0.0: Could not introduce github.com/openSUSE/umoci@v0.0.0, as it is not allowed by constraints from the following projects:
	master from (root)
	master from github.com/geaaru/docker-companion@master

	v0.0.0-rc3: Could not introduce github.com/openSUSE/umoci@v0.0.0-rc3, as it is not allowed by constraints from the following projects:
	master from (root)
	master from github.com/geaaru/docker-companion@master

	v0.0.0-rc2: Could not introduce github.com/openSUSE/umoci@v0.0.0-rc2, as it is not allowed by constraints from the following projects:
	master from (root)
	master from github.com/geaaru/docker-companion@master

	v0.0.0-rc1: Could not introduce github.com/openSUSE/umoci@v0.0.0-rc1, as it is not allowed by constraints from the following projects:
	master from (root)
	master from github.com/geaaru/docker-companion@master

	master: unexpected error while defensively cleaning up after possible derelict nested submodule directories: Entering '.site/themes/hugo-theme-learn'
error: unknown switch `x'
uso: git submodule--helper foreach [--quiet] [--recursive] <command>

    -q, --quiet           Suppress output of entering each submodule command
    --recursive           Recurse into nested submodules

fatal: run_command returned non-zero status while recursing in the nested submodules of .site/themes/hugo-theme-learn
.
: command failed: [git submodule foreach --recursive git clean -x -d -f -f]: exit status 128
	gh-pages: Could not introduce github.com/openSUSE/umoci@gh-pages, as it is not allowed by constraints from the following projects:
	master from (root)
	master from github.com/geaaru/docker-companion@master
```

