### PR TITLE
Check the `[]dependency` slice length to avoid panic

### DIFF
--- a/gps/solver.go
+++ b/gps/solver.go
@@ -942,7 +942,9 @@ func (s *solver) findValidVersion(q *versionQueue, pl []string) error {
 		}
 	}
 
-	s.fail(s.sel.getDependenciesOn(q.id)[0].depender.id)
+	if deps := s.sel.getDependenciesOn(q.id); deps != nil && len(deps) > 0 {
+		s.fail(s.sel.getDependenciesOn(q.id)[0].depender.id)
+	}
 
 	// Return a compound error of all the new errors encountered during this
 	// attempt to find a new, valid version


### PR DESCRIPTION
### What does this do / why do we need it?
It checks if a slice is nil or not and we need because the code will panic without it.

### Do you need help or clarification on anything?
No

### Which issue(s) does this PR fix?
fixes #2194 