### PR TITLE
update CI for go 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ jobs:
         - TZ=UTC
         - GOCACHE=/home/travis/var/cache
       os: linux
-      go: 1.12.x
+      go: 1.13.x
       script:
         - make validate test
         - ./hack/coverage.bash
@@ -24,7 +24,7 @@ jobs:
         - codeclimate-test-reporter < coverage.txt
     # YAML alias, for settings shared across the simpler builds
     - &simple-test
-      go: 1.11.x
+      go: 1.12.x
       stage: test
       go_import_path: github.com/golang/dep
       install:
@@ -35,7 +35,7 @@ jobs:
       script:
         - make test
     - <<: *simple-test
-      go: 1.9.x
+      go: 1.11.x
     - <<: *simple-test
       go: tip
       install:
@@ -48,7 +48,7 @@ jobs:
 
     - <<: *simple-test
       os: osx
-      go: 1.12.x
+      go: 1.13.x
       install:
         # brew takes horribly long to update itself despite the above caching
         # attempt; only bzr install if it's not on the $PATH
@@ -67,7 +67,7 @@ jobs:
         # Related: https://superuser.com/questions/1044130/why-am-i-having-how-can-i-fix-this-error-shell-session-update-command-not-f
         - trap EXIT
         - make test
-    - go: 1.12.x
+    - go: 1.13.x
       # Run on OS X so that we get a CGO-enabled binary for this OS; see
       # https://github.com/golang/dep/issues/1838 for more details.
       os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ jobs:
       env:
         - DEPTESTBYPASS501=1
         - TZ=UTC
+        - GOCACHE=/home/travis/var/cache
       script:
         - make test
     - <<: *simple-test
@@ -41,10 +42,6 @@ jobs:
       install:
         - ssh-keyscan -t $TRAVIS_SSH_KEY_TYPES -H bitbucket.org >> ~/.ssh/known_hosts
         - mkdir -p /home/travis/var/cache
-      env:
-        - GOCACHE=/home/travis/var/cache
-        - DEPTESTBYPASS501=1
-        - TZ=UTC
 
     - <<: *simple-test
       os: osx


### PR DESCRIPTION
# What does this do / why do we need it?

Bumps the go versions for CI, since 1.13 was released.