### PR TITLE
Extend docs on git+ssh auth

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -205,7 +205,16 @@ Once you have set that up, dep will automatically use that Token to authenticate
 
 ## How do I get dep to authenticate via SSH to a git repo?
 
-You can rewrite the repo url and use the git+ssh shema with follow example:
+You can change the source field in the `Gopkg.toml` to use the git+ssh shema.  For example, you could use the following:
+
+```
+[[constraint]]
+  name = "github.yourEnterprise.com/org/project"
+  source = "git@github.yourEnterprise.com:org/project.git"
+  branch = "master"
+```
+
+Alternatively, can rewrite all repo URLs and use the git+ssh shema with follow example:
 
 ```
 git config --global url."git@github.yourEnterprise.com:".insteadOf "https://github.yourEnterprise.com/"


### PR DESCRIPTION
### What does this do / why do we need it?
You can configure dep to auth via ssh by using the manifest file instead of overriding global git config.  Just adding an alternative way to do things