### PR TITLE
Updated Dep installation for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ $ sudo apt-get install go-dep
 On Windows, you can download a tarball from
 [go.equinox.io](https://go.equinox.io/github.com/golang/dep/cmd/dep).
 
+OR
+Install [Git Bash](https://git-scm.com/downloads) & then run 
+```
+$go get -u github.com/golang/dep
+```
+
 On other platforms you can use the `install.sh` script:
 
 ```sh


### PR DESCRIPTION
 ( go.equinox.io  ) link is dead, doesn't go anywhere.


### What does this do / why do we need it?
This allows anyone to successfully install **Go dep**, I think people who would have been suffering like me would need this.

### What should your reviewer look out for in this PR?
Whether this is worth it

### Do you need help or clarification on anything?
Nope

### Which issue(s) does this PR fix?
Gives users a new installation method that works.

