### PR TITLE
gps: pass correct arguments to "git clean"

### DIFF
--- a/gps/vcs_repo.go
+++ b/gps/vcs_repo.go
@@ -146,8 +146,7 @@ func (r *gitRepo) defendAgainstSubmodules(ctx context.Context) error {
 			"submodule",
 			"foreach",
 			"--recursive",
-			"git",
-			"clean", "-x", "-d", "-f", "-f",
+			"git clean -x -d -f -f",
 		)
 		cmd.SetDir(r.LocalPath())
 		if out, err := cmd.CombinedOutput(); err != nil {


### PR DESCRIPTION
Previously, the "-x" in

    git submodule foreach --recursive git clean -x

was being applied to the "git submodule" command not the "git clean"
command. git submodule foreach expects the inner command to be wrapped
in a single string, so pass git clean as a single string.

Verified this works as expected on the command line.

Fixes #2164.
Fixes #2168.