### PR TITLE
README: fix link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <i>Would you like to see your company name here? <a
-href="/golang/dep/issue/2165">We're looking for a stable source of
+href="https://github.com/golang/dep/issues/2165">We're looking for a stable source of
 funding.</a></i>
 
 ## Dep


### PR DESCRIPTION
Whoops! I think Github may rewrite relative links to be relative to
the project root.
