### PR TITLE
Fixing install.sh for MacOS

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -161,7 +161,13 @@ echo "Release Tag = $DEP_RELEASE_TAG"
 downloadJSON RELEASE_DATA "$RELEASES_URL/tag/$DEP_RELEASE_TAG"
 
 BINARY_URL="$RELEASES_URL/download/$DEP_RELEASE_TAG/$BINARY"
-DOWNLOAD_FILE=$(mktemp)
+
+# mktemp command in MacOS has no default template
+if [ "$OS" = "darwin" ]; then
+    DOWNLOAD_FILE=$(mktemp -t temp-dep)
+else
+    DOWNLOAD_FILE=$(mktemp)
+fi
 
 downloadFile "$BINARY_URL" "$DOWNLOAD_FILE"
 


### PR DESCRIPTION
This PR has the fix for installing dep in MacOS using install.sh. 
   * The issue is, the install script uses 'mktemp' command to create a temporary file.
      The OSX's mktemp tool has no default template and requires a template to be specified but in Linux , mktemp (GNU) does not require a template to be specified.

fixes #2234 

