### PR TITLE
Remove the curl command that pipes to sh in the install guide

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,7 +9,8 @@ It is strongly recommended that you use a released version of dep. While tip is 
 Pre-compiled binaries are available on the [releases](https://github.com/golang/dep/releases) page. You can use the `install.sh` script to automatically install one for your local platform:
 
 ```sh
-$ curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+$ curl -O https://raw.githubusercontent.com/golang/dep/master/install.sh
+$ sh ./install.sh
 ```
 
 ## MacOS


### PR DESCRIPTION
### What does this do / why do we need it?
If the server hosting the downloads is compromised, an adversary can serve malicious install scripts to the users that blindly pipe to sh while serving legitimate install scripts to the users that manually inspect them. This increases the time the adversary has to infect users before being discovered. 

### Source
- https://www.idontplaydarts.com/2016/04/detecting-curl-pipe-bash-server-side/