### PR TITLE
Update docs/the-solver.md

### DIFF
--- a/docs/the-solver.md
+++ b/docs/the-solver.md
@@ -71,8 +71,6 @@ Go 1.4 introduced [import comments](https://golang.org/cmd/go/#hdr-Import_path_c
 
 Because most projects are consistent about their import comment use over time, this issue typically only occurs when adding a new dependency or attempting to revive an older project.
 
-> Note: dep does not currently enforce this rule, but [it needs to](https://github.com/golang/dep/issues/902).
-
 **Remediation:** change the code by fixing the offending import paths. If the offending import paths are not in the current project and you don't directly control the dependency, you'll have to fork and fix it yourself, then use `source` to point to your fork.
 
 ### Import path casing


### PR DESCRIPTION
Removes docs reference to a closed issue #902 . (Issue is closed, so I assume the docs no longer need to note it's not implemented...)


```markdown
> Note: dep does not currently enforce this rule, but [it needs to](https://github.com/golang/dep/issues/902).
```

<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

### What does this do / why do we need it?
Docs update. Docs referred to an unimplemented feature. Issue is closed, assuming is implemented.

### What should your reviewer look out for in this PR?
Is it actually implemented? 

### Do you need help or clarification on anything?

### Which issue(s) does this PR fix?

<!--

fixes #
fixes #

-->
