### PR TITLE
hack,internal: fix staticcheck

### DIFF
--- a/hack/lint.bash
+++ b/hack/lint.bash
@@ -9,4 +9,4 @@ set -e
 PKGS=$(go list ./... | grep -vF /vendor/)
 go vet $PKGS
 golint $PKGS
-staticcheck -ignore "github.com/golang/dep/internal/test/test.go:U1000 github.com/golang/dep/gps/prune.go:U1000 github.com/golang/dep/manifest.go:U1000" $PKGS
+staticcheck $PKGS

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//lint:file-ignore U1000 unused fns we might want to use later.
+
 package test
 
 import (


### PR DESCRIPTION
The most recent version of staticcheck drops the "--ignore" flag in
favor of inline ignore directives, so we need to use those or fix on
the older version.

Good news is two of our ignore directives are now no longer needed.

Updates dominikh/go-tools#514.
Updates dominikh/go-tools#515.
Fixes #2178.

