### PR TITLE
Fix minor typo (caught by Lintian)

### DIFF
--- a/cmd/dep/status.go
+++ b/cmd/dep/status.go
@@ -74,7 +74,7 @@ dep status -f='{{if eq .Constraint "master"}}{{.ProjectRoot}} {{end}}'
 
 	Displays the list of package names constrained on the master branch.
 	The -f flag allows you to use Go templates along with it's various
-	constructs for formating output data. Available flags are as follows:
+	constructs for formatting output data. Available flags are as follows:
 	` + availableTemplateVariables + `
 
 dep status -detail -f='{{range $i, $p := .Projects}}{{if ne .Source "" -}}


### PR DESCRIPTION
Hi!  This minor typo was caught by the Lintian tool as part of routine Debian packaging task while upgrading to 0.5.4:

```
$ lintian
I: go-dep: spelling-error-in-binary usr/bin/dep formating formatting
```

Many thanks!